### PR TITLE
feat(routing): assign agency to reports and add submission assistant …

### DIFF
--- a/nexa/src/app/api/reports/[id]/submission-fields/route.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
+import { resolveAgencyId } from "@/lib/jurisdictions/agency";
+import { buildPrefillFields } from "@/lib/submission/prefill";
+
+// GET /api/reports/[id]/submission-fields
+//
+// Returns the per-field "copy-over" guide for filing this report with its
+// agency's official form: the agency, the form URL, and each required field
+// pre-filled with the value we already have. Nexa does not submit on the user's
+// behalf — they copy these values into the official form themselves.
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    const { id } = await context.params;
+
+    const report = await prisma.report.findUnique({
+      where: { id },
+      include: { agency: true },
+    });
+
+    if (!report) {
+      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+    }
+    if (report.userId && report.userId !== session?.userId) {
+      return NextResponse.json(
+        { error: "You can only view your own reports." },
+        { status: 403 },
+      );
+    }
+
+    // Resolve the agency for display without persisting (this is a read).
+    let agency = report.agency;
+    if (!agency) {
+      const agencyId = await resolveAgencyId({
+        latitude: report.latitude,
+        longitude: report.longitude,
+        issueType: report.issueType,
+      });
+      if (agencyId) {
+        agency = await prisma.agency.findUnique({ where: { id: agencyId } });
+      }
+    }
+
+    if (!agency) {
+      return NextResponse.json({ agency: null, fields: [] });
+    }
+
+    const fields = buildPrefillFields(
+      {
+        description: report.description,
+        aiDescription: report.aiDescription,
+        address: report.address,
+        latitude: report.latitude,
+        longitude: report.longitude,
+        imageUrl: report.imageUrl,
+        createdAt: report.createdAt,
+        contactEmail: session?.email ?? null,
+      },
+      agency.requiredFields,
+    );
+
+    return NextResponse.json({
+      agency: {
+        name: agency.name,
+        intakeUrl: agency.intakeUrl,
+        intakeMethod: agency.intakeMethod,
+      },
+      formUrl: agency.intakeUrl,
+      fields,
+    });
+  } catch (error) {
+    console.error("Submission fields error:", error);
+    return NextResponse.json(
+      { error: "Failed to build submission fields." },
+      { status: 500 },
+    );
+  }
+}

--- a/nexa/src/app/api/reports/[id]/submit/route.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
 import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
+import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 
 // POST /api/reports/[id]/submit
 //
@@ -47,7 +48,20 @@ export async function POST(
       );
     }
 
-    const agency = report.agency;
+    // Reports created before jurisdiction routing existed (or whose location
+    // was added later) may not have an agency yet — resolve it on demand.
+    let agency = report.agency;
+    if (!agency) {
+      const agencyId = await resolveAgencyId({
+        latitude: report.latitude,
+        longitude: report.longitude,
+        issueType: report.issueType,
+      });
+      if (agencyId) {
+        await prisma.report.update({ where: { id }, data: { agencyId } });
+        agency = await prisma.agency.findUnique({ where: { id: agencyId } });
+      }
+    }
     if (!agency) {
       return NextResponse.json(
         { error: "No agency is assigned to this report." },

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { IssueType } from "@/generated/prisma/enums";
 import { getSession } from "@/lib/auth";
+import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 
 export async function POST(request: NextRequest) {
   try {
@@ -30,6 +31,14 @@ export async function POST(request: NextRequest) {
         ? (issueType as IssueType)
         : null;
 
+    // Route the report to the responsible agency from its location + issue
+    // type so the submission pipeline has somewhere to file it.
+    const agencyId = await resolveAgencyId({
+      latitude,
+      longitude,
+      issueType: validIssueType,
+    });
+
     const report = await prisma.report.create({
       data: {
         userId: session?.userId ?? null,
@@ -40,6 +49,7 @@ export async function POST(request: NextRequest) {
         longitude,
         address,
         imageUrl,
+        agencyId,
         status: "CONFIRMED",
       },
     });

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { CheckCircle2, ArrowRight } from "lucide-react";
 import { ISSUE_TYPE_LABELS } from "@/lib/constants";
 import { formatFullDateTime, formatRelativeTime } from "@/lib/utils";
+import { SubmissionAssistant } from "@/components/report/submission-assistant";
 
 interface ConfirmedReport {
   id: string;
@@ -85,6 +86,8 @@ export function ConfirmedStep({
           )}
         </div>
       </div>
+
+      {!offline && <SubmissionAssistant reportId={report.id} />}
 
       <div className="flex flex-wrap justify-center gap-3">
         <Link href="/dashboard" className="btn-cta btn-cta-outline">

--- a/nexa/src/components/report/submission-assistant.tsx
+++ b/nexa/src/components/report/submission-assistant.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Copy, ExternalLink, Loader2 } from "lucide-react";
+
+interface PrefillField {
+  key: string;
+  label: string;
+  value: string | null;
+  required: boolean;
+  type: string;
+  hint?: string;
+}
+
+interface SubmissionFieldsResponse {
+  agency: {
+    name: string;
+    intakeUrl: string | null;
+    intakeMethod: string;
+  } | null;
+  formUrl?: string | null;
+  fields: PrefillField[];
+}
+
+interface SubmissionAssistantProps {
+  reportId: string;
+}
+
+export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
+  const [data, setData] = useState<SubmissionFieldsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`/api/reports/${reportId}/submission-fields`);
+        const json = res.ok
+          ? ((await res.json()) as SubmissionFieldsResponse)
+          : null;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [reportId]);
+
+  const handleCopy = async (key: string, value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedKey(key);
+    setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div className="ep-card flex w-full max-w-md items-center gap-2 p-6 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Preparing your filing details…
+      </div>
+    );
+  }
+
+  if (!data?.agency || data.fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="ep-card w-full max-w-md p-6 text-left">
+      <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+        File with {data.agency.name}
+      </span>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Nexa doesn&apos;t submit for you. Open the official form and copy each
+        value below into the matching field.
+      </p>
+
+      {data.formUrl && (
+        <a
+          href={data.formUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-1.5 text-sm text-ep-purple underline-offset-4 hover:underline"
+        >
+          Open {data.agency.name} form
+          <ExternalLink className="size-3.5" />
+        </a>
+      )}
+
+      <div className="mt-5 flex flex-col gap-4">
+        {data.fields.map((field) => (
+          <div key={field.key}>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground">
+                {field.label}
+              </span>
+              {field.required && (
+                <span className="rounded-full bg-red-50 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-red-600">
+                  required
+                </span>
+              )}
+            </div>
+            {field.value ? (
+              <div className="mt-1 flex items-start gap-2">
+                <p className="flex-1 wrap-break-word rounded-md bg-muted/40 px-3 py-2 text-sm text-foreground">
+                  {field.value}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleCopy(field.key, field.value as string)}
+                  aria-label={`Copy ${field.label}`}
+                  className="mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  {copiedKey === field.key ? (
+                    <Check className="size-4 text-ep-green" />
+                  ) : (
+                    <Copy className="size-4" />
+                  )}
+                </button>
+              </div>
+            ) : (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {field.hint ?? "You'll need to fill this in."}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/nexa/src/lib/jurisdictions/agency.ts
+++ b/nexa/src/lib/jurisdictions/agency.ts
@@ -1,0 +1,55 @@
+import { prisma } from "@/lib/prisma";
+import type { IssueType } from "@/generated/prisma/enums";
+import { resolveJurisdiction } from "./resolve";
+import type { JurisdictionId } from "./types";
+
+// Some matched jurisdictions have no agency of their own and are served by a
+// neighboring one. Stanford campus is unincorporated and has no public 311, so
+// its civic issues are handled by Palo Alto (mirrors the portal routing in
+// ./registry.ts).
+const AGENCY_FALLBACKS: Partial<Record<JurisdictionId, JurisdictionId[]>> = {
+  "stanford-campus": ["city-palo-alto"],
+};
+
+/**
+ * Resolves the Agency a report should be filed with, based on its location and
+ * issue type. This is the link between the polygon routing engine
+ * (`resolveJurisdiction`) and the seeded Agency records that the submission
+ * pipeline needs.
+ *
+ * Returns the agency id, or null when there is no location/issue type or no
+ * agency covers that jurisdiction + issue type.
+ */
+export async function resolveAgencyId(args: {
+  latitude?: number | null;
+  longitude?: number | null;
+  issueType?: IssueType | null;
+}): Promise<string | null> {
+  const { latitude, longitude, issueType } = args;
+  if (
+    typeof latitude !== "number" ||
+    typeof longitude !== "number" ||
+    !issueType
+  ) {
+    return null;
+  }
+
+  const match = resolveJurisdiction(latitude, longitude, issueType);
+  if (!match) return null;
+
+  // Try the matched jurisdiction first, then any fallback jurisdictions.
+  const candidates: JurisdictionId[] = [
+    match.jurisdiction.id,
+    ...(AGENCY_FALLBACKS[match.jurisdiction.id] ?? []),
+  ];
+
+  for (const jurisdiction of candidates) {
+    const agency = await prisma.agency.findFirst({
+      where: { jurisdiction, issueTypes: { has: issueType } },
+      select: { id: true },
+    });
+    if (agency) return agency.id;
+  }
+
+  return null;
+}

--- a/nexa/src/lib/submission/prefill.ts
+++ b/nexa/src/lib/submission/prefill.ts
@@ -1,0 +1,104 @@
+// Submission assistant (issue #33, copy-over variant).
+//
+// Rather than auto-submitting, Nexa shows the user exactly what to put in each
+// field of the agency's official form so they can copy it across and file it
+// themselves. This maps an Agency's `requiredFields` schema onto the values we
+// already have for a report.
+
+export type PrefillField = {
+  // Raw field key from the agency schema (e.g. "location_address").
+  key: string;
+  // Human-readable label (e.g. "Location address").
+  label: string;
+  // Pre-filled value from the report, or null when we have nothing to suggest.
+  value: string | null;
+  required: boolean;
+  // The schema type ("string" | "number" | "file" | "datetime" | ...).
+  type: string;
+  // Extra guidance shown under the field (e.g. for photos/unknown fields).
+  hint?: string;
+};
+
+type FieldSpec = { type?: string; required?: boolean };
+
+export type PrefillReport = {
+  description: string | null;
+  aiDescription: string | null;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  imageUrl: string | null;
+  createdAt: Date | string;
+  contactEmail?: string | null;
+};
+
+function humanize(key: string): string {
+  const spaced = key.replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function valueForKey(
+  key: string,
+  type: string,
+  report: PrefillReport,
+): { value: string | null; hint?: string } {
+  const k = key.toLowerCase();
+  const description =
+    report.description?.trim() || report.aiDescription?.trim();
+
+  if (type === "file" || /photo|image|attachment/.test(k)) {
+    return {
+      value: null,
+      hint: report.imageUrl
+        ? "Attach the photo you uploaded to Nexa."
+        : "No photo attached.",
+    };
+  }
+  if (/description|details|comment|problem|issue/.test(k)) {
+    return { value: description ?? null };
+  }
+  if (/address|location|intersection|street/.test(k)) {
+    return { value: report.address ?? null };
+  }
+  if (k.includes("lat")) {
+    return { value: report.latitude != null ? String(report.latitude) : null };
+  }
+  if (k.includes("lon") || k.includes("lng")) {
+    return {
+      value: report.longitude != null ? String(report.longitude) : null,
+    };
+  }
+  if (k.includes("email")) {
+    return { value: report.contactEmail ?? null };
+  }
+  if (/datetime|date|time|observed|observation_date/.test(k)) {
+    return { value: new Date(report.createdAt).toLocaleString() };
+  }
+
+  // Fields we can't derive (e.g. license_plate, vehicle_make) — the user fills
+  // these in from their own knowledge.
+  return { value: null, hint: "You'll need to fill this in." };
+}
+
+/**
+ * Builds the per-field copy-over guide for a report + agency required-fields
+ * schema. Required fields are listed first.
+ */
+export function buildPrefillFields(
+  report: PrefillReport,
+  requiredFields: unknown,
+): PrefillField[] {
+  if (!requiredFields || typeof requiredFields !== "object") return [];
+
+  const entries = Object.entries(requiredFields as Record<string, unknown>);
+  const fields: PrefillField[] = entries.map(([key, rawSpec]) => {
+    const spec = (rawSpec ?? {}) as FieldSpec;
+    const type = typeof spec.type === "string" ? spec.type : "string";
+    const required = spec.required === true;
+    const { value, hint } = valueForKey(key, type, report);
+    return { key, label: humanize(key), value, required, type, hint };
+  });
+
+  // Required fields first, then by original order.
+  return fields.sort((a, b) => Number(b.required) - Number(a.required));
+}


### PR DESCRIPTION
…(#24)

Connect the jurisdiction routing engine to reports so the submission pipeline has somewhere to file, then help users file by showing exactly what to put in each field of the agency's official form (copy-over, no auto-submit).

- src/lib/jurisdictions/agency.ts: resolveAgencyId maps a report's location + issue type to the responsible seeded agency, with a Stanford -> Palo Alto fallback
- src/app/api/reports/route.ts: assign agencyId on report creation
- src/app/api/reports/[id]/submit/route.ts: lazily resolve an agency for reports created before routing existed
- src/lib/submission/prefill.ts: map an agency requiredFields schema to the report's values, flagging required fields and adding hints
- src/app/api/reports/[id]/submission-fields/route.ts: return the agency, form URL, and per-field prefilled values (ownership-checked, read-only)
- src/components/report/submission-assistant.tsx: confirmation-screen UI with an open-form link and copyable per-field values
- src/components/report/confirmed-step.tsx: render the assistant for online submissions