### PR TITLE
fix(classify): tolerate markdown-wrapped JSON from LLMs

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import {
   CLASSIFICATION_PROMPT,
-  type ClassificationResult,
+  parseClassificationResponse,
   type ProviderResult,
 } from "./types";
 
@@ -56,11 +56,11 @@ export async function classifyWithAnthropic(
 
   const raw =
     response.content[0]?.type === "text" ? response.content[0].text : "{}";
-  const parsed = JSON.parse(raw) as ClassificationResult;
+  const parsed = parseClassificationResponse(raw);
 
   return {
     ...parsed,
-    provider: "anthropic/claude-3.5-haiku",
+    provider: "anthropic/claude-haiku-4-5",
     latencyMs: Date.now() - start,
   };
 }

--- a/nexa/src/lib/classify/google-provider.ts
+++ b/nexa/src/lib/classify/google-provider.ts
@@ -1,7 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import {
   CLASSIFICATION_PROMPT,
-  type ClassificationResult,
+  parseClassificationResponse,
   type ProviderResult,
 } from "./types";
 
@@ -51,8 +51,7 @@ export async function classifyWithGoogle(
   });
 
   const raw = response.text ?? "{}";
-  const cleaned = raw.replace(/```json\n?/g, "").replace(/```\n?/g, "");
-  const parsed = JSON.parse(cleaned) as ClassificationResult;
+  const parsed = parseClassificationResponse(raw);
 
   return {
     ...parsed,

--- a/nexa/src/lib/classify/openai-provider.ts
+++ b/nexa/src/lib/classify/openai-provider.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
 import {
   CLASSIFICATION_PROMPT,
-  type ClassificationResult,
+  parseClassificationResponse,
   type ProviderResult,
 } from "./types";
 
@@ -45,7 +45,7 @@ export async function classifyWithOpenAI(
   });
 
   const raw = response.choices[0]?.message?.content ?? "{}";
-  const parsed = JSON.parse(raw) as ClassificationResult;
+  const parsed = parseClassificationResponse(raw);
 
   return {
     ...parsed,

--- a/nexa/src/lib/classify/types.ts
+++ b/nexa/src/lib/classify/types.ts
@@ -50,3 +50,18 @@ Severity guidelines:
 - high: immediate safety hazard or environmental contamination
 - medium: significant inconvenience or moderate risk
 - low: minor issue or cosmetic concern`;
+
+/** Parse model JSON even when wrapped in markdown fences or extra prose. */
+export function parseClassificationResponse(raw: string): ClassificationResult {
+  let text = raw
+    .trim()
+    .replace(/```(?:json)?\s*/gi, "")
+    .replace(/```/g, "");
+  text = text.trim();
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new SyntaxError("No JSON object in model response");
+  }
+  return JSON.parse(text.slice(start, end + 1)) as ClassificationResult;
+}


### PR DESCRIPTION
Models (especially Claude Haiku 4.5) sometimes return classification as ```json ... ``` even though the prompt asks for raw JSON. That caused `JSON.parse` to throw and Anthropic to be dropped entirely from consensus.\n\n- Add `parseClassificationResponse()` in classify `types.ts` (strip fences, extract outermost `{...}`).\n- Use it in OpenAI, Anthropic, and Google providers.\n- Align Anthropic provider label with `claude-haiku-4-5`.

Made with [Cursor](https://cursor.com)