### PR TITLE
feat(report): draggable map pin for location correction

### DIFF
--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -18,12 +18,14 @@
         "clsx": "^2.1.1",
         "dotenv": "^17.4.2",
         "jose": "^6.2.3",
+        "leaflet": "^1.9.4",
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
         "openai": "^6.34.0",
         "posthog-js": "^1.373.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-leaflet": "^5.0.0",
         "shadcn": "^4.3.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -31,6 +33,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/bcryptjs": "^2.4.6",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -105,7 +108,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -700,7 +702,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -757,8 +758,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -1705,7 +1705,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1948,7 +1947,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2055,7 +2053,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2764,6 +2761,17 @@
         }
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3246,6 +3254,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3259,6 +3274,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -3286,7 +3311,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3295,9 +3319,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3381,7 +3404,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3920,7 +3942,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4411,7 +4432,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5581,7 +5601,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5783,7 +5802,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6073,7 +6091,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6955,7 +6972,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7911,6 +7927,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -9258,7 +9280,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9586,7 +9607,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.7.0",
         "@prisma/dev": "0.24.3",
@@ -9812,7 +9832,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9822,7 +9841,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9836,6 +9854,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -11017,7 +11049,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11272,7 +11303,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11870,7 +11900,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -21,12 +21,14 @@
     "clsx": "^2.1.1",
     "dotenv": "^17.4.2",
     "jose": "^6.2.3",
+    "leaflet": "^1.9.4",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "openai": "^6.34.0",
     "posthog-js": "^1.373.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-leaflet": "^5.0.0",
     "shadcn": "^4.3.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/bcryptjs": "^2.4.6",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/nexa/src/app/globals.css
+++ b/nexa/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import "leaflet/dist/leaflet.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -334,6 +334,7 @@ export default function ReportPage() {
             onDescriptionChange={setDescription}
             onAddressChange={handleAddressChange}
             onDetectLocation={geo.detect}
+            onLocationChange={geo.setCoordinates}
             onClassify={handleClassify}
           />
         )}

--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { Camera, MapPin, Loader2, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ErrorBanner } from "@/components/error-banner";
+
+// Leaflet touches `window` at module load, so render the map only on the client.
+const LocationMap = dynamic(() => import("./location-map"), {
+  ssr: false,
+  loading: () => (
+    <div className="mt-3 h-48 animate-pulse rounded-lg border border-border bg-muted/40" />
+  ),
+});
 
 interface DescribeStepProps {
   imagePreview: string | null;
@@ -28,6 +37,7 @@ interface DescribeStepProps {
   onDescriptionChange: (value: string) => void;
   onAddressChange: (value: string) => void;
   onDetectLocation: () => void;
+  onLocationChange: (latitude: number, longitude: number) => void;
   onClassify: () => void;
 }
 
@@ -51,6 +61,7 @@ export function DescribeStep({
   onDescriptionChange,
   onAddressChange,
   onDetectLocation,
+  onLocationChange,
   onClassify,
 }: DescribeStepProps) {
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
@@ -203,19 +214,29 @@ export function DescribeStep({
         {locationError && (
           <p className="mt-3 text-xs text-red-500">{locationError}</p>
         )}
-        {latitude && longitude && (
-          <div className="mt-3 flex flex-wrap items-center gap-3 font-mono text-xs text-muted-foreground">
-            <span>
-              GPS: {latitude.toFixed(6)}, {longitude.toFixed(6)}
-            </span>
-            {accuracy && (
-              <span
-                className={`rounded-full px-2 py-0.5 ${accuracy <= 20 ? "bg-ep-green-light text-ep-green" : accuracy <= 100 ? "bg-yellow-50 text-yellow-600" : "bg-red-50 text-red-600"}`}
-              >
-                ±{Math.round(accuracy)}m
+        {latitude !== null && longitude !== null && (
+          <>
+            <div className="mt-3 flex flex-wrap items-center gap-3 font-mono text-xs text-muted-foreground">
+              <span>
+                GPS: {latitude.toFixed(6)}, {longitude.toFixed(6)}
               </span>
-            )}
-          </div>
+              {accuracy && (
+                <span
+                  className={`rounded-full px-2 py-0.5 ${accuracy <= 20 ? "bg-ep-green-light text-ep-green" : accuracy <= 100 ? "bg-yellow-50 text-yellow-600" : "bg-red-50 text-red-600"}`}
+                >
+                  ±{Math.round(accuracy)}m
+                </span>
+              )}
+              <span className="text-muted-foreground/70">
+                Drag the pin to correct
+              </span>
+            </div>
+            <LocationMap
+              latitude={latitude}
+              longitude={longitude}
+              onMove={onLocationChange}
+            />
+          </>
         )}
       </div>
 

--- a/nexa/src/components/report/location-map.tsx
+++ b/nexa/src/components/report/location-map.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import L from "leaflet";
+import { MapContainer, Marker, TileLayer, useMap } from "react-leaflet";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+// Bundlers don't resolve Leaflet's default-icon URLs; provide them explicitly.
+const defaultIcon = L.icon({
+  iconUrl: markerIcon.src,
+  iconRetinaUrl: markerIcon2x.src,
+  shadowUrl: markerShadow.src,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+interface LocationMapProps {
+  latitude: number;
+  longitude: number;
+  onMove: (latitude: number, longitude: number) => void;
+}
+
+function RecenterOnChange({ lat, lng }: { lat: number; lng: number }) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView([lat, lng], map.getZoom(), { animate: true });
+  }, [lat, lng, map]);
+  return null;
+}
+
+export default function LocationMap({
+  latitude,
+  longitude,
+  onMove,
+}: LocationMapProps) {
+  const markerRef = useRef<L.Marker | null>(null);
+  const eventHandlers = useMemo(
+    () => ({
+      dragend: () => {
+        const marker = markerRef.current;
+        if (!marker) return;
+        const { lat, lng } = marker.getLatLng();
+        onMove(lat, lng);
+      },
+    }),
+    [onMove],
+  );
+
+  return (
+    <div className="mt-3 h-48 overflow-hidden rounded-lg border border-border">
+      <MapContainer
+        center={[latitude, longitude]}
+        zoom={16}
+        scrollWheelZoom={false}
+        className="h-full w-full"
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <Marker
+          position={[latitude, longitude]}
+          icon={defaultIcon}
+          draggable
+          eventHandlers={eventHandlers}
+          ref={markerRef}
+        />
+        <RecenterOnChange lat={latitude} lng={longitude} />
+      </MapContainer>
+    </div>
+  );
+}

--- a/nexa/src/types/static-images.d.ts
+++ b/nexa/src/types/static-images.d.ts
@@ -1,0 +1,14 @@
+// Type declarations for Next.js static-asset imports. The matching
+// declarations live in `next-env.d.ts`, which Next.js auto-generates on `next
+// dev` / `next build` but is gitignored — so CI's `tsc --noEmit` step (which
+// runs without ever building Next) needs an in-repo copy.
+
+declare module "*.png" {
+  const content: {
+    src: string;
+    height: number;
+    width: number;
+    blurDataURL?: string;
+  };
+  export default content;
+}


### PR DESCRIPTION
## Summary

- After GPS detect (or selecting an autocomplete suggestion), a small map appears under the Location card with a draggable pin on the captured coordinates.
- Dragging the pin updates the wizard's lat/lng state, so the report is filed at the corrected location.
- Uses **Leaflet + react-leaflet** with **OpenStreetMap tiles** (no API key, no Vercel env vars to set). The issue suggested Mapbox or Google; Leaflet was picked because the app already uses OSM/Nominatim for reverse geocoding, and no new key dance was needed.
- Map is dynamic-imported with `ssr: false` (Leaflet touches `window` at module load).

## Files touched

- **NEW** `src/components/report/location-map.tsx` — client-only map component
- **NEW** `src/types/static-images.d.ts` — type shim for `*.png` imports (CI runs `tsc --noEmit` without ever building Next, and `next-env.d.ts` is gitignored)
- **EDIT** `src/components/report/describe-step.tsx` — renders the map when lat/lng are set; adds `onLocationChange` prop
- **EDIT** `src/app/report/page.tsx` — passes `geo.setCoordinates` as `onLocationChange`
- **EDIT** `src/app/globals.css` — `@import "leaflet/dist/leaflet.css"`
- **EDIT** `package.json` / `package-lock.json` — adds `leaflet`, `react-leaflet`, `@types/leaflet`

## What's intentionally NOT in this PR

- **Address text does NOT auto-refresh on pin drag.** Only the lat/lng update; the address string the user typed/detected stays as-is. Reverse-geocoding on drag would require refactoring `use-geolocation.ts` — worth its own issue.
- **No custom map styling.** Default OSM tiles. Can be themed later.
- **Tests** — repo has no test infra yet (#43 tracks it).

## Test plan (manual, since dragging can't be exercised by CI)

- [ ] Log in, go to `/report`, click **Detect** → the map appears with a pin on your location.
- [ ] Drag the pin to a new spot → release → the GPS coordinates in the row above update to match.
- [ ] Submit the report → confirm on the dashboard that the saved coordinates match the *dragged* position, not the original detected one.
- [ ] Type an address into the input, pick a suggestion → the map re-centers on the picked location.
- [ ] Tap **Detect** again after dragging → the map re-centers on the new GPS reading.
- [ ] On mobile Safari/Chrome: pin is drag-friendly with touch.

## Risk

Low. Map only renders when lat/lng are set; nothing else in the wizard flow changes. Bundle size grows by ~150 KB gz (Leaflet + react-leaflet) — acceptable for a feature that's gated behind GPS capture.

Closes #28