### PR TITLE
feat(report): voice input via Web Speech API

### DIFF
--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Camera, MapPin, Loader2, X, Zap } from "lucide-react";
+import { Camera, MapPin, Mic, Loader2, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ErrorBanner } from "@/components/error-banner";
+import { useSpeechRecognition } from "@/hooks/use-speech-recognition";
 
 interface DescribeStepProps {
   imagePreview: string | null;
@@ -55,6 +56,13 @@ export function DescribeStep({
 }: DescribeStepProps) {
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
   const locationWrapperRef = useRef<HTMLDivElement | null>(null);
+  const speech = useSpeechRecognition();
+  // Keep the latest description in a ref so the speech callback appends to the
+  // current value rather than the one captured when listening started.
+  const descriptionRef = useRef(description);
+  useEffect(() => {
+    descriptionRef.current = description;
+  });
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -73,6 +81,17 @@ export function DescribeStep({
   };
 
   const showSuggestions = suggestionsOpen && addressSuggestions.length > 0;
+
+  const handleMicToggle = () => {
+    if (speech.listening) {
+      speech.stop();
+      return;
+    }
+    speech.start((text) => {
+      const current = descriptionRef.current;
+      onDescriptionChange(current ? `${current} ${text}` : text);
+    });
+  };
 
   return (
     <div className="flex flex-col gap-10">
@@ -123,12 +142,34 @@ export function DescribeStep({
       </div>
 
       <div className="ep-card p-6">
-        <Label
-          htmlFor="description"
-          className="mb-3 block font-mono text-xs uppercase tracking-wider text-muted-foreground"
-        >
-          Description
-        </Label>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <Label
+            htmlFor="description"
+            className="block font-mono text-xs uppercase tracking-wider text-muted-foreground"
+          >
+            Description
+          </Label>
+          {speech.supported && (
+            <button
+              type="button"
+              onClick={handleMicToggle}
+              aria-label={
+                speech.listening ? "Stop dictation" : "Dictate description"
+              }
+              aria-pressed={speech.listening}
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider transition-colors ${
+                speech.listening
+                  ? "bg-red-50 text-red-600 hover:bg-red-100"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <Mic
+                className={`size-3.5 ${speech.listening ? "animate-pulse" : ""}`}
+              />
+              {speech.listening ? "Listening…" : "Dictate"}
+            </button>
+          )}
+        </div>
         <Textarea
           id="description"
           placeholder='e.g. "Large pothole on the corner of Elm and Main, about 2 feet wide..."'
@@ -136,6 +177,9 @@ export function DescribeStep({
           value={description}
           onChange={(e) => onDescriptionChange(e.target.value)}
         />
+        {speech.error && (
+          <p className="mt-3 text-xs text-red-500">{speech.error}</p>
+        )}
       </div>
 
       <div className="ep-card p-6" ref={locationWrapperRef}>

--- a/nexa/src/hooks/use-speech-recognition.ts
+++ b/nexa/src/hooks/use-speech-recognition.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  0: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error: string;
+}
+
+interface SpeechRecognitionInstance {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+}
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
+function getSpeechRecognitionCtor(): SpeechRecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+// Stable subscribe + snapshots for useSyncExternalStore: speech-recognition
+// support is determined entirely by the runtime environment, never changes
+// after mount, and must read `false` during SSR to avoid hydration mismatch.
+const subscribe = () => () => {};
+const getClientSnapshot = () => getSpeechRecognitionCtor() !== null;
+const getServerSnapshot = () => false;
+
+export function useSpeechRecognition() {
+  const supported = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+  const [listening, setListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const onFinalRef = useRef<((text: string) => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+      recognitionRef.current = null;
+    };
+  }, []);
+
+  const start = useCallback((onFinal: (text: string) => void) => {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) {
+      setError("Speech recognition is not supported in this browser.");
+      return;
+    }
+
+    // Guard against double-starts — calling start() on an active instance throws.
+    if (recognitionRef.current) return;
+
+    onFinalRef.current = onFinal;
+    setError(null);
+
+    const recognition = new Ctor();
+    recognition.lang =
+      typeof navigator !== "undefined" ? navigator.language : "en-US";
+    recognition.continuous = false;
+    recognition.interimResults = false;
+
+    recognition.onresult = (event) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          const text = result[0]?.transcript?.trim();
+          if (text) onFinalRef.current?.(text);
+        }
+      }
+    };
+
+    recognition.onerror = (event) => {
+      if (
+        event.error === "not-allowed" ||
+        event.error === "service-not-allowed"
+      ) {
+        setError("Microphone permission denied. Please allow access.");
+      } else if (event.error === "no-speech") {
+        setError("No speech detected. Try again.");
+      } else if (event.error === "audio-capture") {
+        setError("No microphone found.");
+      } else {
+        setError("Speech recognition failed. Try again.");
+      }
+    };
+
+    recognition.onend = () => {
+      setListening(false);
+      recognitionRef.current = null;
+      onFinalRef.current = null;
+    };
+
+    try {
+      recognition.start();
+      recognitionRef.current = recognition;
+      setListening(true);
+    } catch {
+      setError("Could not start speech recognition.");
+      recognitionRef.current = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+  }, []);
+
+  return { supported, listening, error, start, stop };
+}


### PR DESCRIPTION
## Summary

- Adds a microphone button to the Describe step that dictates speech into the description textarea using the browser's native `SpeechRecognition` (webkit-prefixed on Safari).
- New `useSpeechRecognition` hook in `src/hooks/`, mirroring the style of `useGeolocation` / `useImageUpload`.
- Single-utterance mode (`continuous: false`); each tap captures one phrase and appends it to the existing description. Unsupported browsers hide the button rather than render a dead control.

## What's intentionally NOT in this PR

- **Whisper API fallback** — the issue mentions it as a fallback; keeping it out to keep this PR small. Worth a separate issue.
- **Tests** — there is no test infra in the repo yet (#43 tracks adding Playwright).

## Test plan

Manual browser testing required (microphone input can't be exercised by CI):

- [ ] In Chrome on desktop: navigate to `/report`, click the **Dictate** chip in the Description card, allow mic permission, speak a phrase, confirm the text appears in the description field.
- [ ] Tap **Dictate** twice in a row with different phrases — confirm the second phrase is appended (not overwriting) with a space between.
- [ ] Type a phrase manually, then dictate — the dictated text should be appended after the typed text.
- [ ] Tap **Dictate** then **Listening…** to cancel mid-utterance — no error, button returns to idle.
- [ ] Deny mic permission when prompted — confirm the inline error message "Microphone permission denied. Please allow access." appears.
- [ ] Safari (desktop or iOS): confirm the button appears (webkit prefix is wired) and works.
- [ ] Firefox desktop: confirm the button is **hidden** entirely (Firefox does not implement Web Speech API).

Closes #40