### PR TITLE
Civic-form lookup, address autocomplete, and report deletion

### DIFF
--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type NominatimSearchResult = {
+  display_name?: string;
+  lat?: string;
+  lon?: string;
+};
+
+type GoogleAutocompleteResponse = {
+  predictions?: Array<{
+    description?: string;
+    place_id?: string;
+  }>;
+  status?: string;
+};
+
+type GooglePlaceDetailsResponse = {
+  result?: {
+    formatted_address?: string;
+    geometry?: {
+      location?: {
+        lat?: number;
+        lng?: number;
+      };
+    };
+  };
+  status?: string;
+};
+
+type LocationSuggestion = {
+  displayName: string;
+  latitude: number;
+  longitude: number;
+};
+
+async function fetchGoogleSuggestions(
+  query: string,
+  apiKey: string,
+): Promise<LocationSuggestion[]> {
+  const autocompleteParams = new URLSearchParams({
+    input: query,
+    types: "address",
+    key: apiKey,
+  });
+
+  const autocompleteResponse = await fetch(
+    `https://maps.googleapis.com/maps/api/place/autocomplete/json?${autocompleteParams.toString()}`,
+    { cache: "no-store" },
+  );
+
+  if (!autocompleteResponse.ok) {
+    return [];
+  }
+
+  const autocompleteData =
+    (await autocompleteResponse.json()) as GoogleAutocompleteResponse;
+
+  if (
+    autocompleteData.status !== "OK" ||
+    !autocompleteData.predictions?.length
+  ) {
+    return [];
+  }
+
+  const topPredictions = autocompleteData.predictions.slice(0, 5);
+
+  const details = await Promise.all(
+    topPredictions.map(async (prediction) => {
+      if (!prediction.place_id) return null;
+
+      const detailParams = new URLSearchParams({
+        place_id: prediction.place_id,
+        fields: "formatted_address,geometry/location",
+        key: apiKey,
+      });
+
+      const detailResponse = await fetch(
+        `https://maps.googleapis.com/maps/api/place/details/json?${detailParams.toString()}`,
+        { cache: "no-store" },
+      );
+
+      if (!detailResponse.ok) return null;
+
+      const detailData =
+        (await detailResponse.json()) as GooglePlaceDetailsResponse;
+      if (detailData.status !== "OK") return null;
+
+      const lat = detailData.result?.geometry?.location?.lat;
+      const lng = detailData.result?.geometry?.location?.lng;
+      const displayName =
+        detailData.result?.formatted_address ?? prediction.description ?? "";
+
+      if (
+        !displayName ||
+        typeof lat !== "number" ||
+        !Number.isFinite(lat) ||
+        typeof lng !== "number" ||
+        !Number.isFinite(lng)
+      ) {
+        return null;
+      }
+
+      return {
+        displayName,
+        latitude: lat,
+        longitude: lng,
+      };
+    }),
+  );
+
+  return details.filter((item): item is LocationSuggestion => item !== null);
+}
+
+async function fetchNominatimSuggestions(
+  query: string,
+): Promise<LocationSuggestion[]> {
+  const response = await fetch(
+    `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`,
+    {
+      headers: {
+        "User-Agent": "Nexa location suggestions",
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) return [];
+
+  const data = (await response.json()) as NominatimSearchResult[];
+  return data
+    .map((item) => ({
+      displayName: item.display_name ?? "",
+      latitude: Number(item.lat),
+      longitude: Number(item.lon),
+    }))
+    .filter(
+      (item) =>
+        !!item.displayName &&
+        Number.isFinite(item.latitude) &&
+        Number.isFinite(item.longitude),
+    );
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const query = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+    if (query.length < 3) {
+      return NextResponse.json({ suggestions: [] });
+    }
+
+    const googleApiKey = process.env.GOOGLE_MAPS_API_KEY;
+    let suggestions: LocationSuggestion[] = [];
+
+    if (googleApiKey) {
+      suggestions = await fetchGoogleSuggestions(query, googleApiKey);
+    }
+
+    if (!suggestions.length) {
+      suggestions = await fetchNominatimSuggestions(query);
+    }
+
+    return NextResponse.json({ suggestions });
+  } catch (error) {
+    console.error("Location suggestion error:", error);
+    return NextResponse.json({ suggestions: [] });
+  }
+}

--- a/nexa/src/app/api/reports/[id]/route.ts
+++ b/nexa/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
+
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: "Not authenticated." },
+        { status: 401 },
+      );
+    }
+
+    const { id } = await context.params;
+
+    const report = await prisma.report.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
+
+    if (!report) {
+      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+    }
+
+    if (report.userId !== session.userId) {
+      return NextResponse.json(
+        { error: "You can only delete your own reports." },
+        { status: 403 },
+      );
+    }
+
+    await prisma.report.delete({ where: { id } });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Report deletion error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete report. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -1,0 +1,326 @@
+import { NextRequest, NextResponse } from "next/server";
+import { openai } from "@/lib/openai";
+import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import { IssueType } from "@/generated/prisma/enums";
+
+type Confidence = "low" | "medium" | "high";
+
+type FormLinkResult =
+  | {
+      status: "found";
+      cityName: string;
+      formUrl: string;
+      reason: string;
+      confidence: Confidence;
+    }
+  | {
+      status: "not_found";
+      cityName: string | null;
+      message: string;
+      reason?: string;
+    };
+
+type LookupResult =
+  | {
+      status: "found";
+      formUrl: string;
+      reason: string;
+      confidence: Confidence;
+    }
+  | {
+      status: "not_found";
+      reason: string;
+    };
+
+type NominatimAddress = {
+  city?: string;
+  town?: string;
+  village?: string;
+  hamlet?: string;
+  municipality?: string;
+  state?: string;
+};
+
+const LOOKUP_SYSTEM_PROMPT = `You help find the official city webpage a resident should use to report a civic issue.
+
+Rules:
+- You MUST use the web_search tool. Do not answer from memory.
+- Search queries should target the specific city's official government website (e.g. "City of Palo Alto report an issue 311").
+- The result is "found" as long as the URL is on the official city government website (typically a *.gov, *.us, or the city's official domain) and the page is a place residents use to report civic issues. This includes general 311 / Report-an-Issue / service-request portals that cover many issue types.
+- You DO NOT need a separate form for each issue type. If the city uses a unified 311 / Report-an-Issue page that residents use for things like potholes, streetlights, dumping, etc., return THAT page.
+- Exclude county, state, federal, private, non-profit, news, and third-party sites.
+- Only return "not_found" if no official city government reporting / 311 page exists for this city. Do NOT return "not_found" just because there is no issue-type-specific page.
+- Use "high" confidence when the page is clearly the city's 311 / Report-an-Issue page. Use "medium" for the city's general services page if no 311 page is visible. Use "low" only when uncertain.
+- Reply with a single JSON object only (no prose, no markdown fences) matching this shape:
+{
+  "status": "found" | "not_found",
+  "formUrl": string | null,
+  "reason": string,
+  "confidence": "low" | "medium" | "high"
+}
+
+Example: For Palo Alto, "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311" is the correct unified 311 page and should be returned for any civic issue type, including road damage.`;
+
+function parseCityName(address: NominatimAddress | undefined): string | null {
+  if (!address) return null;
+  return (
+    address.city ??
+    address.town ??
+    address.village ??
+    address.hamlet ??
+    address.municipality ??
+    null
+  );
+}
+
+function isOfficialCityGovUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    if (host.endsWith(".gov")) return true;
+    if (host.endsWith(".us")) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function extractJsonObject(raw: string): string | null {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : raw;
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}
+
+async function reverseLookupCity(
+  latitude: number,
+  longitude: number,
+): Promise<{ cityName: string | null; stateName: string | null }> {
+  const response = await fetch(
+    `https://nominatim.openstreetmap.org/reverse?format=jsonv2&addressdetails=1&lat=${latitude}&lon=${longitude}`,
+    {
+      headers: {
+        "User-Agent": "Nexa civic form lookup",
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    return { cityName: null, stateName: null };
+  }
+
+  const data = (await response.json()) as { address?: NominatimAddress };
+  const cityName = parseCityName(data.address);
+  return {
+    cityName,
+    stateName: data.address?.state ?? null,
+  };
+}
+
+async function geocodeAddress(
+  address: string,
+): Promise<{ cityName: string | null; stateName: string | null }> {
+  const response = await fetch(
+    `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=1&q=${encodeURIComponent(address)}`,
+    {
+      headers: {
+        "User-Agent": "Nexa civic form lookup",
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    return { cityName: null, stateName: null };
+  }
+
+  const data = (await response.json()) as Array<{ address?: NominatimAddress }>;
+  const first = data[0];
+  const cityName = parseCityName(first?.address);
+  return {
+    cityName,
+    stateName: first?.address?.state ?? null,
+  };
+}
+
+async function resolveCity(
+  address: string | undefined,
+  latitude: number | undefined,
+  longitude: number | undefined,
+): Promise<{ cityName: string | null; stateName: string | null }> {
+  if (typeof latitude === "number" && typeof longitude === "number") {
+    const reverse = await reverseLookupCity(latitude, longitude);
+    if (reverse.cityName) return reverse;
+  }
+
+  if (address?.trim()) {
+    return geocodeAddress(address.trim());
+  }
+
+  return { cityName: null, stateName: null };
+}
+
+async function lookupOfficialForm(params: {
+  cityName: string;
+  stateName: string | null;
+  issueType: IssueType;
+  address?: string;
+}): Promise<LookupResult> {
+  const issueLabel = ISSUE_TYPE_LABELS[params.issueType] ?? params.issueType;
+  const statePart = params.stateName ? `, ${params.stateName}` : "";
+
+  const prompt = `Use web_search to find the official city webpage a resident should use to report a "${issueLabel}" issue in ${params.cityName}${statePart}.
+
+Context:
+- User-provided location: ${params.address ?? "not provided"}
+- Issue type: ${params.issueType} (${issueLabel})
+
+Instructions:
+1. Search for the city's official 311 / Report-an-Issue / service-request portal (e.g. "${params.cityName} 311 report an issue", "${params.cityName} report a pothole official city site").
+2. If the city has a single unified Report-an-Issue / 311 page that covers many civic issue types, return THAT page — even if it isn't dedicated to "${issueLabel}".
+3. Confirm the page is on the official city government website (typically a *.gov, *.us, or the city's official domain). Reject county, state, federal, news, and third-party sites.
+4. Reply with the JSON object described in the system instructions.
+
+Do not say "not_found" just because there is no "${issueLabel}"-specific form — the general city 311 / Report-an-Issue page is the correct answer in that case.`;
+
+  const response = await openai.responses.create({
+    model: "gpt-4o-mini",
+    input: [
+      {
+        role: "system",
+        content: [{ type: "input_text", text: LOOKUP_SYSTEM_PROMPT }],
+      },
+      {
+        role: "user",
+        content: [{ type: "input_text", text: prompt }],
+      },
+    ],
+    tools: [{ type: "web_search_preview" }],
+    tool_choice: { type: "web_search_preview" },
+  });
+
+  const raw = response.output_text?.trim();
+  if (!raw) {
+    return {
+      status: "not_found",
+      reason: "Search response was empty.",
+    };
+  }
+
+  const jsonText = extractJsonObject(raw);
+  if (!jsonText) {
+    console.warn("Form lookup: no JSON object in response", raw);
+    return {
+      status: "not_found",
+      reason: "Could not parse the search response.",
+    };
+  }
+
+  let parsed: {
+    status?: string;
+    formUrl?: string | null;
+    reason?: string;
+    confidence?: Confidence;
+  };
+
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (error) {
+    console.warn("Form lookup: invalid JSON", jsonText, error);
+    return {
+      status: "not_found",
+      reason: "Could not parse the search response.",
+    };
+  }
+
+  if (
+    parsed.status === "found" &&
+    typeof parsed.formUrl === "string" &&
+    isOfficialCityGovUrl(parsed.formUrl)
+  ) {
+    return {
+      status: "found",
+      formUrl: parsed.formUrl,
+      reason: parsed.reason ?? "Official city service-request page.",
+      confidence: parsed.confidence ?? "medium",
+    };
+  }
+
+  return {
+    status: "not_found",
+    reason:
+      parsed.reason ??
+      "Did not find a verifiable official city service-request page.",
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { issueType, address, latitude, longitude } = body as {
+      issueType?: string;
+      address?: string;
+      latitude?: number;
+      longitude?: number;
+    };
+
+    if (
+      !issueType ||
+      !Object.values(IssueType).includes(issueType as IssueType)
+    ) {
+      return NextResponse.json(
+        { error: "Valid issueType is required." },
+        { status: 400 },
+      );
+    }
+
+    const city = await resolveCity(address, latitude, longitude);
+    if (!city.cityName) {
+      const result: FormLinkResult = {
+        status: "not_found",
+        cityName: null,
+        message: "No official city form found.",
+        reason: "Could not determine a city from the provided location.",
+      };
+      return NextResponse.json(result);
+    }
+
+    const lookup = await lookupOfficialForm({
+      cityName: city.cityName,
+      stateName: city.stateName,
+      issueType: issueType as IssueType,
+      address,
+    });
+
+    if (lookup.status === "found") {
+      const result: FormLinkResult = {
+        status: "found",
+        cityName: city.cityName,
+        formUrl: lookup.formUrl,
+        reason: lookup.reason,
+        confidence: lookup.confidence,
+      };
+      return NextResponse.json(result);
+    }
+
+    const result: FormLinkResult = {
+      status: "not_found",
+      cityName: city.cityName,
+      message: "No official city form found.",
+      reason: lookup.reason,
+    };
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Official form lookup error:", error);
+    return NextResponse.json(
+      { error: "Failed to look up official city form." },
+      { status: 500 },
+    );
+  }
+}

--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, CheckCircle2, Clock3, ClipboardList } from "lucide-react";
 import { ISSUE_TYPE_LABELS } from "@/lib/constants";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { DeleteReportButton } from "@/components/dashboard/delete-report-button";
 
 function formatStatus(status: string): string {
   return status
@@ -125,37 +126,33 @@ export default async function DashboardPage() {
                 key={report.id}
                 className="ep-card p-6 transition-colors hover:bg-muted/20"
               >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-                      {ISSUE_TYPE_LABELS[report.issueType ?? ""] ||
-                        report.issueType ||
-                        "Uncategorized"}
-                    </p>
-                    <h2 className="mt-1 text-lg font-medium">
-                      {report.address || "No location provided"}
-                    </h2>
-                  </div>
-                  <div className="text-right">
-                    <p
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+                    {ISSUE_TYPE_LABELS[report.issueType ?? ""] ||
+                      report.issueType ||
+                      "Uncategorized"}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <span
                       className={`inline-flex rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider ${statusPillClass(report.status)}`}
                     >
                       {formatStatus(report.status)}
-                    </p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {new Date(report.createdAt).toLocaleString()}
-                    </p>
+                    </span>
+                    <DeleteReportButton reportId={report.id} />
                   </div>
                 </div>
 
-                <p className="mt-4 text-sm text-foreground">
+                <h2 className="mt-4 text-lg font-medium leading-snug">
+                  {report.address || "No location provided"}
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {new Date(report.createdAt).toLocaleString()}
+                </p>
+
+                <p className="mt-4 text-sm leading-relaxed text-foreground">
                   {report.aiDescription ||
                     report.description ||
                     "No description"}
-                </p>
-
-                <p className="mt-4 font-mono text-xs text-muted-foreground">
-                  ID: {report.id}
                 </p>
               </article>
             ))}

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Stepper, type ReportStep } from "@/components/report/stepper";
 import { DescribeStep } from "@/components/report/describe-step";
 import { ReviewStep } from "@/components/report/review-step";
@@ -20,6 +20,27 @@ interface CreatedReport {
   description: string | null;
   aiDescription: string | null;
   createdAt: string;
+}
+
+type OfficialFormLookupResult =
+  | {
+      status: "found";
+      cityName: string;
+      formUrl: string;
+      reason: string;
+      confidence: "low" | "medium" | "high";
+    }
+  | {
+      status: "not_found";
+      cityName: string | null;
+      message: string;
+      reason?: string;
+    };
+
+interface AddressSuggestion {
+  displayName: string;
+  latitude: number;
+  longitude: number;
 }
 
 async function fetchJSON<T>(url: string, body: unknown): Promise<T> {
@@ -45,9 +66,6 @@ export default function ReportPage() {
   const [classifying, setClassifying] = useState(false);
   const [classification, setClassification] =
     useState<ClassificationResult | null>(null);
-  const [selectedIssueType, setSelectedIssueType] = useState<string | null>(
-    null,
-  );
   const [classifyError, setClassifyError] = useState<string | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
@@ -55,17 +73,137 @@ export default function ReportPage() {
     null,
   );
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [officialForm, setOfficialForm] =
+    useState<OfficialFormLookupResult | null>(null);
+  const [officialFormLoading, setOfficialFormLoading] = useState(false);
+  const [addressSuggestions, setAddressSuggestions] = useState<
+    AddressSuggestion[]
+  >([]);
+  const [locationSuggesting, setLocationSuggesting] = useState(false);
+  const addressLookupTimerRef = useRef<number | null>(null);
+  const addressLookupRequestRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      if (addressLookupTimerRef.current) {
+        window.clearTimeout(addressLookupTimerRef.current);
+      }
+    };
+  }, []);
+
+  const lookupAddressSuggestions = (query: string) => {
+    if (addressLookupTimerRef.current) {
+      window.clearTimeout(addressLookupTimerRef.current);
+      addressLookupTimerRef.current = null;
+    }
+
+    const trimmed = query.trim();
+    if (trimmed.length < 3) {
+      setAddressSuggestions([]);
+      setLocationSuggesting(false);
+      return;
+    }
+
+    setLocationSuggesting(true);
+    addressLookupTimerRef.current = window.setTimeout(async () => {
+      const requestId = ++addressLookupRequestRef.current;
+
+      try {
+        const response = await fetch(
+          `/api/location/suggest?q=${encodeURIComponent(trimmed)}`,
+        );
+        if (!response.ok) throw new Error("Location suggestion lookup failed.");
+
+        const data = (await response.json()) as {
+          suggestions?: AddressSuggestion[];
+        };
+        if (requestId !== addressLookupRequestRef.current) return;
+
+        setAddressSuggestions(data.suggestions ?? []);
+      } catch {
+        if (requestId !== addressLookupRequestRef.current) return;
+        setAddressSuggestions([]);
+      } finally {
+        if (requestId !== addressLookupRequestRef.current) return;
+        setLocationSuggesting(false);
+      }
+    }, 250);
+  };
+
+  const lookupOfficialForm = async (issueType: string) => {
+    const hasLocation =
+      !!geo.address.trim() ||
+      (typeof geo.latitude === "number" && typeof geo.longitude === "number");
+
+    if (!hasLocation) {
+      setOfficialForm({
+        status: "not_found",
+        cityName: null,
+        message: "No official city form found.",
+        reason: "Add a location to look up the official city website.",
+      });
+      return;
+    }
+
+    setOfficialFormLoading(true);
+    try {
+      const result = await fetchJSON<OfficialFormLookupResult>(
+        "/api/reports/form-link",
+        {
+          issueType,
+          address: geo.address || undefined,
+          latitude: geo.latitude ?? undefined,
+          longitude: geo.longitude ?? undefined,
+        },
+      );
+      setOfficialForm(result);
+    } catch (err) {
+      setOfficialForm({
+        status: "not_found",
+        cityName: null,
+        message: "No official city form found.",
+        reason:
+          err instanceof Error
+            ? err.message
+            : "Could not look up an official city website.",
+      });
+    } finally {
+      setOfficialFormLoading(false);
+    }
+  };
+
+  const handleAddressChange = (value: string) => {
+    geo.setAddress(value);
+
+    const selectedSuggestion = addressSuggestions.find(
+      (suggestion) => suggestion.displayName === value,
+    );
+
+    if (selectedSuggestion) {
+      geo.setCoordinates(
+        selectedSuggestion.latitude,
+        selectedSuggestion.longitude,
+      );
+      setAddressSuggestions([]);
+      setLocationSuggesting(false);
+      return;
+    }
+
+    geo.setCoordinates(null, null);
+    lookupAddressSuggestions(value);
+  };
 
   const handleClassify = async () => {
     setClassifying(true);
     setClassifyError(null);
     try {
+      setOfficialForm(null);
       const result = await fetchJSON<ClassificationResult>(
         "/api/reports/classify",
         { image: image.imageBase64, description: description || undefined },
       );
       setClassification(result);
-      setSelectedIssueType(result.issueType);
+      void lookupOfficialForm(result.issueType);
       setStep("review");
     } catch (err) {
       setClassifyError(
@@ -84,7 +222,7 @@ export default function ReportPage() {
       const report = await fetchJSON<CreatedReport>("/api/reports", {
         description,
         aiDescription: classification.aiDescription,
-        issueType: selectedIssueType,
+        issueType: classification.issueType,
         latitude: geo.latitude,
         longitude: geo.longitude,
         address: geo.address,
@@ -106,11 +244,18 @@ export default function ReportPage() {
     setDescription("");
     image.clearImage();
     geo.reset();
+    setAddressSuggestions([]);
+    setLocationSuggesting(false);
+    if (addressLookupTimerRef.current) {
+      window.clearTimeout(addressLookupTimerRef.current);
+      addressLookupTimerRef.current = null;
+    }
     setClassification(null);
-    setSelectedIssueType(null);
     setCreatedReport(null);
     setClassifyError(null);
     setSubmitError(null);
+    setOfficialForm(null);
+    setOfficialFormLoading(false);
   };
 
   return (
@@ -130,6 +275,10 @@ export default function ReportPage() {
             latitude={geo.latitude}
             longitude={geo.longitude}
             locationLoading={geo.loading}
+            locationSuggesting={locationSuggesting}
+            addressSuggestions={addressSuggestions.map(
+              (suggestion) => suggestion.displayName,
+            )}
             classifying={classifying}
             classifyError={classifyError}
             canSubmit={!!(image.imageBase64 || description.trim())}
@@ -137,7 +286,7 @@ export default function ReportPage() {
             onDrop={image.handleDrop}
             onClearImage={image.clearImage}
             onDescriptionChange={setDescription}
-            onAddressChange={geo.setAddress}
+            onAddressChange={handleAddressChange}
             onDetectLocation={geo.detect}
             onClassify={handleClassify}
           />
@@ -149,10 +298,10 @@ export default function ReportPage() {
             imagePreview={image.imagePreview}
             description={description}
             address={geo.address}
-            selectedIssueType={selectedIssueType}
             submitting={submitting}
             submitError={submitError}
-            onIssueTypeChange={setSelectedIssueType}
+            officialForm={officialForm}
+            officialFormLoading={officialFormLoading}
             onBack={() => setStep("describe")}
             onSubmit={handleSubmit}
           />

--- a/nexa/src/components/dashboard/delete-report-button.tsx
+++ b/nexa/src/components/dashboard/delete-report-button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, Trash2 } from "lucide-react";
+
+interface DeleteReportButtonProps {
+  reportId: string;
+}
+
+export function DeleteReportButton({ reportId }: DeleteReportButtonProps) {
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+
+    setDeleting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(data?.error ?? "Failed to delete the report.");
+      }
+
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete.");
+      setConfirming(false);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-2">
+        {confirming && !deleting && (
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="font-mono text-xs uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={deleting}
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider transition-colors ${
+            confirming
+              ? "bg-red-600 text-white hover:bg-red-700"
+              : "text-muted-foreground hover:bg-muted hover:text-red-600"
+          } disabled:opacity-60`}
+          aria-label={confirming ? "Confirm delete" : "Delete report"}
+        >
+          {deleting ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Trash2 className="size-3.5" />
+          )}
+          {confirming ? "Confirm" : "Delete"}
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { Camera, MapPin, Loader2, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -14,6 +15,8 @@ interface DescribeStepProps {
   latitude: number | null;
   longitude: number | null;
   locationLoading: boolean;
+  locationSuggesting: boolean;
+  addressSuggestions: string[];
   classifying: boolean;
   classifyError: string | null;
   canSubmit: boolean;
@@ -33,6 +36,8 @@ export function DescribeStep({
   latitude,
   longitude,
   locationLoading,
+  locationSuggesting,
+  addressSuggestions,
   classifying,
   classifyError,
   canSubmit,
@@ -44,6 +49,27 @@ export function DescribeStep({
   onDetectLocation,
   onClassify,
 }: DescribeStepProps) {
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false);
+  const locationWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!locationWrapperRef.current) return;
+      if (!locationWrapperRef.current.contains(event.target as Node)) {
+        setSuggestionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelectSuggestion = (suggestion: string) => {
+    onAddressChange(suggestion);
+    setSuggestionsOpen(false);
+  };
+
+  const showSuggestions = suggestionsOpen && addressSuggestions.length > 0;
+
   return (
     <div className="flex flex-col gap-10">
       <div>
@@ -108,21 +134,49 @@ export function DescribeStep({
         />
       </div>
 
-      <div className="ep-card p-6">
+      <div className="ep-card p-6" ref={locationWrapperRef}>
         <Label
           htmlFor="address"
           className="mb-3 block font-mono text-xs uppercase tracking-wider text-muted-foreground"
         >
           Location
         </Label>
-        <div className="flex gap-2">
-          <Input
-            id="address"
-            placeholder="Address or location description"
-            className="border-0 bg-transparent shadow-none focus-visible:ring-0"
-            value={address}
-            onChange={(e) => onAddressChange(e.target.value)}
-          />
+        <div className="relative flex gap-2">
+          <div className="relative flex-1">
+            <Input
+              id="address"
+              placeholder="Address or location description"
+              className="border-0 bg-transparent shadow-none focus-visible:ring-0"
+              value={address}
+              autoComplete="off"
+              onChange={(e) => {
+                onAddressChange(e.target.value);
+                setSuggestionsOpen(true);
+              }}
+              onFocus={() => setSuggestionsOpen(true)}
+            />
+            {showSuggestions && (
+              <div className="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+                <ul className="max-h-72 overflow-y-auto py-1 text-sm">
+                  {addressSuggestions.map((suggestion) => (
+                    <li key={suggestion}>
+                      <button
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          handleSelectSuggestion(suggestion);
+                        }}
+                        className="flex w-full items-start gap-2 px-4 py-2.5 text-left text-foreground transition-colors hover:bg-muted"
+                      >
+                        <MapPin className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{suggestion}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
           <Button
             variant="outline"
             onClick={onDetectLocation}
@@ -137,6 +191,11 @@ export function DescribeStep({
             {locationLoading ? "..." : "Detect"}
           </Button>
         </div>
+        {locationSuggesting && (
+          <p className="mt-2 font-mono text-xs text-muted-foreground">
+            Searching locations...
+          </p>
+        )}
         {latitude && longitude && (
           <p className="mt-3 font-mono text-xs text-muted-foreground">
             GPS: {latitude.toFixed(6)}, {longitude.toFixed(6)}

--- a/nexa/src/components/report/review-step.tsx
+++ b/nexa/src/components/report/review-step.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import { ArrowLeft, ArrowRight, Loader2 } from "lucide-react";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { ArrowLeft, ArrowRight, ExternalLink, Loader2 } from "lucide-react";
 import { ErrorBanner } from "@/components/error-banner";
 import { ISSUE_TYPE_LABELS, SEVERITY_COLORS } from "@/lib/constants";
 
@@ -18,15 +10,30 @@ interface ClassificationResult {
   severity: "low" | "medium" | "high";
 }
 
+type OfficialFormLookupResult =
+  | {
+      status: "found";
+      cityName: string;
+      formUrl: string;
+      reason: string;
+      confidence: "low" | "medium" | "high";
+    }
+  | {
+      status: "not_found";
+      cityName: string | null;
+      message: string;
+      reason?: string;
+    };
+
 interface ReviewStepProps {
   classification: ClassificationResult;
   imagePreview: string | null;
   description: string;
   address: string;
-  selectedIssueType: string | null;
   submitting: boolean;
   submitError: string | null;
-  onIssueTypeChange: (value: string | null) => void;
+  officialForm: OfficialFormLookupResult | null;
+  officialFormLoading: boolean;
   onBack: () => void;
   onSubmit: () => void;
 }
@@ -36,10 +43,10 @@ export function ReviewStep({
   imagePreview,
   description,
   address,
-  selectedIssueType,
   submitting,
   submitError,
-  onIssueTypeChange,
+  officialForm,
+  officialFormLoading,
   onBack,
   onSubmit,
 }: ReviewStepProps) {
@@ -103,24 +110,51 @@ export function ReviewStep({
       )}
 
       <div className="ep-card p-6">
-        <Label className="mb-3 block font-mono text-xs uppercase tracking-wider text-muted-foreground">
-          Issue Type (adjust if needed)
-        </Label>
-        <Select
-          value={selectedIssueType}
-          onValueChange={(value) => onIssueTypeChange(value)}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select issue type" />
-          </SelectTrigger>
-          <SelectContent>
-            {Object.entries(ISSUE_TYPE_LABELS).map(([value, label]) => (
-              <SelectItem key={value} value={value}>
-                {label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+          Where to submit
+        </span>
+
+        {officialFormLoading ? (
+          <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Finding official city form...
+          </div>
+        ) : officialForm?.status === "found" ? (
+          <div className="mt-3">
+            <p className="text-sm text-foreground">
+              Official city website for {officialForm.cityName}
+            </p>
+            <a
+              href={officialForm.formUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex items-center gap-1.5 text-sm text-ep-purple underline-offset-4 hover:underline"
+            >
+              Open official city form
+              <ExternalLink className="size-3.5" />
+            </a>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Confidence: {officialForm.confidence}
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {officialForm.reason}
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Nexa does not submit your data to this external website.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-3">
+            <p className="text-sm text-foreground">
+              No official city form found.
+            </p>
+            {officialForm?.reason && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {officialForm.reason}
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {submitError && <ErrorBanner message={submitError} />}

--- a/nexa/src/hooks/use-geolocation.ts
+++ b/nexa/src/hooks/use-geolocation.ts
@@ -8,6 +8,14 @@ export function useGeolocation() {
   const [longitude, setLongitude] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const setCoordinates = useCallback(
+    (lat: number | null, lng: number | null) => {
+      setLatitude(lat);
+      setLongitude(lng);
+    },
+    [],
+  );
+
   const detect = useCallback(() => {
     if (!navigator.geolocation) return;
     setLoading(true);
@@ -16,8 +24,7 @@ export function useGeolocation() {
       async (position) => {
         const lat = position.coords.latitude;
         const lng = position.coords.longitude;
-        setLatitude(lat);
-        setLongitude(lng);
+        setCoordinates(lat, lng);
 
         try {
           const res = await fetch(
@@ -33,13 +40,21 @@ export function useGeolocation() {
       },
       () => setLoading(false),
     );
-  }, []);
+  }, [setCoordinates]);
 
   const reset = useCallback(() => {
     setAddress("");
-    setLatitude(null);
-    setLongitude(null);
-  }, []);
+    setCoordinates(null, null);
+  }, [setCoordinates]);
 
-  return { address, setAddress, latitude, longitude, loading, detect, reset };
+  return {
+    address,
+    setAddress,
+    latitude,
+    longitude,
+    loading,
+    setCoordinates,
+    detect,
+    reset,
+  };
 }


### PR DESCRIPTION
## Summary

- **Official city form lookup on Review screen**: After AI classifies the report, the review step now shows a "Where to submit" card that links to the official city 311 / Report-an-Issue page for the user's location. Nexa does **not** post the report to that external site — it just surfaces the link.
- **Google-Places-style address autocomplete**: The Location field on the report page now suggests real, geocoded addresses as you type, replacing the previous free-text input and the (very black) native macOS `<datalist>` popup. Picking a suggestion populates the address and its lat/lng.
- **Delete reports from the dashboard**: Each report on `/dashboard` now has a two-step Delete → Confirm button. Server-side, the new `DELETE /api/reports/:id` route enforces session auth and ownership.
- **Dashboard card polish**: Cleaner layout (category + status pill on the top row, address as heading, timestamp underneath, description below). Removed the `ID: …` line.
- **Review step cleanup**: Dropped the now-unused "Issue Type (adjust if needed)" selector — submits use the AI classification directly.

## Implementation notes

Backend
- `nexa/src/app/api/reports/form-link/route.ts` — OpenAI Responses API with `web_search_preview` (forced via `tool_choice`). Reverse-geocodes via Nominatim, then asks the model for the city's unified 311 / Report-an-Issue page. Validates the URL is `.gov` or `.us` before returning `status: "found"`. Returns `status: "not_found"` with "No official city form found." when nothing on an official domain is verifiable.
- `nexa/src/app/api/location/suggest/route.ts` — Google Places Autocomplete + Place Details when `GOOGLE_MAPS_API_KEY` is set, with Nominatim as a fallback.
- `nexa/src/app/api/reports/[id]/route.ts` — `DELETE` handler with session auth (401), existence check (404), and ownership check (403).

Frontend
- `nexa/src/components/report/describe-step.tsx` — custom autocomplete dropdown that matches the app's card styling (no more black macOS popup); selections set both address and coordinates.
- `nexa/src/app/report/page.tsx` — debounced suggestion fetch, suggestion-pick wiring, and auto-trigger of the form-link lookup after classification.
- `nexa/src/components/report/review-step.tsx` — new "Where to submit" card (loading / found / not-found states) plus a "Nexa does not submit your data to this external website" note. Issue-type override removed.
- `nexa/src/components/dashboard/delete-report-button.tsx` — client component with confirm step, spinner, error display, `router.refresh()` on success.
- `nexa/src/app/dashboard/page.tsx` — restructured report cards and wired in the delete button.
- `nexa/src/hooks/use-geolocation.ts` — exposes `setCoordinates` so picking a suggestion sets lat/lng directly.

Environment
- New optional env var: `GOOGLE_MAPS_API_KEY`. When unset the suggestion API falls back to Nominatim.

## Test plan

- [ ] \`docker compose up -d\` + \`npm run dev\`, then open \`/report\`.
- [ ] Upload a photo or write a description, click **Detect** — confirm coords + reverse-geocoded address still work.
- [ ] Clear the address, type \`550 las\` — confirm the new dropdown appears with formatted address suggestions and matches the app theme (white card, not the old black popup).
- [ ] Select a Palo Alto address suggestion; confirm GPS line shows the coords from the suggestion.
- [ ] Click **Analyze Issue** and on the Review screen confirm the **Where to submit** card resolves to the [Palo Alto 311 page](https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311) with "found" + confidence.
- [ ] Try a location with no obvious city 311 page — confirm "No official city form found." renders cleanly.
- [ ] Submit the report; open \`/dashboard\`.
- [ ] Click **Delete** on a report; confirm the button switches to red **Confirm**; click Confirm; verify the report disappears (and that you can't delete reports that aren't yours by hitting \`DELETE /api/reports/:id\` directly — should 403).
- [ ] \`npm run lint\`, \`npm run build\`, \`npm run format:check\` all clean.


Made with [Cursor](https://cursor.com)