### PR TITLE
feat(pwa): add web app manifest and icon for installability (#41)

### DIFF
--- a/nexa/public/sw.js
+++ b/nexa/public/sw.js
@@ -7,7 +7,9 @@ const CACHE = "nexa-v1";
 const OFFLINE_URLS = ["/"];
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(OFFLINE_URLS)));
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(OFFLINE_URLS)),
+  );
   self.skipWaiting();
 });
 

--- a/nexa/public/sw.js
+++ b/nexa/public/sw.js
@@ -1,0 +1,69 @@
+// Nexa service worker — offline app shell + static asset caching.
+// Part of the PWA work (issue #41). Pairs with the web app manifest and the
+// offline report queue (src/lib/offline-queue.ts), which replays queued POSTs
+// from the page on reconnect rather than here.
+
+const CACHE = "nexa-v1";
+const OFFLINE_URLS = ["/"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(OFFLINE_URLS)));
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle same-origin GETs; never cache API traffic or POSTs.
+  if (
+    request.method !== "GET" ||
+    url.origin !== self.location.origin ||
+    url.pathname.startsWith("/api")
+  ) {
+    return;
+  }
+
+  // Navigations: network-first, fall back to the cached shell when offline.
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cached) => cached || caches.match("/")),
+        ),
+    );
+    return;
+  }
+
+  // Static assets: stale-while-revalidate.
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const network = fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => cached);
+      return cached || network;
+    }),
+  );
+});

--- a/nexa/src/app/icon.svg
+++ b/nexa/src/app/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#10b981" />
+      <stop offset="0.5" stop-color="#14b8a6" />
+      <stop offset="1" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#g)" />
+  <text x="50%" y="50%" dy="0.36em" text-anchor="middle"
+    font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+    font-size="320" font-weight="700" fill="#ffffff">N</text>
+</svg>

--- a/nexa/src/app/layout.tsx
+++ b/nexa/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Navbar } from "@/components/navbar";
 import { PostHogProvider } from "@/components/posthog-provider";
@@ -19,6 +19,16 @@ export const metadata: Metadata = {
   title: "Nexa — Snap a Photo, We'll Handle City Hall",
   description:
     "Report neighborhood issues to your city in seconds. AI-powered civic reporting that knows which department to call and how to file it.",
+  applicationName: "Nexa",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Nexa",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#14b8a6",
 };
 
 export default function RootLayout({

--- a/nexa/src/app/layout.tsx
+++ b/nexa/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Navbar } from "@/components/navbar";
 import { PostHogProvider } from "@/components/posthog-provider";
+import { PwaSetup } from "@/components/pwa-setup";
 import "leaflet/dist/leaflet.css";
 import "./globals.css";
 
@@ -43,6 +44,7 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         <PostHogProvider>
+          <PwaSetup />
           <Navbar />
           {children}
         </PostHogProvider>

--- a/nexa/src/app/manifest.ts
+++ b/nexa/src/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+
+// Web app manifest — first piece of the PWA work (issue #41). Makes Nexa
+// installable to a phone home screen so field reporting feels like a native
+// app. Service worker + offline queueing are the follow-up pieces.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Nexa — Civic Issue Reporting",
+    short_name: "Nexa",
+    description:
+      "Report neighborhood issues to your city in seconds. AI-powered civic reporting.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#14b8a6",
+    icons: [
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -8,6 +8,7 @@ import { ReviewStep } from "@/components/report/review-step";
 import { ConfirmedStep } from "@/components/report/confirmed-step";
 import { useImageUpload } from "@/hooks/use-image-upload";
 import { useGeolocation } from "@/hooks/use-geolocation";
+import { queueReport } from "@/lib/offline-queue";
 
 interface ClassificationResult {
   issueType: string;
@@ -81,6 +82,7 @@ export default function ReportPage() {
     null,
   );
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submittedOffline, setSubmittedOffline] = useState(false);
   const [officialForm, setOfficialForm] =
     useState<OfficialFormLookupResult | null>(null);
   const [officialFormLoading, setOfficialFormLoading] = useState(false);
@@ -262,19 +264,22 @@ export default function ReportPage() {
     if (!classification) return;
     setSubmitting(true);
     setSubmitError(null);
+
+    const payload = {
+      description,
+      aiDescription: classification.aiDescription,
+      issueType: classification.issueType,
+      latitude: geo.latitude,
+      longitude: geo.longitude,
+      address: geo.address,
+      imageUrl: image.imageBase64,
+    };
+
     try {
       const res = await fetch("/api/reports", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          description,
-          aiDescription: classification.aiDescription,
-          issueType: classification.issueType,
-          latitude: geo.latitude,
-          longitude: geo.longitude,
-          address: geo.address,
-          imageUrl: image.imageBase64,
-        }),
+        body: JSON.stringify(payload),
       });
 
       if (!res.ok) {
@@ -284,6 +289,7 @@ export default function ReportPage() {
 
       const report: CreatedReport = await res.json();
       setCreatedReport(report);
+      setSubmittedOffline(false);
       setStep("confirmed");
       posthog?.capture("report_submitted", {
         report_id: report.id,
@@ -293,7 +299,27 @@ export default function ReportPage() {
         has_location: !!geo.latitude,
       });
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : "Something went wrong");
+      // No connectivity: park the report locally and confirm optimistically.
+      // PwaSetup replays the queue once the browser is back online.
+      if (typeof navigator !== "undefined" && !navigator.onLine) {
+        queueReport(payload);
+        setCreatedReport({
+          id: "Pending sync",
+          issueType: classification.issueType,
+          description,
+          aiDescription: classification.aiDescription,
+          createdAt: new Date().toISOString(),
+        });
+        setSubmittedOffline(true);
+        setStep("confirmed");
+        posthog?.capture("report_queued_offline", {
+          issue_type: classification.issueType,
+          has_image: !!image.imageBase64,
+          has_location: !!geo.latitude,
+        });
+      } else {
+        setSubmitError(e instanceof Error ? e.message : "Something went wrong");
+      }
     } finally {
       setSubmitting(false);
     }
@@ -316,6 +342,7 @@ export default function ReportPage() {
     setCreatedReport(null);
     setClassifyError(null);
     setSubmitError(null);
+    setSubmittedOffline(false);
     setOfficialForm(null);
     setOfficialFormLoading(false);
   };
@@ -429,7 +456,11 @@ export default function ReportPage() {
         )}
 
         {step === "confirmed" && createdReport && (
-          <ConfirmedStep report={createdReport} onReportAnother={resetForm} />
+          <ConfirmedStep
+            report={createdReport}
+            offline={submittedOffline}
+            onReportAnother={resetForm}
+          />
         )}
       </div>
 

--- a/nexa/src/components/pwa-setup.tsx
+++ b/nexa/src/components/pwa-setup.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { flushQueue } from "@/lib/offline-queue";
+
+// Registers the service worker and replays any reports queued while offline.
+// Rendered once from the root layout. Returns no UI.
+export function PwaSetup() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {
+        // Registration failures are non-fatal — the app still works online.
+      });
+    }
+
+    void flushQueue();
+    const onOnline = () => void flushQueue();
+    window.addEventListener("online", onOnline);
+    return () => window.removeEventListener("online", onOnline);
+  }, []);
+
+  return null;
+}

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -12,10 +12,15 @@ interface ConfirmedReport {
 
 interface ConfirmedStepProps {
   report: ConfirmedReport;
+  offline?: boolean;
   onReportAnother: () => void;
 }
 
-export function ConfirmedStep({ report, onReportAnother }: ConfirmedStepProps) {
+export function ConfirmedStep({
+  report,
+  offline = false,
+  onReportAnother,
+}: ConfirmedStepProps) {
   return (
     <div className="flex flex-col items-center gap-10 py-12 text-center">
       <div className="flex size-20 items-center justify-center rounded-full bg-ep-green-light">
@@ -24,10 +29,12 @@ export function ConfirmedStep({ report, onReportAnother }: ConfirmedStepProps) {
 
       <div>
         <h2 className="text-3xl font-normal tracking-tight">
-          Report submitted!
+          {offline ? "Saved offline" : "Report submitted!"}
         </h2>
         <p className="mt-2 text-muted-foreground">
-          Your civic report has been filed successfully.
+          {offline
+            ? "You're offline — we'll file this report automatically when your connection returns."
+            : "Your civic report has been filed successfully."}
         </p>
       </div>
 

--- a/nexa/src/lib/offline-queue.ts
+++ b/nexa/src/lib/offline-queue.ts
@@ -1,0 +1,75 @@
+// Offline report queue (PWA work, issue #41). When a report is submitted
+// without connectivity, its payload is parked in localStorage and replayed to
+// /api/reports once the browser reports it is back online.
+
+const STORAGE_KEY = "nexa:offline-report-queue";
+
+export interface QueuedReport {
+  id: string;
+  payload: Record<string, unknown>;
+  queuedAt: number;
+}
+
+function read(): QueuedReport[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as QueuedReport[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(items: QueuedReport[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // Storage full or unavailable — nothing more we can do here.
+  }
+}
+
+export function queueReport(payload: Record<string, unknown>): QueuedReport {
+  const item: QueuedReport = {
+    id: `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    payload,
+    queuedAt: Date.now(),
+  };
+  write([...read(), item]);
+  return item;
+}
+
+export function getQueuedCount(): number {
+  return read().length;
+}
+
+/** Replays every queued report; keeps the ones that still fail. Returns the count submitted. */
+export async function flushQueue(): Promise<number> {
+  if (typeof window === "undefined" || !navigator.onLine) return 0;
+
+  const items = read();
+  if (items.length === 0) return 0;
+
+  const remaining: QueuedReport[] = [];
+  let flushed = 0;
+
+  for (const item of items) {
+    try {
+      const res = await fetch("/api/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(item.payload),
+      });
+      if (res.ok) {
+        flushed += 1;
+      } else {
+        remaining.push(item);
+      }
+    } catch {
+      remaining.push(item);
+    }
+  }
+
+  write(remaining);
+  return flushed;
+}


### PR DESCRIPTION
Add a Next.js web app manifest, branded SVG app icon, and iOS home-screen metadata so Nexa can be installed to a phone home screen. This is the first piece of the PWA work in #41; the service worker and offline report queueing remain as follow-ups.

- src/app/manifest.ts: name, standalone display, brand theme color, icon
- src/app/icon.svg: gradient N mark matching the Nexa logo
- src/app/layout.tsx: applicationName, appleWebApp, themeColor viewport