### PR TITLE
Add report dashboard and startup checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 You can verify the backend is working by visiting [http://localhost:3000/api/health](http://localhost:3000/api/health).
 
+## Daily Startup Checklist
+
+After initial setup is done, use these commands each time you come back to the project:
+
+1. Start the database (from repo root):
+
+```bash
+docker compose up -d
+```
+
+2. Start the app (from `nexa/`):
+
+```bash
+cd nexa
+npm run dev
+```
+
+3. Open the app:
+   - Usually [http://localhost:3000](http://localhost:3000)
+   - If port 3000 is already in use, Next.js will auto-pick another port (for example `http://localhost:3001`)
+
 ## Useful Commands
 
 | Command | Description |

--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -2845,7 +2845,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { IssueType } from "@/generated/prisma/enums";
+import { getSession } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
   try {
+    const session = await getSession();
     const body = await request.json();
     const {
       description,
@@ -30,6 +32,7 @@ export async function POST(request: NextRequest) {
 
     const report = await prisma.report.create({
       data: {
+        userId: session?.userId ?? null,
         description,
         aiDescription,
         issueType: validIssueType,

--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowRight, CheckCircle2, Clock3, ClipboardList } from "lucide-react";
+import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+function formatStatus(status: string): string {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function statusPillClass(status: string): string {
+  switch (status) {
+    case "CONFIRMED":
+      return "bg-ep-green-light text-ep-green";
+    case "RESOLVED":
+    case "CLOSED":
+      return "bg-blue-50 text-blue-700";
+    case "SUBMITTED":
+    case "IN_PROGRESS":
+      return "bg-ep-purple-light text-ep-purple";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+export default async function DashboardPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect(`/login?redirect=${encodeURIComponent("/dashboard")}`);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.userId },
+    select: { name: true, email: true },
+  });
+
+  const reports = await prisma.report.findMany({
+    where: { userId: session.userId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      issueType: true,
+      status: true,
+      description: true,
+      aiDescription: true,
+      address: true,
+      createdAt: true,
+    },
+  });
+
+  const totalReports = reports.length;
+  const confirmedReports = reports.filter(
+    (report) => report.status === "CONFIRMED",
+  ).length;
+  const latestReportDate =
+    reports.length > 0 ? new Date(reports[0].createdAt).toLocaleString() : "—";
+
+  return (
+    <main className="mx-auto w-full max-w-4xl flex-1 px-6 py-10">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <span className="section-label">/ Dashboard</span>
+          <h1 className="mt-3 text-3xl font-normal tracking-tight">
+            My reports
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Tracking reports for {user?.name || user?.email || session.email}
+          </p>
+        </div>
+        <Link href="/report" className="btn-cta btn-cta-purple">
+          Report Issue
+          <ArrowRight className="size-4" />
+        </Link>
+      </div>
+
+      <div className="mt-8 grid gap-4 sm:grid-cols-3">
+        <div className="ep-card p-5">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <ClipboardList className="size-4" />
+            <p className="font-mono text-xs uppercase tracking-wider">
+              Total Reports
+            </p>
+          </div>
+          <p className="mt-3 text-3xl font-semibold">{totalReports}</p>
+        </div>
+
+        <div className="ep-card p-5">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <CheckCircle2 className="size-4" />
+            <p className="font-mono text-xs uppercase tracking-wider">
+              Confirmed
+            </p>
+          </div>
+          <p className="mt-3 text-3xl font-semibold">{confirmedReports}</p>
+        </div>
+
+        <div className="ep-card p-5">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Clock3 className="size-4" />
+            <p className="font-mono text-xs uppercase tracking-wider">
+              Most Recent
+            </p>
+          </div>
+          <p className="mt-3 text-sm font-medium">{latestReportDate}</p>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        {reports.length === 0 ? (
+          <div className="ep-card p-8 text-center">
+            <p className="text-lg">No reports yet.</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Your submitted issues will appear here once you file one.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {reports.map((report) => (
+              <article key={report.id} className="ep-card p-6 transition-colors hover:bg-muted/20">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                      {ISSUE_TYPE_LABELS[report.issueType ?? ""] ||
+                        report.issueType ||
+                        "Uncategorized"}
+                    </p>
+                    <h2 className="mt-1 text-lg font-medium">
+                      {report.address || "No location provided"}
+                    </h2>
+                  </div>
+                  <div className="text-right">
+                    <p
+                      className={`inline-flex rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider ${statusPillClass(report.status)}`}
+                    >
+                      {formatStatus(report.status)}
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {new Date(report.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-sm text-foreground">
+                  {report.aiDescription || report.description || "No description"}
+                </p>
+
+                <p className="mt-4 font-mono text-xs text-muted-foreground">
+                  ID: {report.id}
+                </p>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/nexa/src/components/navbar.tsx
+++ b/nexa/src/components/navbar.tsx
@@ -6,9 +6,9 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, LayoutDashboard, LogOut } from "lucide-react";
+import { Menu } from "@base-ui/react/menu";
 import { Logo } from "@/components/logo";
-import { Button } from "@/components/ui/button";
 
 const NAV_LINKS = [
   { href: "/#how-it-works", label: "How It Works" },
@@ -20,6 +20,15 @@ interface AuthUser {
   id: string;
   email: string;
   name: string | null;
+}
+
+function getInitials(user: AuthUser): string {
+  const source = (user.name?.trim() || user.email || "").trim();
+  if (!source) return "?";
+  const parts = source.split(/[\s@.]+/).filter(Boolean);
+  if (parts.length === 0) return source.charAt(0).toUpperCase();
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 export function Navbar() {
@@ -45,8 +54,8 @@ export function Navbar() {
   }
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur-sm">
-      <div className="mx-auto grid h-[72px] max-w-[1440px] grid-cols-3 items-center px-6">
+    <nav className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <div className="mx-auto grid h-[72px] max-w-[1440px] grid-cols-[auto_1fr_auto] items-center gap-6 px-6">
         <div className="justify-self-start">
           <Logo />
         </div>
@@ -64,21 +73,31 @@ export function Navbar() {
         </div>
 
         <div className="flex items-center justify-self-end gap-3">
-          {/* Show nothing while we're checking the session to avoid a flash */}
-          {user === undefined ? null : user ? (
+          {user === undefined ? (
+            <div
+              aria-hidden
+              className="size-9 animate-pulse rounded-full bg-muted"
+            />
+          ) : user ? (
             <>
-              <span className="hidden text-sm text-muted-foreground md:block">
-                {user.name || user.email}
-              </span>
-              <Button variant="outline" size="sm" onClick={handleLogout}>
-                Sign out
-              </Button>
+              <Link
+                href="/report"
+                className={`btn-cta btn-cta-dark ${pathname === "/report" ? "opacity-70" : ""}`}
+              >
+                Report Issue
+                <ArrowRight className="size-3.5" />
+              </Link>
+              <UserMenu
+                user={user}
+                pathname={pathname}
+                onLogout={handleLogout}
+              />
             </>
           ) : (
             <>
               <Link
                 href="/login"
-                className="font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                className={`font-mono text-xs font-medium uppercase tracking-wider transition-colors hover:text-foreground ${pathname === "/login" ? "text-foreground" : "text-muted-foreground"}`}
               >
                 Sign in
               </Link>
@@ -91,19 +110,91 @@ export function Navbar() {
               </Link>
             </>
           )}
-
-          {/* When logged in, still show the Report Issue button */}
-          {user && (
-            <Link
-              href="/report"
-              className={`btn-cta btn-cta-dark ${pathname === "/report" ? "opacity-70" : ""}`}
-            >
-              Report Issue
-              <ArrowRight className="size-3.5" />
-            </Link>
-          )}
         </div>
       </div>
     </nav>
+  );
+}
+
+function UserMenu({
+  user,
+  pathname,
+  onLogout,
+}: {
+  user: AuthUser;
+  pathname: string;
+  onLogout: () => Promise<void>;
+}) {
+  const initials = getInitials(user);
+  const isOnDashboard = pathname === "/dashboard";
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        aria-label="Open account menu"
+        className="flex size-9 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 via-teal-500 to-cyan-500 text-xs font-semibold tracking-wide text-white shadow-sm outline-none ring-offset-background transition hover:scale-[1.04] hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[popup-open]:ring-2 data-[popup-open]:ring-ring data-[popup-open]:ring-offset-2"
+      >
+        {initials}
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner
+          side="bottom"
+          align="end"
+          sideOffset={10}
+          className="z-50"
+        >
+          <Menu.Popup className="min-w-64 origin-(--transform-origin) overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-lg ring-1 ring-black/[0.04] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+            <div className="flex items-center gap-3 border-b border-border px-3 py-3">
+              <div
+                aria-hidden
+                className="flex size-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 via-teal-500 to-cyan-500 text-sm font-semibold text-white"
+              >
+                {initials}
+              </div>
+              <div className="min-w-0 flex-1">
+                {user.name ? (
+                  <>
+                    <p className="truncate text-sm font-medium leading-tight">
+                      {user.name}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                      {user.email}
+                    </p>
+                  </>
+                ) : (
+                  <p className="truncate text-sm font-medium leading-tight">
+                    {user.email}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="p-1">
+              <Menu.LinkItem
+                render={
+                  <Link
+                    href="/dashboard"
+                    aria-current={isOnDashboard ? "page" : undefined}
+                  />
+                }
+                closeOnClick
+                className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground ${isOnDashboard ? "bg-muted" : ""}`}
+              >
+                <LayoutDashboard className="size-4 text-muted-foreground" />
+                Dashboard
+              </Menu.LinkItem>
+
+              <Menu.Item
+                onClick={onLogout}
+                className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
+                <LogOut className="size-4 text-muted-foreground" />
+                Sign out
+              </Menu.Item>
+            </div>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
   );
 }

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -81,6 +81,9 @@ export function ConfirmedStep({ report, onReportAnother }: ConfirmedStepProps) {
         <Link href="/" className="btn-cta btn-cta-outline">
           Home
         </Link>
+        <Link href="/dashboard" className="btn-cta btn-cta-outline">
+          My Dashboard
+        </Link>
         <button className="btn-cta btn-cta-purple" onClick={onReportAnother}>
           Report Another Issue
           <ArrowRight className="size-4" />


### PR DESCRIPTION
## Summary
- add a new authenticated `/dashboard` page to track a user's submitted reports with summary cards and status styling
- associate new reports with the current session user in `POST /api/reports` and add dashboard entry points in the navbar and confirmation flow
- document a daily local startup checklist in the root README

## Test plan
- [x] Start app locally and verify `/dashboard` redirects to login when signed out
- [x] Verify report creation endpoint still succeeds and reports are associated with logged-in users
- [x] Manually review updated navbar/dashboard UI behavior in local dev

Made with [Cursor](https://cursor.com)