### PR TITLE
feat(dashboard): show relative timestamps

### DIFF
--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, CheckCircle2, Clock3, ClipboardList } from "lucide-react";
 import { ISSUE_TYPE_LABELS } from "@/lib/constants";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatFullDateTime, formatRelativeTime } from "@/lib/utils";
 import { DeleteReportButton } from "@/components/dashboard/delete-report-button";
 
 function formatStatus(status: string): string {
@@ -58,8 +59,7 @@ export default async function DashboardPage() {
   const confirmedReports = reports.filter(
     (report) => report.status === "CONFIRMED",
   ).length;
-  const latestReportDate =
-    reports.length > 0 ? new Date(reports[0].createdAt).toLocaleString() : "—";
+  const latestReport = reports[0];
 
   return (
     <main className="mx-auto w-full max-w-4xl flex-1 px-6 py-10">
@@ -107,7 +107,18 @@ export default async function DashboardPage() {
               Most Recent
             </p>
           </div>
-          <p className="mt-3 text-sm font-medium">{latestReportDate}</p>
+          <p className="mt-3 text-sm font-medium">
+            {latestReport ? (
+              <time
+                dateTime={latestReport.createdAt.toISOString()}
+                title={formatFullDateTime(latestReport.createdAt)}
+              >
+                {formatRelativeTime(latestReport.createdAt)}
+              </time>
+            ) : (
+              "—"
+            )}
+          </p>
         </div>
       </div>
 
@@ -146,7 +157,12 @@ export default async function DashboardPage() {
                   {report.address || "No location provided"}
                 </h2>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {new Date(report.createdAt).toLocaleString()}
+                  <time
+                    dateTime={report.createdAt.toISOString()}
+                    title={formatFullDateTime(report.createdAt)}
+                  >
+                    {formatRelativeTime(report.createdAt)}
+                  </time>
                 </p>
 
                 <p className="mt-4 text-sm leading-relaxed text-foreground">

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { CheckCircle2, ArrowRight } from "lucide-react";
 import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import { formatFullDateTime, formatRelativeTime } from "@/lib/utils";
 
 interface ConfirmedReport {
   id: string;
@@ -54,9 +55,13 @@ export function ConfirmedStep({ report, onReportAnother }: ConfirmedStepProps) {
             <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
               Submitted
             </span>
-            <span className="text-sm">
-              {new Date(report.createdAt).toLocaleString()}
-            </span>
+            <time
+              dateTime={new Date(report.createdAt).toISOString()}
+              title={formatFullDateTime(report.createdAt)}
+              className="text-sm"
+            >
+              {formatRelativeTime(report.createdAt)}
+            </time>
           </div>
           {report.aiDescription && (
             <>

--- a/nexa/src/lib/utils.ts
+++ b/nexa/src/lib/utils.ts
@@ -4,3 +4,41 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const relativeTimeFormat = new Intl.RelativeTimeFormat("en", {
+  numeric: "auto",
+});
+
+/**
+ * "just now" / "5 minutes ago" / "yesterday" / "3 days ago" for recent times;
+ * a short absolute date ("May 13", "May 13, 2025") for anything older than a week.
+ */
+export function formatRelativeTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const diffSec = Math.round((d.getTime() - Date.now()) / 1000);
+  const absSec = Math.abs(diffSec);
+
+  if (absSec < 45) return "just now";
+  if (absSec < 60 * 60) {
+    return relativeTimeFormat.format(Math.round(diffSec / 60), "minute");
+  }
+  if (absSec < 60 * 60 * 24) {
+    return relativeTimeFormat.format(Math.round(diffSec / 3600), "hour");
+  }
+  if (absSec < 60 * 60 * 24 * 7) {
+    return relativeTimeFormat.format(Math.round(diffSec / 86400), "day");
+  }
+
+  const now = new Date();
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() === now.getFullYear() ? undefined : "numeric",
+  });
+}
+
+/** Full timestamp suitable for a tooltip / aria-label. */
+export function formatFullDateTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString();
+}


### PR DESCRIPTION
## Summary

Replaces full-datetime strings with friendlier relative forms across the user-facing surfaces that show a timestamp:

- **Dashboard rows** — "Posted 5/13/2026, 5:23:18 PM" becomes "5 minutes ago"
- **Dashboard "Most Recent" stat card** — same
- **Confirmed step / Submitted line** — same

Relative for less than a week; falls back to a short absolute date (e.g. "May 13", or "May 13, 2025" across years) for anything older. Each value is wrapped in a `<time>` element with `title` set to the full datetime — so hovering still shows the exact moment, and screen readers get a machine-readable `dateTime`.

Uses native `Intl.RelativeTimeFormat` — no new dependencies, no bundle growth.

## Files touched

- **EDIT** `src/lib/utils.ts` — adds `formatRelativeTime()` + `formatFullDateTime()` helpers
- **EDIT** `src/app/dashboard/page.tsx` — uses both helpers; `latestReport` extracted from the array directly
- **EDIT** `src/components/report/confirmed-step.tsx` — uses both helpers

## Caveat

The relative value is computed at page-load time (the dashboard is server-rendered). If a user keeps the dashboard open for an hour, "5 minutes ago" will stay "5 minutes ago" until they refresh. Live-updating would require converting to a client component — out of scope here, but worth a follow-up issue if anyone cares.

## Test plan

- [ ] Dashboard: file a new report, then visit the dashboard — its row should read "just now" (or "1 minute ago" if you took a beat).
- [ ] Dashboard: existing demo reports (>7 days old) should show short absolute dates like "May 13".
- [ ] Dashboard: "Most Recent" stat card matches the top row.
- [ ] Confirmed step: after submitting a report, the Submitted line reads "just now".
- [ ] Hover any timestamp — the tooltip shows the full datetime.
- [ ] When the user has zero reports, the "Most Recent" card shows "—" (not a date).

Closes #65