### PR TITLE
Update README, VERCEL_SETUP, and nexa README for current build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 # Nexa
 
-A full-stack Next.js application for reporting and tracking civic issues (road damage, streetlight outages, illegal dumping, etc.). AI-powered classification compares results across multiple LLMs to make the best judgment.
+A full-stack Next.js application for reporting and tracking civic issues (road damage, streetlight outages, illegal dumping, etc.). AI-powered classification compares results across multiple LLMs to make the best judgment, and an official city form lookup surfaces the correct 311 / Report-an-Issue page for the user's location.
 
 ## Tech Stack
 
 - **Frontend**: Next.js 16, React 19, TypeScript, Tailwind CSS v4, shadcn/ui
 - **Backend**: Next.js API Routes (under `src/app/api/`)
-- **AI Classification**: Multi-provider consensus engine (OpenAI GPT-4o-mini, Anthropic Claude Sonnet, Google Gemini 2.0 Flash)
-- **Database**: PostgreSQL 16 (via Docker), Prisma ORM
+- **AI Classification**: Multi-provider consensus engine (OpenAI GPT-4o-mini, Anthropic Claude 3.5 Haiku, Google Gemini 2.0 Flash)
+- **Database**: PostgreSQL (Neon on Vercel, Docker for local dev), Prisma ORM
+- **Address Autocomplete**: Google Places API (with Nominatim fallback)
+- **Civic Form Lookup**: OpenAI Responses API with `web_search_preview` tool
 - **Telemetry**: PostHog (passive event tracking, session replays)
-- **Deployment**: Vercel
+- **Auth**: JWT-based sessions (jose)
+- **Deployment**: Vercel (auto-deploys from `main`)
 - **CI**: GitHub Actions (lint, type-check, format check on PRs)
+
+## Features
+
+- **Report submission wizard** — describe an issue with text, photo, or both; detect GPS location or type an address with autocomplete suggestions
+- **Multi-LLM AI classification** — three providers classify in parallel; a consensus engine picks the best result; the review step shows a comparison panel
+- **Official city form lookup** — after classification, Nexa finds the official 311 / Report-an-Issue page for the user's city and surfaces a direct link (Nexa never sends data to the external site)
+- **Dashboard** — personal history of submitted reports with status tracking, category labels, and two-step report deletion
+- **Auth** — register, login, and session-aware navbar
+- **Address autocomplete** — Google Places suggestions (falls back to Nominatim when `GOOGLE_MAPS_API_KEY` is unset)
 
 ## AI Classification — How It Works
 
@@ -19,7 +31,7 @@ When a user submits a report, the `/api/reports/classify` endpoint sends the ima
 | Provider | Model | Strengths |
 |---|---|---|
 | OpenAI | `gpt-4o-mini` | Fast, strong vision, low cost |
-| Anthropic | `claude-sonnet` | Careful reasoning, good at ambiguous cases |
+| Anthropic | `claude-3-5-haiku-20241022` | Fast, careful reasoning, low cost |
 | Google | `gemini-2.0-flash` | Fast, good at structured output |
 
 A **consensus engine** then picks the best result:
@@ -35,15 +47,34 @@ The review step shows the user the winning classification **and** a comparison p
 
 ```
 spr26-Team-24/
-├── docker-compose.yml        # PostgreSQL database
+├── docker-compose.yml        # PostgreSQL database (local dev)
 ├── .github/workflows/ci.yml  # CI pipeline
 └── nexa/                     # Next.js application
     ├── src/
     │   ├── app/              # Pages and API routes
-    │   │   ├── api/          # Backend API endpoints
+    │   │   ├── api/
+    │   │   │   ├── auth/             # Login, register, logout, session
+    │   │   │   ├── health/           # Health check endpoint
+    │   │   │   ├── location/
+    │   │   │   │   └── suggest/      # Address autocomplete (Google Places / Nominatim)
+    │   │   │   └── reports/
+    │   │   │       ├── route.ts      # POST — create a report
+    │   │   │       ├── classify/     # POST — multi-LLM classification
+    │   │   │       ├── form-link/    # POST — official city form lookup
+    │   │   │       └── [id]/         # DELETE — remove a report (owner only)
     │   │   ├── dashboard/    # Report tracking dashboard
+    │   │   ├── login/        # Login page
+    │   │   ├── register/     # Registration page
     │   │   └── report/       # Report submission flow
-    │   ├── components/       # React components
+    │   ├── components/
+    │   │   ├── dashboard/
+    │   │   │   └── delete-report-button.tsx
+    │   │   ├── report/
+    │   │   │   ├── describe-step.tsx   # Step 1: description + photo + location
+    │   │   │   ├── review-step.tsx     # Step 2: AI result + form link + edit
+    │   │   │   ├── confirmed-step.tsx  # Step 3: confirmation
+    │   │   │   └── stepper.tsx         # Progress indicator
+    │   │   └── ui/           # shadcn/ui primitives
     │   ├── lib/
     │   │   ├── classify/     # Multi-LLM classification engine
     │   │   │   ├── types.ts           # Shared types and prompt
@@ -51,8 +82,13 @@ spr26-Team-24/
     │   │   │   ├── anthropic-provider.ts
     │   │   │   ├── google-provider.ts
     │   │   │   └── consensus.ts       # Voting / comparison logic
-    │   │   └── ...           # Auth, Prisma, constants
-    │   ├── hooks/            # Custom React hooks
+    │   │   ├── auth.ts       # JWT session helpers
+    │   │   ├── prisma.ts     # Prisma client singleton
+    │   │   ├── openai.ts     # OpenAI client (lazy init)
+    │   │   └── constants.ts  # Issue type labels, etc.
+    │   ├── hooks/
+    │   │   ├── use-geolocation.ts  # GPS detect + reverse geocode + setCoordinates
+    │   │   └── use-image-upload.ts # Photo upload / drag-drop
     │   └── types/            # TypeScript type definitions
     └── prisma/
         ├── schema.prisma     # Database schema
@@ -62,7 +98,7 @@ spr26-Team-24/
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) v22 or later
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (optional — only needed for local Postgres)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (optional — only needed for local Postgres; production uses Neon)
 
 ## Getting Started
 
@@ -86,32 +122,33 @@ npm install
 cp .env.example .env.local
 ```
 
-Open `.env.local` and fill in any API keys you have (`OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `NEXT_PUBLIC_POSTHOG_KEY`). The
-`DATABASE_URL` and `JWT_SECRET` defaults already work against the Docker DB.
+Open `.env.local` and fill in your API keys. The app can connect to the production Neon database directly for local development (recommended), or you can run Postgres locally via Docker.
 
 | Key | Required | Purpose |
 |---|---|---|
-| `OPENAI_API_KEY` | Yes | GPT-4o-mini classification |
-| `ANTHROPIC_API_KEY` | Yes | Claude Sonnet classification |
-| `GOOGLE_API_KEY` | Yes | Gemini Flash classification |
+| `DATABASE_URL` | Yes | PostgreSQL connection string (Neon or local Docker) |
 | `JWT_SECRET` | Yes | Session token signing |
-| `DATABASE_URL` | For DB features | PostgreSQL connection string |
+| `OPENAI_API_KEY` | Yes | GPT-4o-mini classification + civic form lookup |
+| `ANTHROPIC_API_KEY` | Yes | Claude 3.5 Haiku classification |
+| `GOOGLE_API_KEY` | Yes | Gemini 2.0 Flash classification |
+| `GOOGLE_MAPS_API_KEY` | Optional | Google Places address autocomplete (falls back to Nominatim) |
 | `NEXT_PUBLIC_POSTHOG_KEY` | For telemetry | PostHog analytics |
+| `NEXT_PUBLIC_POSTHOG_HOST` | For telemetry | PostHog region host |
 
 For production deployment, see [`nexa/VERCEL_SETUP.md`](nexa/VERCEL_SETUP.md).
 
-### 4. Start the development server
+### 4. Set up the database
+
+**Option A — Use the production Neon database (recommended for demo):**
+
+Set `DATABASE_URL` in `.env.local` to the Neon connection string, then run:
 
 ```bash
-npm run dev
+cd nexa
+npx prisma migrate deploy
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
-
-### 5. (Optional) Start the database
-
-Only needed if you want real data persistence instead of localStorage:
+**Option B — Local Postgres via Docker:**
 
 ```bash
 # From repo root
@@ -120,11 +157,19 @@ cd nexa
 npx prisma migrate dev
 ```
 
+### 5. Start the development server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
 ## Daily Startup Checklist
 
 After initial setup is done, use these commands each time you come back to the project:
 
-1. Start the database (from repo root):
+1. (If using local Docker DB) start the database from repo root:
 
 ```bash
 docker compose up -d
@@ -149,10 +194,12 @@ npm run dev
 | `npm run build` | Build for production (from `nexa/`) |
 | `npm run lint` | Run ESLint (from `nexa/`) |
 | `npm run format` | Format code with Prettier (from `nexa/`) |
+| `npm run format:check` | Check formatting without writing (from `nexa/`) |
 | `npx prisma studio` | Open a visual database browser (from `nexa/`) |
-| `npx prisma migrate dev` | Apply pending migrations (from `nexa/`) |
-| `docker compose up -d` | Start the database (from repo root) |
-| `docker compose down` | Stop the database (from repo root) |
+| `npx prisma migrate dev` | Create and apply migrations locally (from `nexa/`) |
+| `npx prisma migrate deploy` | Apply pending migrations to production (from `nexa/`) |
+| `docker compose up -d` | Start the local database (from repo root) |
+| `docker compose down` | Stop the local database (from repo root) |
 
 ## Wiki
 
@@ -160,3 +207,4 @@ npm run dev
 - [PRD](https://github.com/StanfordCS194/spr26-Team-24/wiki/PRD)
 - [Measure For Success (OKRs/KPIs)](https://github.com/StanfordCS194/spr26-Team-24/wiki/Measure-For-Success)
 - [Customer Discovery Summary](https://github.com/StanfordCS194/spr26-Team-24/wiki/Customer-Discovery-Summary)
+- [Midpoint User Testing Plan](https://github.com/StanfordCS194/spr26-Team-24/wiki/Midpoint-User-Testing-Plan)

--- a/nexa/README.md
+++ b/nexa/README.md
@@ -1,36 +1,7 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Nexa — Next.js Application
 
-## Getting Started
+This is the Next.js application directory for Nexa. For full documentation
+(setup, architecture, environment variables, features), see the
+[project README](../README.md) in the repository root.
 
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+For Vercel deployment instructions, see [VERCEL_SETUP.md](VERCEL_SETUP.md).

--- a/nexa/VERCEL_SETUP.md
+++ b/nexa/VERCEL_SETUP.md
@@ -12,13 +12,16 @@ and the one-time migration step.
 ## 1. Provision a production Postgres
 
 Recommended: **Neon** via the Vercel Marketplace integration. It's free for the
-demo's traffic volume and exposes a pooled connection string that Prisma 7's
-`@prisma/adapter-pg` (already in `package.json`) handles natively.
+demo's traffic volume and exposes a pooled connection string that Prisma handles
+natively.
 
 1. From the Vercel dashboard, open the `nexa` project → **Storage** tab.
 2. Click **Create Database** → **Neon Postgres** → accept the defaults
    (`nexa-prod-db`, region close to your users).
-3. Once provisioned, Neon will auto-inject `DATABASE_URL` into the project's
+3. **Important:** when connecting, change the **Custom Prefix** from `STORAGE`
+   to `DATABASE` so that the injected env var is called `DATABASE_URL`
+   (which is what Prisma expects).
+4. Once provisioned, Neon will auto-inject `DATABASE_URL` into the project's
    env vars. **Verify** it's set under Settings → Environment Variables for
    all three environments (Production, Preview, Development).
 
@@ -32,34 +35,43 @@ tab offers first.
 Settings → Environment Variables → add each of the following for the **Production**
 environment (and **Preview** if you want PR deploys to work end-to-end).
 
-| Key                        | Value                                     | Notes                                                            |
-| -------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
-| `DATABASE_URL`             | _(auto-set by Neon — verify it's there)_  | Pooled connection string.                                        |
-| `JWT_SECRET`               | output of `openssl rand -base64 32`       | Must be **different** from the local-dev secret in `.env.local`. |
-| `OPENAI_API_KEY`           | `sk-…` from platform.openai.com           | Required. Used by `/api/reports/classify`.                       |
-| `ANTHROPIC_API_KEY`        | `sk-ant-…` from console.anthropic.com     | Only required on the `llm-comparison` branch.                    |
-| `GOOGLE_API_KEY`           | from aistudio.google.com                  | Only required on the `llm-comparison` branch.                    |
-| `NEXT_PUBLIC_POSTHOG_KEY`  | `phc_…` from app.posthog.com              | Required for the K2 time-to-submit telemetry.                    |
-| `NEXT_PUBLIC_POSTHOG_HOST` | `https://us.i.posthog.com`                | Match the region of your PostHog project.                        |
-| `NEXT_PUBLIC_APP_URL`      | `https://<your-vercel-domain>.vercel.app` | Used to construct absolute URLs in agency-receipt emails.        |
+| Key                        | Value                                     | Notes                                                                                     |
+| -------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `DATABASE_URL`             | _(auto-set by Neon — verify it's there)_  | Pooled connection string.                                                                 |
+| `JWT_SECRET`               | output of `openssl rand -base64 32`       | Must be **different** from the local-dev secret in `.env.local`.                          |
+| `OPENAI_API_KEY`           | `sk-…` from platform.openai.com           | Required. Used by classification + civic form lookup.                                     |
+| `ANTHROPIC_API_KEY`        | `sk-ant-…` from console.anthropic.com     | Required. Used by multi-LLM classification consensus engine.                              |
+| `GOOGLE_API_KEY`           | from aistudio.google.com                  | Required. Used by multi-LLM classification consensus engine.                              |
+| `GOOGLE_MAPS_API_KEY`      | from console.cloud.google.com             | Optional. Enables Google Places address autocomplete; falls back to Nominatim when unset. |
+| `NEXT_PUBLIC_POSTHOG_KEY`  | `phc_…` from app.posthog.com              | Required for the K2 time-to-submit telemetry.                                             |
+| `NEXT_PUBLIC_POSTHOG_HOST` | `https://us.i.posthog.com`                | Match the region of your PostHog project.                                                 |
+| `NEXT_PUBLIC_APP_URL`      | `https://<your-vercel-domain>.vercel.app` | Used to construct absolute URLs in agency-receipt emails.                                 |
+
+> **Note:** AI provider clients (OpenAI, Anthropic, Google) use lazy
+> initialization, so the build will succeed even if their API keys are not
+> set in a Preview environment — the endpoints will just return errors at
+> runtime when called without keys.
 
 ---
 
-## 3. Run the production migration once
+## 3. Database migrations
 
-Vercel's build step runs `prisma generate && next build` (see `package.json`'s
-`build` script) but **not** `migrate deploy`. You need to apply the schema to
-the Neon DB once, from your laptop:
+The `build` script in `package.json` runs:
+
+```
+prisma generate && ([ -n "$DATABASE_URL" ] && prisma migrate deploy || true) && next build
+```
+
+This means **migrations are applied automatically** during every Vercel build
+when `DATABASE_URL` is set. If `DATABASE_URL` is not set (e.g. in some Preview
+environments), the migration step is skipped gracefully and the build continues.
+
+You can also apply migrations manually from your laptop:
 
 ```bash
 cd nexa
-# Pull the production DATABASE_URL into a temp local var so the migration
-# script targets the prod DB, not your local Docker DB:
 DATABASE_URL="<paste Neon connection string>" npx prisma migrate deploy
 ```
-
-After this, every future migration committed to `main` will need the same
-command run once (or wired into a GitHub Action).
 
 ---
 
@@ -69,7 +81,7 @@ command run once (or wired into a GitHub Action).
 2. Hit `https://<your-domain>/` — landing page should render.
 3. Register a new user, log in, file a test report. Check Neon's SQL console
    to confirm a row appears in the `Report` table.
-4. Open PostHog → Events; you should see `report_started` and
+4. Open PostHog → Events; you should see `report_classified` and
    `report_submitted` events.
 
 ---


### PR DESCRIPTION
## Summary

- **README.md**: Add new features (address autocomplete, official city form lookup, report deletion), fix model name to Claude 3.5 Haiku, add `GOOGLE_MAPS_API_KEY` to env table, expand project structure with all current API routes and components, remove stale localStorage references, reorder database setup section
- **VERCEL_SETUP.md**: Fix build script docs (now includes conditional `prisma migrate deploy`), mark `ANTHROPIC_API_KEY` and `GOOGLE_API_KEY` as required on main (no longer branch-only), add `GOOGLE_MAPS_API_KEY`, add lazy-init note, fix Neon custom prefix instruction
- **nexa/README.md**: Replace default create-next-app boilerplate with a pointer to the root README

## Test plan

- [x] `npm run lint` — 0 errors (2 pre-existing `<img>` warnings)
- [x] `npm run format:check` — all clean
- [x] `npm run build` — compiles and generates all routes successfully

Made with [Cursor](https://cursor.com)