### PR TITLE
fix(security): validate post-auth redirect to same-origin paths [#101]

### DIFF
--- a/nexa/src/components/auth/login-form.tsx
+++ b/nexa/src/components/auth/login-form.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n/provider";
+import { safeRedirect } from "@/lib/utils";
 
 export function LoginForm() {
   const router = useRouter();
@@ -35,7 +36,7 @@ export function LoginForm() {
         return;
       }
 
-      const redirect = searchParams.get("redirect") || "/";
+      const redirect = safeRedirect(searchParams.get("redirect"));
       router.push(redirect);
       router.refresh();
     } catch {

--- a/nexa/src/components/auth/register-form.tsx
+++ b/nexa/src/components/auth/register-form.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n/provider";
-import { safeRedirect } from "@/lib/utils";
 
 export function RegisterForm() {
   const router = useRouter();
@@ -42,7 +41,7 @@ export function RegisterForm() {
         return;
       }
 
-      router.push(safeRedirect("/"));
+      router.push("/");
       router.refresh();
     } catch {
       setError(t("common.somethingWrong"));

--- a/nexa/src/components/auth/register-form.tsx
+++ b/nexa/src/components/auth/register-form.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n/provider";
+import { safeRedirect } from "@/lib/utils";
 
 export function RegisterForm() {
   const router = useRouter();
@@ -41,7 +42,7 @@ export function RegisterForm() {
         return;
       }
 
-      router.push("/");
+      router.push(safeRedirect("/"));
       router.refresh();
     } catch {
       setError(t("common.somethingWrong"));

--- a/nexa/src/lib/utils.ts
+++ b/nexa/src/lib/utils.ts
@@ -6,6 +6,26 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Validate a post-auth redirect target to prevent open redirects.
+ *
+ * Returns the target only when it is a same-origin relative path: it must
+ * start with a single "/" (not "//", which the browser treats as a
+ * protocol-relative absolute URL) and must not be an absolute URL with a
+ * scheme. Anything else falls back to "/".
+ */
+export function safeRedirect(target: string | null | undefined): string {
+  if (
+    typeof target === "string" &&
+    target.startsWith("/") &&
+    !target.startsWith("//") &&
+    !target.startsWith("/\\")
+  ) {
+    return target;
+  }
+  return "/";
+}
+
+/**
  * "just now" / "5 minutes ago" / "yesterday" / "3 days ago" for recent times;
  * a short absolute date ("May 13", "May 13, 2025") for anything older than a week.
  */


### PR DESCRIPTION
## What changed
Adds a shared `safeRedirect()` helper in `src/lib/utils.ts` that validates a post-auth redirect target and only returns it when it is a **same-origin relative path** — it must start with a single `/`, must not start with `//` (protocol-relative absolute URL) or `/\` (backslash variant some browsers normalize), and must not be an absolute URL. Anything else falls back to `/`.

- `src/components/auth/login-form.tsx`: replaced the unvalidated `searchParams.get("redirect") || "/"` with `safeRedirect(searchParams.get("redirect"))`. This closes the open-redirect: `?redirect=https://attacker.com` or `?redirect=//attacker.com` now fall back to `/`.
- `src/components/auth/register-form.tsx`: **not vulnerable today** (it hardcodes `router.push("/")`), but adopts the shared helper preemptively so a future redirect param can't diverge from the login form's validation.

Scope is limited to the two auth form components plus the one shared helper. No `src/app/api/**` route was touched (owned by sibling PRs).

## Acceptance criteria (#101)
- [x] Redirect is used only when it starts with a single `/` (not `//` and not an absolute URL)
- [x] Disallowed values fall back to `/`
- [x] Shared helper used by both forms to avoid divergence

A unit regression test for `safeRedirect()` is **deferred to post-#112** (vitest infra is not on `main` yet).

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (only 2 pre-existing `<img>` warnings in unrelated report components)
- `npm run build` — succeeds