### PR TITLE
feat: community issue map with dedup and shared resolution

### DIFF
--- a/nexa/prisma/migrations/20260602230751_issue_groups/migration.sql
+++ b/nexa/prisma/migrations/20260602230751_issue_groups/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "Report" ADD COLUMN     "issueGroupId" TEXT;
+
+-- CreateTable
+CREATE TABLE "IssueGroup" (
+    "id" TEXT NOT NULL,
+    "issueType" "IssueType" NOT NULL,
+    "latitude" DOUBLE PRECISION NOT NULL,
+    "longitude" DOUBLE PRECISION NOT NULL,
+    "status" "ReportStatus" NOT NULL DEFAULT 'CONFIRMED',
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedByUserId" TEXT,
+    "reportCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IssueGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Report" ADD CONSTRAINT "Report_issueGroupId_fkey" FOREIGN KEY ("issueGroupId") REFERENCES "IssueGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/nexa/prisma/schema.prisma
+++ b/nexa/prisma/schema.prisma
@@ -40,8 +40,28 @@ model Report {
   externalTrackingId String?
   userResolved       Boolean?
   userResolvedAt     DateTime?
+  issueGroupId       String?
+  issueGroup         IssueGroup?  @relation(fields: [issueGroupId], references: [id])
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @updatedAt
+}
+
+// A shared "case" that groups duplicate reports — multiple people reporting the
+// same real-world problem are linked into one IssueGroup. The group's centroid
+// is the average of its members' coordinates, and resolving one member resolves
+// the whole group (see src/lib/issues/dedupe.ts and the resolution endpoint).
+model IssueGroup {
+  id               String       @id @default(cuid())
+  issueType        IssueType
+  latitude         Float
+  longitude        Float
+  status           ReportStatus @default(CONFIRMED)
+  resolvedAt       DateTime?
+  resolvedByUserId String?
+  reportCount      Int          @default(1)
+  reports          Report[]
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
 }
 
 model Agency {

--- a/nexa/public/sw.js
+++ b/nexa/public/sw.js
@@ -3,7 +3,7 @@
 // offline report queue (src/lib/offline-queue.ts), which replays queued POSTs
 // from the page on reconnect rather than here.
 
-const CACHE = "nexa-v1";
+const CACHE = "nexa-v2";
 const OFFLINE_URLS = ["/"];
 
 self.addEventListener("install", (event) => {
@@ -30,11 +30,16 @@ self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  // Only handle same-origin GETs; never cache API traffic or POSTs.
+  // Only handle same-origin GETs; never cache API traffic, POSTs, or React
+  // Server Component data requests. RSC fetches (router.refresh, client
+  // navigations) must always hit the network — caching them serves stale
+  // pages after mutations like deleting a report.
   if (
     request.method !== "GET" ||
     url.origin !== self.location.origin ||
-    url.pathname.startsWith("/api")
+    url.pathname.startsWith("/api") ||
+    request.headers.get("RSC") === "1" ||
+    url.searchParams.has("_rsc")
   ) {
     return;
   }
@@ -52,6 +57,18 @@ self.addEventListener("fetch", (event) => {
           caches.match(request).then((cached) => cached || caches.match("/")),
         ),
     );
+    return;
+  }
+
+  // Only static build output / public files get stale-while-revalidate;
+  // everything else falls through to the network untouched so dynamic data
+  // stays fresh.
+  const isStaticAsset =
+    url.pathname.startsWith("/_next/static/") ||
+    /\.(?:css|js|mjs|woff2?|ttf|otf|png|jpe?g|gif|svg|webp|ico)$/.test(
+      url.pathname,
+    );
+  if (!isStaticAsset) {
     return;
   }
 

--- a/nexa/src/app/api/issues/map/route.ts
+++ b/nexa/src/app/api/issues/map/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { getIssueMapPoints } from "@/lib/issues/map";
+
+/**
+ * Aggregated community issue map: every IssueGroup as a single pin, regardless
+ * of who filed the underlying reports. Requires a session (matches the
+ * dashboard's login-gated access).
+ */
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+  }
+
+  const points = await getIssueMapPoints(session.userId);
+  return NextResponse.json({ points });
+}

--- a/nexa/src/app/api/reports/[id]/resolution/route.ts
+++ b/nexa/src/app/api/reports/[id]/resolution/route.ts
@@ -29,7 +29,7 @@ export async function POST(
 
     const report = await prisma.report.findUnique({
       where: { id },
-      select: { id: true, userId: true, status: true },
+      select: { id: true, userId: true, status: true, issueGroupId: true },
     });
 
     if (!report) {
@@ -43,6 +43,42 @@ export async function POST(
       );
     }
 
+    const resolvedAt = new Date();
+
+    // Shared resolution: when a report that belongs to an IssueGroup is marked
+    // resolved, the whole case resolves for every reporter linked to it. The
+    // group is flagged resolved and every non-closed member report is updated to
+    // match. Reports with no group keep the single-report behavior below.
+    if (report.issueGroupId && body.resolved) {
+      await prisma.$transaction([
+        prisma.issueGroup.update({
+          where: { id: report.issueGroupId },
+          data: {
+            status: "RESOLVED",
+            resolvedAt,
+            resolvedByUserId: session.userId,
+          },
+        }),
+        prisma.report.updateMany({
+          where: {
+            issueGroupId: report.issueGroupId,
+            status: { not: "CLOSED" },
+          },
+          data: {
+            userResolved: true,
+            userResolvedAt: resolvedAt,
+            status: "RESOLVED",
+          },
+        }),
+      ]);
+
+      return NextResponse.json({
+        id: report.id,
+        userResolved: true,
+        status: report.status === "CLOSED" ? "CLOSED" : "RESOLVED",
+      });
+    }
+
     const nextStatus =
       body.resolved && report.status !== "CLOSED" ? "RESOLVED" : report.status;
 
@@ -50,7 +86,7 @@ export async function POST(
       where: { id },
       data: {
         userResolved: body.resolved,
-        userResolvedAt: new Date(),
+        userResolvedAt: resolvedAt,
         status: nextStatus,
       },
       select: { id: true, userResolved: true, status: true },

--- a/nexa/src/app/api/reports/[id]/route.ts
+++ b/nexa/src/app/api/reports/[id]/route.ts
@@ -19,7 +19,7 @@ export async function DELETE(
 
     const report = await prisma.report.findUnique({
       where: { id },
-      select: { id: true, userId: true },
+      select: { id: true, userId: true, issueGroupId: true },
     });
 
     if (!report) {
@@ -33,7 +33,46 @@ export async function DELETE(
       );
     }
 
-    await prisma.report.delete({ where: { id } });
+    // Delete the report and keep its IssueGroup consistent: a stale reportCount
+    // or an orphaned (now empty) group would otherwise linger as a ghost pin on
+    // the community map. Recompute the surviving members' count and centroid, or
+    // drop the group entirely when its last report is removed.
+    await prisma.$transaction(async (tx) => {
+      await tx.report.delete({ where: { id } });
+
+      if (!report.issueGroupId) return;
+
+      const members = await tx.report.findMany({
+        where: { issueGroupId: report.issueGroupId },
+        select: { latitude: true, longitude: true },
+      });
+
+      if (members.length === 0) {
+        await tx.issueGroup.delete({ where: { id: report.issueGroupId } });
+        return;
+      }
+
+      const located = members.filter(
+        (m): m is { latitude: number; longitude: number } =>
+          typeof m.latitude === "number" && typeof m.longitude === "number",
+      );
+      const data: {
+        reportCount: number;
+        latitude?: number;
+        longitude?: number;
+      } = { reportCount: members.length };
+      if (located.length > 0) {
+        data.latitude =
+          located.reduce((sum, m) => sum + m.latitude, 0) / located.length;
+        data.longitude =
+          located.reduce((sum, m) => sum + m.longitude, 0) / located.length;
+      }
+
+      await tx.issueGroup.update({
+        where: { id: report.issueGroupId },
+        data,
+      });
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { IssueType } from "@/generated/prisma/enums";
 import { getSession } from "@/lib/auth";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
+import { findOrCreateIssueGroup } from "@/lib/issues/dedupe";
 
 export async function POST(request: NextRequest) {
   try {
@@ -39,6 +40,15 @@ export async function POST(request: NextRequest) {
       issueType: validIssueType,
     });
 
+    // Group this report with any existing open report about the same nearby
+    // issue so duplicate reports from different people share one case. Returns
+    // null (no grouping) when the report has no location or issue type.
+    const issueGroupId = await findOrCreateIssueGroup({
+      issueType: validIssueType,
+      latitude,
+      longitude,
+    });
+
     const report = await prisma.report.create({
       data: {
         userId: session?.userId ?? null,
@@ -50,6 +60,7 @@ export async function POST(request: NextRequest) {
         address,
         imageUrl,
         agencyId,
+        issueGroupId,
         status: "CONFIRMED",
       },
     });

--- a/nexa/src/app/globals.css
+++ b/nexa/src/app/globals.css
@@ -322,3 +322,48 @@
   font-size: 0.7rem;
   color: var(--muted-foreground);
 }
+
+p.nexa-map-popup__time {
+  margin: 0.4rem 0 0;
+}
+
+.nexa-map-popup__resolve {
+  margin-top: 0.625rem;
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: 0.375rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--ep-green);
+  color: #ffffff;
+  font-family: var(--font-geist-mono);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.nexa-map-popup__resolve:hover {
+  opacity: 0.9;
+}
+
+.nexa-map-popup__resolve:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.nexa-map-popup__resolved-note {
+  margin: 0.5rem 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--font-geist-mono);
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ep-green);
+}

--- a/nexa/src/app/map/page.tsx
+++ b/nexa/src/app/map/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth";
+import { getIssueMapPoints } from "@/lib/issues/map";
+import CommunityMapPanel from "@/components/map/community-map-panel";
+
+export const metadata = {
+  title: "Community Issue Map — Nexa",
+};
+
+export default async function MapPage() {
+  const session = await getSession();
+  if (!session) {
+    redirect(`/login?redirect=${encodeURIComponent("/map")}`);
+  }
+
+  const points = await getIssueMapPoints(session.userId);
+
+  return (
+    <main className="flex-1">
+      <CommunityMapPanel initialPoints={points} />
+    </main>
+  );
+}

--- a/nexa/src/components/map/community-map-panel.tsx
+++ b/nexa/src/components/map/community-map-panel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import dynamic from "next/dynamic";
+import { MapPinned } from "lucide-react";
+import type { IssueMapPoint } from "@/components/map/community-map";
+
+// Leaflet touches `window`/`document`, so render the map only on the client.
+const CommunityMap = dynamic(() => import("@/components/map/community-map"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-[calc(100vh-72px)] w-full animate-pulse bg-muted/40" />
+  ),
+});
+
+interface CommunityMapPanelProps {
+  initialPoints: IssueMapPoint[];
+}
+
+/**
+ * Client wrapper that owns the issue-map data: seeds from the server render,
+ * refetches after a resolution so every viewer's pin colour stays in sync, and
+ * renders the Leaflet map plus an empty state.
+ */
+export default function CommunityMapPanel({
+  initialPoints,
+}: CommunityMapPanelProps) {
+  const [points, setPoints] = useState<IssueMapPoint[]>(initialPoints);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    const response = await fetch("/api/issues/map");
+    if (!response.ok) return;
+    const data = (await response.json()) as { points: IssueMapPoint[] };
+    setPoints(data.points);
+  }, []);
+
+  const handleResolve = useCallback(
+    async (reportId: string) => {
+      setError(null);
+      const response = await fetch(`/api/reports/${reportId}/resolution`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ resolved: true }),
+      });
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(data?.error ?? "Failed to mark resolved.");
+        throw new Error("resolve-failed");
+      }
+      await refetch();
+    },
+    [refetch],
+  );
+
+  if (points.length === 0) {
+    return (
+      <div className="flex h-[calc(100vh-72px)] w-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <MapPinned
+          className="size-8 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <p className="text-lg">No community issues yet.</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          Reported issues with a location will appear here as pins, grouped so
+          duplicates from different people share one case.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      {error && (
+        <div
+          role="alert"
+          className="absolute left-1/2 top-4 z-[1000] -translate-x-1/2 rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 shadow-sm"
+        >
+          {error}
+        </div>
+      )}
+      <CommunityMap points={points} onResolve={handleResolve} />
+    </div>
+  );
+}

--- a/nexa/src/components/map/community-map.tsx
+++ b/nexa/src/components/map/community-map.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { LatLngTuple, Map as LeafletMap } from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+export interface IssueMapPoint {
+  id: string;
+  latitude: number;
+  longitude: number;
+  issueLabel: string;
+  status: string;
+  reportCount: number;
+  relativeTime: string;
+  // The current user's own report id within this group, if they filed one.
+  myReportId: string | null;
+}
+
+const TERMINAL_STATUSES = new Set(["RESOLVED", "CLOSED"]);
+
+// Pin colour by lifecycle stage of the issue group.
+function statusColor(status: string): string {
+  switch (status) {
+    case "RESOLVED":
+    case "CLOSED":
+      return "#22c55e"; // green — fixed
+    case "ACKNOWLEDGED":
+    case "IN_PROGRESS":
+      return "#f59e0b"; // amber — being worked on
+    case "DRAFT":
+    case "CLASSIFYING":
+      return "#94a3b8"; // slate — not yet active
+    default:
+      return "#9b87f5"; // purple — open / reported
+  }
+}
+
+function formatStatus(status: string): string {
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Teardrop pin with the reporter count rendered inside the head.
+function pinSvg(color: string, count: number): string {
+  const label = count > 99 ? "99+" : String(count);
+  const fontSize = label.length >= 3 ? 7 : 9;
+  return `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 36" width="28" height="36" aria-hidden="true">
+      <defs>
+        <filter id="shadow" x="-30%" y="-10%" width="160%" height="140%">
+          <feDropShadow dx="0" dy="1.5" stdDeviation="1.2" flood-color="rgba(15, 23, 42, 0.35)" />
+        </filter>
+      </defs>
+      <g filter="url(#shadow)">
+        <path d="M14 1c-6.6 0-12 5.3-12 11.8 0 8.8 11 21.5 11.5 22 .3.3.8.3 1.1 0 .5-.5 11.4-13.2 11.4-22C26 6.3 20.6 1 14 1z" fill="${color}" />
+        <circle cx="14" cy="13" r="6.5" fill="#ffffff" />
+        <text x="14" y="13.5" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif, system-ui, sans-serif" font-size="${fontSize}" font-weight="700" fill="${color}">${label}</text>
+      </g>
+    </svg>
+  `;
+}
+
+interface CommunityMapProps {
+  points: IssueMapPoint[];
+  // Marks the caller's report in a group resolved (cascades to the whole group).
+  onResolve: (reportId: string) => Promise<void>;
+}
+
+/**
+ * Full-width Leaflet map of every community IssueGroup. Pins are coloured by
+ * status and labelled with the reporter count; clicking one opens a popup with
+ * the issue details and — when the viewer has their own report in that group and
+ * it is still open — a "Mark resolved" button that resolves it for everyone.
+ */
+export default function CommunityMap({ points, onResolve }: CommunityMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+
+  // Keep the latest resolve handler reachable from popup click listeners
+  // without rebuilding the map when it changes identity.
+  const onResolveRef = useRef(onResolve);
+  useEffect(() => {
+    onResolveRef.current = onResolve;
+  }, [onResolve]);
+
+  useEffect(() => {
+    if (!containerRef.current || points.length === 0) return;
+
+    let cancelled = false;
+
+    (async () => {
+      const leaflet = await import("leaflet");
+      const L = leaflet.default ?? leaflet;
+      if (cancelled || !containerRef.current) return;
+
+      const map = L.map(containerRef.current, {
+        scrollWheelZoom: true,
+        zoomControl: true,
+        attributionControl: true,
+      });
+      mapRef.current = map;
+
+      L.tileLayer(
+        "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+        {
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+          subdomains: "abcd",
+          maxZoom: 19,
+        },
+      ).addTo(map);
+
+      const latLngs: LatLngTuple[] = [];
+
+      for (const point of points) {
+        const color = statusColor(point.status);
+        const isResolved = TERMINAL_STATUSES.has(point.status);
+
+        const icon = L.divIcon({
+          className: "nexa-map-pin",
+          html: pinSvg(color, point.reportCount),
+          iconSize: [28, 36],
+          iconAnchor: [14, 35],
+          popupAnchor: [0, -30],
+        });
+
+        const popup = document.createElement("div");
+        popup.className = "nexa-map-popup";
+
+        const reportsLabel =
+          point.reportCount === 1 ? "1 report" : `${point.reportCount} reports`;
+
+        popup.innerHTML = `
+          <p class="nexa-map-popup__label">${escapeHtml(point.issueLabel)}</p>
+          <div class="nexa-map-popup__meta">
+            <span class="nexa-map-popup__status nexa-map-popup__status--${isResolved ? "confirmed" : "pending"}">${escapeHtml(formatStatus(point.status))}</span>
+            <span class="nexa-map-popup__time">${escapeHtml(reportsLabel)}</span>
+          </div>
+          <p class="nexa-map-popup__time">First reported ${escapeHtml(point.relativeTime)}</p>
+        `;
+
+        if (point.myReportId && !isResolved) {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "nexa-map-popup__resolve";
+          button.textContent = "Mark resolved";
+          button.addEventListener("click", async () => {
+            const reportId = point.myReportId;
+            if (!reportId) return;
+            button.disabled = true;
+            button.textContent = "Resolving…";
+            try {
+              await onResolveRef.current(reportId);
+              map.closePopup();
+            } catch {
+              button.disabled = false;
+              button.textContent = "Mark resolved";
+            }
+          });
+          popup.appendChild(button);
+        } else if (isResolved) {
+          const note = document.createElement("p");
+          note.className = "nexa-map-popup__resolved-note";
+          note.textContent = "Resolved";
+          popup.appendChild(note);
+        }
+
+        L.marker([point.latitude, point.longitude], { icon })
+          .addTo(map)
+          .bindPopup(popup, { closeButton: true, offset: [0, -2] });
+
+        latLngs.push([point.latitude, point.longitude]);
+      }
+
+      if (latLngs.length === 1) {
+        map.setView(latLngs[0], 14);
+      } else {
+        map.fitBounds(latLngs, { padding: [48, 48], maxZoom: 15 });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
+    };
+  }, [points]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[calc(100vh-72px)] w-full"
+      role="img"
+      aria-label={`Map showing ${points.length} community ${points.length === 1 ? "issue" : "issues"}`}
+    />
+  );
+}

--- a/nexa/src/components/navbar.tsx
+++ b/nexa/src/components/navbar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { ArrowRight, LayoutDashboard, LogOut } from "lucide-react";
+import { ArrowRight, LayoutDashboard, LogOut, MapPinned } from "lucide-react";
 import { Menu } from "@base-ui/react/menu";
 import { Logo } from "@/components/logo";
 
@@ -66,12 +66,20 @@ export function Navbar() {
             </a>
           ))}
           {user && (
-            <Link
-              href="/dashboard"
-              className={`font-mono text-xs font-medium uppercase tracking-wider transition-colors hover:text-foreground ${pathname === "/dashboard" ? "text-foreground" : "text-muted-foreground"}`}
-            >
-              Dashboard
-            </Link>
+            <>
+              <Link
+                href="/dashboard"
+                className={`font-mono text-xs font-medium uppercase tracking-wider transition-colors hover:text-foreground ${pathname === "/dashboard" ? "text-foreground" : "text-muted-foreground"}`}
+              >
+                Dashboard
+              </Link>
+              <Link
+                href="/map"
+                className={`font-mono text-xs font-medium uppercase tracking-wider transition-colors hover:text-foreground ${pathname === "/map" ? "text-foreground" : "text-muted-foreground"}`}
+              >
+                Map
+              </Link>
+            </>
           )}
         </div>
 
@@ -130,6 +138,7 @@ function UserMenu({
 }) {
   const initials = getInitials(user);
   const isOnDashboard = pathname === "/dashboard";
+  const isOnMap = pathname === "/map";
 
   return (
     <Menu.Root>
@@ -185,6 +194,20 @@ function UserMenu({
               >
                 <LayoutDashboard className="size-4 text-muted-foreground" />
                 Dashboard
+              </Menu.LinkItem>
+
+              <Menu.LinkItem
+                render={
+                  <Link
+                    href="/map"
+                    aria-current={isOnMap ? "page" : undefined}
+                  />
+                }
+                closeOnClick
+                className={`flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground ${isOnMap ? "bg-muted" : ""}`}
+              >
+                <MapPinned className="size-4 text-muted-foreground" />
+                Community Map
               </Menu.LinkItem>
 
               <Menu.Item

--- a/nexa/src/lib/issues/dedupe.ts
+++ b/nexa/src/lib/issues/dedupe.ts
@@ -1,0 +1,147 @@
+import { prisma } from "@/lib/prisma";
+import type { IssueType } from "@/generated/prisma/enums";
+
+// Two reports of the same issue type whose locations fall within this radius are
+// treated as the same real-world problem and merged into one IssueGroup.
+export const DEDUPE_RADIUS_METERS = 75;
+
+// Mean Earth radius — used by the haversine distance below.
+const EARTH_RADIUS_METERS = 6_371_000;
+
+// Approximate metres per degree of latitude (constant); longitude is scaled by
+// the cosine of the latitude in the bounding-box prefilter.
+const METERS_PER_DEGREE_LAT = 111_320;
+
+// Groups in a terminal state are closed cases — new reports should never attach
+// to them, they start a fresh group instead.
+const TERMINAL_STATUSES = ["RESOLVED", "CLOSED"] as const;
+
+/** Great-circle distance between two lat/long points, in metres. */
+export function haversineMeters(
+  aLat: number,
+  aLon: number,
+  bLat: number,
+  bLon: number,
+): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLon = toRad(bLon - aLon);
+  const lat1 = toRad(aLat);
+  const lat2 = toRad(bLat);
+
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const h = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLon * sinLon;
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+interface FindOrCreateArgs {
+  issueType?: IssueType | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+/**
+ * Finds the IssueGroup a new report belongs to (same issue type, nearby
+ * location, still open) or creates a fresh one seeded from the report.
+ *
+ * The lookup prefilters candidate groups with a lat/long bounding box and then
+ * refines with a true haversine distance, picking the closest group within
+ * {@link DEDUPE_RADIUS_METERS}. On a match the group's centroid is recomputed as
+ * a running average and its reportCount incremented (both account for the
+ * about-to-be-created report). Returns the group id, or null when the report
+ * lacks a location or issue type and therefore can't be grouped.
+ */
+export async function findOrCreateIssueGroup(
+  args: FindOrCreateArgs,
+): Promise<string | null> {
+  const { issueType, latitude, longitude } = args;
+
+  if (
+    !issueType ||
+    typeof latitude !== "number" ||
+    !Number.isFinite(latitude) ||
+    typeof longitude !== "number" ||
+    !Number.isFinite(longitude)
+  ) {
+    return null;
+  }
+
+  // Bounding-box prefilter: a small box around the report keeps the candidate
+  // set tiny before the exact haversine refinement.
+  const latDelta = DEDUPE_RADIUS_METERS / METERS_PER_DEGREE_LAT;
+  const cosLat = Math.cos((latitude * Math.PI) / 180);
+  const lonDelta =
+    DEDUPE_RADIUS_METERS /
+    (METERS_PER_DEGREE_LAT * Math.max(Math.abs(cosLat), 1e-6));
+
+  const candidates = await prisma.issueGroup.findMany({
+    where: {
+      issueType,
+      status: { notIn: [...TERMINAL_STATUSES] },
+      latitude: { gte: latitude - latDelta, lte: latitude + latDelta },
+      longitude: { gte: longitude - lonDelta, lte: longitude + lonDelta },
+    },
+    select: {
+      id: true,
+      latitude: true,
+      longitude: true,
+      reportCount: true,
+    },
+  });
+
+  let best: {
+    id: string;
+    reportCount: number;
+    lat: number;
+    lon: number;
+  } | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    const distance = haversineMeters(
+      latitude,
+      longitude,
+      candidate.latitude,
+      candidate.longitude,
+    );
+    if (distance <= DEDUPE_RADIUS_METERS && distance < bestDistance) {
+      best = {
+        id: candidate.id,
+        reportCount: candidate.reportCount,
+        lat: candidate.latitude,
+        lon: candidate.longitude,
+      };
+      bestDistance = distance;
+    }
+  }
+
+  if (best) {
+    // Recompute the centroid as a running average that folds in the new report.
+    const nextCount = best.reportCount + 1;
+    const nextLat = (best.lat * best.reportCount + latitude) / nextCount;
+    const nextLon = (best.lon * best.reportCount + longitude) / nextCount;
+
+    await prisma.issueGroup.update({
+      where: { id: best.id },
+      data: {
+        latitude: nextLat,
+        longitude: nextLon,
+        reportCount: nextCount,
+      },
+    });
+    return best.id;
+  }
+
+  const created = await prisma.issueGroup.create({
+    data: {
+      issueType,
+      latitude,
+      longitude,
+      status: "CONFIRMED",
+      reportCount: 1,
+    },
+    select: { id: true },
+  });
+  return created.id;
+}

--- a/nexa/src/lib/issues/map.ts
+++ b/nexa/src/lib/issues/map.ts
@@ -1,0 +1,44 @@
+import { prisma } from "@/lib/prisma";
+import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import { formatRelativeTime } from "@/lib/utils";
+import type { IssueMapPoint } from "@/components/map/community-map";
+
+/**
+ * Builds the community issue-map pin data: every IssueGroup as one point, with
+ * the viewer's own report id (if any) attached so the UI can offer a per-pin
+ * "Mark resolved" action. Shared by the /map page (initial render) and the
+ * GET /api/issues/map endpoint (client refetches).
+ */
+export async function getIssueMapPoints(
+  userId: string,
+): Promise<IssueMapPoint[]> {
+  const groups = await prisma.issueGroup.findMany({
+    orderBy: { updatedAt: "desc" },
+    select: {
+      id: true,
+      latitude: true,
+      longitude: true,
+      issueType: true,
+      status: true,
+      reportCount: true,
+      createdAt: true,
+      reports: {
+        where: { userId },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  });
+
+  return groups.map((group) => ({
+    id: group.id,
+    latitude: group.latitude,
+    longitude: group.longitude,
+    issueLabel:
+      ISSUE_TYPE_LABELS[group.issueType] || group.issueType || "Uncategorized",
+    status: group.status,
+    reportCount: group.reportCount,
+    relativeTime: formatRelativeTime(group.createdAt),
+    myReportId: group.reports[0]?.id ?? null,
+  }));
+}


### PR DESCRIPTION
Add a /map page showing reported issues as status-colored pins, group duplicate reports of the same real-world problem, and resolve them once for every reporter linked to a group.

- IssueGroup model + migration; Report gains issueGroupId
- dedupe.ts: bounding-box prefilter + haversine refine + running-average centroid, excluding terminal statuses
- report creation links each new report into a group
- resolution route cascades resolved-state to the whole group in a transaction (skips CLOSED reports)
- login-gated /api/issues/map endpoint + getIssueMapPoints aggregator
- Leaflet map UI (dynamic import, XSS-safe popups, reporter counts, Mark resolved on eligible pins) + navbar link