### PR TITLE
Implement stale report follow-up notifications

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -32,5 +32,10 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 BREVO_API_KEY=
 BREVO_SENDER_EMAIL=noreply@nexa.app
 
+# --- Manual reminder job ---
+# Protects POST /api/reports/send-follow-up-reminders. Generate with:
+# openssl rand -base64 32
+FOLLOW_UP_REMINDER_SECRET=
+
 # --- App ---
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/nexa/src/app/api/reports/send-follow-up-reminders/route.ts
+++ b/nexa/src/app/api/reports/send-follow-up-reminders/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sendReportFollowUpReminderEmail } from "@/lib/email";
+import { FOLLOW_UP_REMINDER_STALE_DAYS } from "@/lib/reports/follow-up";
+import { findStaleUnresolvedReportsForFollowUp } from "@/lib/reports/follow-up-reminders";
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.FOLLOW_UP_REMINDER_SECRET;
+  if (!secret) return false;
+
+  const headerSecret = request.headers.get("x-follow-up-reminder-secret");
+  const bearer = request.headers.get("authorization")?.replace(/^Bearer /i, "");
+  return headerSecret === secret || bearer === secret;
+}
+
+function parsePositiveInteger(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export async function POST(request: NextRequest) {
+  if (!process.env.FOLLOW_UP_REMINDER_SECRET) {
+    return NextResponse.json(
+      {
+        error:
+          "FOLLOW_UP_REMINDER_SECRET is not configured. Set it before running reminders.",
+      },
+      { status: 500 },
+    );
+  }
+
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Not authorized." }, { status: 401 });
+  }
+
+  const staleDays =
+    parsePositiveInteger(request.nextUrl.searchParams.get("days")) ??
+    FOLLOW_UP_REMINDER_STALE_DAYS;
+  const dryRun = request.nextUrl.searchParams.get("dryRun") !== "false";
+
+  if (!dryRun && !process.env.BREVO_API_KEY) {
+    return NextResponse.json(
+      {
+        error:
+          "BREVO_API_KEY is not configured. Run with dryRun=true or configure Brevo before sending reminders.",
+      },
+      { status: 500 },
+    );
+  }
+
+  let candidates;
+  try {
+    candidates = await findStaleUnresolvedReportsForFollowUp({
+      staleDays,
+    });
+  } catch (error) {
+    console.error("Follow-up reminder lookup error:", error);
+    return NextResponse.json(
+      { error: "Failed to look up eligible reports." },
+      { status: 500 },
+    );
+  }
+
+  const result = {
+    staleDays,
+    dryRun,
+    eligibleReports: candidates.length,
+    sent: 0,
+    skipped: 0,
+    failures: [] as { reportId: string; error: string }[],
+    note: "This route sends at most one reminder per eligible report per invocation. Persistent cross-run deduplication would require a reminder log/table or timestamp field.",
+  };
+
+  if (dryRun) {
+    result.skipped = candidates.length;
+    return NextResponse.json(result);
+  }
+
+  for (const report of candidates) {
+    if (!report.user) {
+      result.skipped += 1;
+      continue;
+    }
+
+    try {
+      await sendReportFollowUpReminderEmail(report.user, report);
+      result.sent += 1;
+    } catch (error) {
+      result.failures.push({
+        reportId: report.id,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -36,6 +36,7 @@ export default async function DashboardPage() {
       latitude: true,
       longitude: true,
       createdAt: true,
+      updatedAt: true,
       externalTrackingId: true,
       userResolved: true,
     },

--- a/nexa/src/components/dashboard/report-card.tsx
+++ b/nexa/src/components/dashboard/report-card.tsx
@@ -3,11 +3,11 @@
 import { useState } from "react";
 import { ChevronDown, ImageOff, MapPin } from "lucide-react";
 import { ISSUE_TYPE_LABELS, shortenAddress } from "@/lib/constants";
+import { isReportEligibleForFollowUpReminder } from "@/lib/reports/follow-up";
 import { formatFullDateTime, formatRelativeTime } from "@/lib/utils";
 import { DeleteReportButton } from "@/components/dashboard/delete-report-button";
 import { ResolutionPrompt } from "@/components/dashboard/resolution-prompt";
 
-const RESOLUTION_PROMPT_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
 const STATUSES_HIDING_PROMPT = new Set([
   "DRAFT",
   "CLASSIFYING",
@@ -24,6 +24,7 @@ export interface DashboardReport {
   address: string | null;
   imageUrl: string | null;
   createdAt: Date;
+  updatedAt?: Date | null;
   externalTrackingId?: string | null;
   userResolved?: boolean | null;
 }
@@ -33,7 +34,7 @@ function shouldShowResolutionPrompt(report: DashboardReport): boolean {
   if (report.userResolved !== null && report.userResolved !== undefined)
     return false;
   if (STATUSES_HIDING_PROMPT.has(report.status)) return false;
-  return Date.now() - report.createdAt.getTime() >= RESOLUTION_PROMPT_AFTER_MS;
+  return isReportEligibleForFollowUpReminder(report);
 }
 
 interface ReportCardProps {

--- a/nexa/src/lib/email/index.ts
+++ b/nexa/src/lib/email/index.ts
@@ -2,6 +2,7 @@ import type { IssueType, ReportStatus } from "@/generated/prisma/enums";
 import { welcomeTemplate } from "./templates/welcome";
 import { reportConfirmationTemplate } from "./templates/report-confirmation";
 import { reportStatusTemplate } from "./templates/report-status";
+import { followUpReminderTemplate } from "./templates/follow-up-reminder";
 
 const BREVO_API_URL = "https://api.brevo.com/v3/smtp/email";
 
@@ -98,6 +99,37 @@ export async function sendReportStatusEmail(
   });
 
   if (!template) return;
+
+  await sendEmail(
+    { email: user.email, name: user.name ?? undefined },
+    template.subject,
+    template.html,
+  );
+}
+
+export async function sendReportFollowUpReminderEmail(
+  user: { email: string; name: string | null },
+  report: {
+    id: string;
+    issueType: IssueType | string | null;
+    address: string | null;
+    description: string | null;
+    aiDescription: string | null;
+    externalTrackingId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  },
+) {
+  const template = followUpReminderTemplate({
+    name: user.name ?? "",
+    reportId: report.id,
+    issueType: report.issueType,
+    address: report.address,
+    createdAt: report.createdAt,
+    updatedAt: report.updatedAt,
+    externalTrackingId: report.externalTrackingId,
+    summary: report.aiDescription?.trim() || report.description?.trim() || null,
+  });
 
   await sendEmail(
     { email: user.email, name: user.name ?? undefined },

--- a/nexa/src/lib/email/templates/follow-up-reminder.ts
+++ b/nexa/src/lib/email/templates/follow-up-reminder.ts
@@ -1,0 +1,167 @@
+import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import { formatFullDateTime } from "@/lib/utils";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatIssueType(issueType: string | null): string {
+  if (!issueType) return "an infrastructure issue";
+  return ISSUE_TYPE_LABELS[issueType] ?? issueType;
+}
+
+export function followUpReminderTemplate(params: {
+  name: string;
+  reportId: string;
+  issueType: string | null;
+  address: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  externalTrackingId: string | null;
+  summary: string | null;
+}) {
+  const {
+    name,
+    reportId,
+    issueType,
+    address,
+    createdAt,
+    updatedAt,
+    externalTrackingId,
+    summary,
+  } = params;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const displayName = escapeHtml(name || "there");
+  const issueLabelText = formatIssueType(issueType);
+  const issueLabel = escapeHtml(issueLabelText);
+  const safeAddress = address ? escapeHtml(address) : null;
+  const safeSummary = summary ? escapeHtml(summary) : null;
+  const safeTrackingId = externalTrackingId
+    ? escapeHtml(externalTrackingId)
+    : null;
+  const submittedDate = escapeHtml(formatFullDateTime(createdAt));
+  const lastUpdatedDate = escapeHtml(formatFullDateTime(updatedAt));
+
+  return {
+    subject: `Follow-up recommended for your ${issueLabelText} report`,
+    html: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Follow-up Reminder</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
+          <tr>
+            <td style="background-color:#18181b;padding:32px 40px;">
+              <p style="margin:0;font-size:24px;font-weight:700;color:#ffffff;letter-spacing:-0.5px;">Nexa</p>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:32px 40px 0;">
+              <span style="display:inline-block;background-color:#f59e0b;color:#ffffff;font-size:13px;font-weight:600;padding:4px 12px;border-radius:999px;letter-spacing:0.3px;">
+                FOLLOW-UP RECOMMENDED
+              </span>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:20px 40px 40px;">
+              <h1 style="margin:0 0 12px;font-size:22px;font-weight:600;color:#18181b;">Check in on your report, ${displayName}</h1>
+              <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#3f3f46;">
+                You submitted a report about ${issueLabel} on ${submittedDate}. We have not seen a recent update in Nexa, so you may want to check whether the issue has been resolved or follow up with the relevant office.
+              </p>
+              <p style="margin:0 0 24px;font-size:13px;line-height:1.6;color:#71717a;">
+                This reminder reflects app-side tracking only. It is not official confirmation from a municipality and does not mean the city has acknowledged, started, or completed work.
+              </p>
+
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9f9fb;border:1px solid #e4e4e7;border-radius:6px;margin-bottom:28px;">
+                <tr>
+                  <td style="padding:20px 24px;">
+                    <table width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;width:140px;">Reference</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;font-family:monospace;">${escapeHtml(reportId)}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Issue type</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;font-weight:500;">${issueLabel}</td>
+                      </tr>
+                      ${
+                        safeAddress
+                          ? `
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Location</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;">${safeAddress}</td>
+                      </tr>`
+                          : ""
+                      }
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Submitted</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;">${submittedDate}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Last app update</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;">${lastUpdatedDate}</td>
+                      </tr>
+                      ${
+                        safeTrackingId
+                          ? `
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Tracking ID</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;">${safeTrackingId}</td>
+                      </tr>`
+                          : ""
+                      }
+                      ${
+                        safeSummary
+                          ? `
+                      <tr>
+                        <td style="padding:6px 0;font-size:13px;color:#71717a;">Summary</td>
+                        <td style="padding:6px 0;font-size:13px;color:#18181b;">${safeSummary}</td>
+                      </tr>`
+                          : ""
+                      }
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:#3f3f46;">
+                Suggested follow-up: ask the relevant office whether this report is still open and, if it has been fixed, mark it resolved in Nexa.
+              </p>
+
+              <a href="${appUrl}/dashboard"
+                style="display:inline-block;background-color:#18181b;color:#ffffff;text-decoration:none;font-size:15px;font-weight:500;padding:12px 24px;border-radius:6px;">
+                View your reports
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding:24px 40px;border-top:1px solid #e4e4e7;">
+              <p style="margin:0;font-size:13px;color:#71717a;">
+                You're receiving this because you submitted a report on
+                <a href="${appUrl}" style="color:#71717a;">Nexa</a>.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`,
+  };
+}

--- a/nexa/src/lib/reports/follow-up-reminders.ts
+++ b/nexa/src/lib/reports/follow-up-reminders.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@/lib/prisma";
+import {
+  FOLLOW_UP_REMINDER_STALE_DAYS,
+  isReportEligibleForFollowUpReminder,
+} from "@/lib/reports/follow-up";
+
+export interface StaleReportReminderCandidate {
+  id: string;
+  issueType: string | null;
+  status: string;
+  description: string | null;
+  aiDescription: string | null;
+  address: string | null;
+  externalTrackingId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  user: {
+    email: string;
+    name: string | null;
+  } | null;
+}
+
+export async function findStaleUnresolvedReportsForFollowUp(options?: {
+  staleDays?: number;
+  now?: Date;
+}): Promise<StaleReportReminderCandidate[]> {
+  const staleDays = options?.staleDays ?? FOLLOW_UP_REMINDER_STALE_DAYS;
+  const now = options?.now ?? new Date();
+  const cutoff = new Date(now.getTime() - staleDays * 24 * 60 * 60 * 1000);
+
+  const reports = await prisma.report.findMany({
+    where: {
+      status: { notIn: ["RESOLVED", "CLOSED"] },
+      userId: { not: null },
+      user: { is: { email: { not: "" } } },
+      updatedAt: { lte: cutoff },
+    },
+    orderBy: { updatedAt: "asc" },
+    select: {
+      id: true,
+      issueType: true,
+      status: true,
+      description: true,
+      aiDescription: true,
+      address: true,
+      externalTrackingId: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: {
+          email: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return reports.filter((report) =>
+    isReportEligibleForFollowUpReminder(report, now, staleDays),
+  );
+}

--- a/nexa/src/lib/reports/follow-up.ts
+++ b/nexa/src/lib/reports/follow-up.ts
@@ -1,0 +1,76 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const FOLLOW_UP_REMINDER_STALE_DAYS = 14;
+
+const RESOLVED_STATUSES = new Set(["RESOLVED", "CLOSED"]);
+
+export interface FollowUpReportLike {
+  status: string;
+  createdAt: Date;
+  updatedAt?: Date | null;
+}
+
+export interface ReportFollowUpState {
+  isUnresolved: boolean;
+  isStale: boolean;
+  ageDays: number;
+  lastActivityAt: Date;
+  label: "Awaiting response" | "Follow-up recommended" | "Resolved";
+  description: string;
+}
+
+export function getReportFollowUpState(
+  report: FollowUpReportLike,
+  now = new Date(),
+  staleDays = FOLLOW_UP_REMINDER_STALE_DAYS,
+): ReportFollowUpState {
+  const lastActivityAt = report.updatedAt ?? report.createdAt;
+  const ageDays = Math.max(
+    0,
+    Math.floor((now.getTime() - lastActivityAt.getTime()) / MS_PER_DAY),
+  );
+  const isUnresolved = !RESOLVED_STATUSES.has(report.status);
+  const isStale = isUnresolved && ageDays >= staleDays;
+
+  if (!isUnresolved) {
+    return {
+      isUnresolved,
+      isStale,
+      ageDays,
+      lastActivityAt,
+      label: "Resolved",
+      description:
+        "This report is marked resolved or closed in Nexa's app-side tracking.",
+    };
+  }
+
+  if (isStale) {
+    return {
+      isUnresolved,
+      isStale,
+      ageDays,
+      lastActivityAt,
+      label: "Follow-up recommended",
+      description:
+        "This reflects app-side tracking only. It does not confirm municipality action.",
+    };
+  }
+
+  return {
+    isUnresolved,
+    isStale,
+    ageDays,
+    lastActivityAt,
+    label: "Awaiting response",
+    description:
+      "This reflects app-side tracking only. It does not confirm municipality action.",
+  };
+}
+
+export function isReportEligibleForFollowUpReminder(
+  report: FollowUpReportLike,
+  now = new Date(),
+  staleDays = FOLLOW_UP_REMINDER_STALE_DAYS,
+): boolean {
+  return getReportFollowUpState(report, now, staleDays).isStale;
+}


### PR DESCRIPTION
Added follow-up reminders for stale unresolved reports by extending the existing notification workflow. Users can now receive reminders to check whether an issue has been resolved or requires further action, while making clear that report status reflects app-side tracking rather than confirmed municipality updates.