### PR TITLE
fix(classify): update Anthropic model to claude-haiku-4-5

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -49,7 +49,7 @@ export async function classifyWithAnthropic(
   content.push({ type: "text", text: textPrompt });
 
   const response = await getClient().messages.create({
-    model: "claude-3-5-haiku-20241022",
+    model: "claude-haiku-4-5",
     max_tokens: 300,
     messages: [{ role: "user", content }],
   });


### PR DESCRIPTION
Anthropic returns `404 not_found_error` for `claude-3-5-haiku-20241022` on the Messages API. The `claude-haiku-4-5` alias resolves correctly (cheap Haiku tier for demos).\n\n**Note:** OpenAI/Google failures in local classify are unrelated — OpenAI returns `401` invalid key until the key is rotated; Google Gemini may return `429` quota on free tier.

Made with [Cursor](https://cursor.com)