### PR TITLE
fix(auth): verify passwords on login and add claim flow for orphan ac…

### DIFF
--- a/nexa/scripts/audit-passwordless-users.ts
+++ b/nexa/scripts/audit-passwordless-users.ts
@@ -1,0 +1,77 @@
+// Audit + optional cleanup for User rows that have no passwordHash.
+//
+// Background: an earlier version of /api/auth/login used
+// `prisma.user.upsert({ where: { email } })`, which silently created a User
+// row for any email anyone typed into the login form, never verifying a
+// password. Many of those rows are not real accounts.
+//
+// Usage:
+//   npx tsx scripts/audit-passwordless-users.ts           # read-only audit
+//   npx tsx scripts/audit-passwordless-users.ts --delete  # delete the safe set
+//
+// The script only ever deletes rows that have:
+//   - passwordHash IS NULL                  (never set a password), AND
+//   - zero Reports tied to the userId       (no submitted data to preserve)
+//
+// Rows with passwordHash IS NULL *but* with reports are reported only — those
+// represent users who filed real reports before the password gate existed,
+// and they should be migrated through /claim rather than deleted.
+
+import { PrismaClient } from "../src/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  const dryRun = !process.argv.includes("--delete");
+
+  const passwordless = await prisma.user.findMany({
+    where: { passwordHash: null },
+    select: {
+      id: true,
+      email: true,
+      createdAt: true,
+      _count: { select: { reports: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const safeToDelete = passwordless.filter((u) => u._count.reports === 0);
+  const hasReports = passwordless.filter((u) => u._count.reports > 0);
+
+  console.log(`Total passwordless users: ${passwordless.length}`);
+  console.log(`  - no reports (safe to delete): ${safeToDelete.length}`);
+  console.log(`  - with reports (needs /claim): ${hasReports.length}`);
+
+  if (hasReports.length > 0) {
+    console.log("\nUsers with reports but no password:");
+    for (const u of hasReports) {
+      console.log(
+        `  ${u.email}\t${u._count.reports} report(s)\tcreated ${u.createdAt.toISOString()}`,
+      );
+    }
+  }
+
+  if (safeToDelete.length === 0) {
+    console.log("\nNothing to delete.");
+    return;
+  }
+
+  if (dryRun) {
+    console.log("\n(dry run — pass --delete to actually remove)");
+    return;
+  }
+
+  const result = await prisma.user.deleteMany({
+    where: { id: { in: safeToDelete.map((u) => u.id) } },
+  });
+  console.log(`\nDeleted ${result.count} passwordless users with no reports.`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/nexa/src/app/(auth)/claim/page.tsx
+++ b/nexa/src/app/(auth)/claim/page.tsx
@@ -1,0 +1,13 @@
+import { ClaimForm } from "@/components/auth/claim-form";
+
+export const metadata = {
+  title: "Claim your account — Nexa",
+};
+
+export default function ClaimPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 py-12">
+      <ClaimForm />
+    </main>
+  );
+}

--- a/nexa/src/app/api/auth/claim/route.ts
+++ b/nexa/src/app/api/auth/claim/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+// One-shot path to set a password on accounts that never had one. This exists
+// to clean up after a prior bug in /api/auth/login that upserted users by
+// email without ever asking for or verifying a password — see README / PR.
+//
+// Only succeeds if the account currently has `passwordHash = null`. Once a
+// password is set, this endpoint becomes a no-op for that user.
+export async function POST(request: NextRequest) {
+  try {
+    const { email, password, name } = await request.json();
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: "Email and password are required" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof password !== "string" || password.length < 8) {
+      return NextResponse.json(
+        { error: "Password must be at least 8 characters" },
+        { status: 400 },
+      );
+    }
+
+    const existing = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, passwordHash: true },
+    });
+
+    if (existing && existing.passwordHash) {
+      return NextResponse.json(
+        {
+          error:
+            "This account already has a password. Sign in instead, or reset your password.",
+        },
+        { status: 409 },
+      );
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    const user = existing
+      ? await prisma.user.update({
+          where: { id: existing.id },
+          data: { passwordHash, ...(name ? { name } : {}) },
+          select: { id: true, email: true, name: true },
+        })
+      : await prisma.user.create({
+          data: { email, name: name ?? null, passwordHash },
+          select: { id: true, email: true, name: true },
+        });
+
+    const token = await createToken({ userId: user.id, email: user.email });
+    const response = NextResponse.json(user, { status: 200 });
+    response.cookies.set(SESSION_COOKIE, token, cookieOptions);
+    return response;
+  } catch (error) {
+    console.error("Account claim error:", error);
+    return NextResponse.json(
+      { error: "Failed to set password. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/nexa/src/app/api/auth/login/route.ts
+++ b/nexa/src/app/api/auth/login/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -13,14 +14,27 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const user = await prisma.user.upsert({
+    const user = await prisma.user.findUnique({
       where: { email },
-      update: {},
-      create: {
-        email,
-        name: email.split("@")[0],
-      },
+      select: { id: true, email: true, name: true, passwordHash: true },
     });
+
+    // Use the same generic message for "no user" and "wrong password" so the
+    // login endpoint cannot be used to enumerate which emails have accounts.
+    if (!user || !user.passwordHash) {
+      return NextResponse.json(
+        { error: "Invalid email or password" },
+        { status: 401 },
+      );
+    }
+
+    const ok = await bcrypt.compare(password, user.passwordHash);
+    if (!ok) {
+      return NextResponse.json(
+        { error: "Invalid email or password" },
+        { status: 401 },
+      );
+    }
 
     const token = await createToken({ userId: user.id, email: user.email });
     const response = NextResponse.json(

--- a/nexa/src/components/auth/claim-form.tsx
+++ b/nexa/src/components/auth/claim-form.tsx
@@ -56,8 +56,8 @@ export function ClaimForm() {
             Claim your account
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            If your account was created before passwords were required, set
-            one here to take it over.
+            If your account was created before passwords were required, set one
+            here to take it over.
           </p>
         </div>
 

--- a/nexa/src/components/auth/claim-form.tsx
+++ b/nexa/src/components/auth/claim-form.tsx
@@ -2,17 +2,17 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-export function LoginForm() {
+export function ClaimForm() {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -22,21 +22,24 @@ export function LoginForm() {
     setLoading(true);
 
     try {
-      const res = await fetch("/api/auth/login", {
+      const res = await fetch("/api/auth/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({
+          email,
+          password,
+          name: name || undefined,
+        }),
       });
 
       const data = await res.json();
 
       if (!res.ok) {
-        setError(data.error || "Login failed");
+        setError(data.error || "Failed to claim account");
         return;
       }
 
-      const redirect = searchParams.get("redirect") || "/";
-      router.push(redirect);
+      router.push("/dashboard");
       router.refresh();
     } catch {
       setError("Something went wrong. Please try again.");
@@ -49,9 +52,12 @@ export function LoginForm() {
     <div className="w-full max-w-sm">
       <div className="ep-card p-8">
         <div className="mb-6">
-          <h1 className="text-xl font-semibold tracking-tight">Welcome back</h1>
+          <h1 className="text-xl font-semibold tracking-tight">
+            Claim your account
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Sign in to your Nexa account
+            If your account was created before passwords were required, set
+            one here to take it over.
           </p>
         </div>
 
@@ -70,13 +76,26 @@ export function LoginForm() {
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="password">Password</Label>
+            <Label htmlFor="name">Name (optional)</Label>
+            <Input
+              id="name"
+              type="text"
+              placeholder="Jane Smith"
+              autoComplete="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="password">New password</Label>
             <Input
               id="password"
               type="password"
-              placeholder="Your password"
-              autoComplete="current-password"
+              placeholder="At least 8 characters"
+              autoComplete="new-password"
               required
+              minLength={8}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
@@ -89,25 +108,18 @@ export function LoginForm() {
           )}
 
           <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? "Signing in\u2026" : "Sign in"}
+            {loading ? "Setting password…" : "Set password & sign in"}
           </Button>
         </form>
       </div>
 
       <p className="mt-4 text-center text-sm text-muted-foreground">
-        Don&apos;t have an account?{" "}
+        Already have a password?{" "}
         <Link
-          href="/register"
+          href="/login"
           className="font-medium text-foreground underline-offset-4 hover:underline"
         >
-          Create one
-        </Link>
-      </p>
-
-      <p className="mt-2 text-center text-xs text-muted-foreground">
-        Signed up before passwords were required?{" "}
-        <Link href="/claim" className="underline-offset-4 hover:underline">
-          Claim your account
+          Sign in
         </Link>
       </p>
     </div>


### PR DESCRIPTION
…counts

The /api/auth/login route was upserting users by email and issuing a session without ever checking the supplied password. Two problems:

  1. Anyone who knew an email could sign in as that user.
  2. Every email ever typed into the form became a real User row, with passwordHash = NULL.

Login now does a findUnique + bcrypt.compare against the stored hash, and returns a generic 'Invalid email or password' for both 'no such user' and 'wrong password' to avoid email enumeration.

To let legitimate users recover accounts created by the bug, add a /claim endpoint and page that only succeeds when passwordHash is null, and add scripts/audit-passwordless-users.ts to identify and (with --delete) remove orphan rows that have no reports.