### PR TITLE
fix(cron): fail closed when CRON_SECRET is unset [#99]

### DIFF
--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -16,6 +16,10 @@ import {
 //
 // Protected by CRON_SECRET: callers must send `Authorization: Bearer <secret>`.
 // Vercel Cron automatically attaches this header when CRON_SECRET is set.
+//
+// Fail closed: if CRON_SECRET is unset/empty we refuse the request (503) and do
+// NOT poll, so a missing secret can never expose this endpoint to unauthenticated
+// callers triggering external Open311 traffic (#99).
 
 // States we still expect updates for. RESOLVED/CLOSED are terminal, so we stop
 // polling them to keep the job cheap.
@@ -30,11 +34,17 @@ const MAX_PER_RUN = 100;
 
 export async function GET(request: NextRequest) {
   const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const auth = request.headers.get("authorization");
-    if (auth !== `Bearer ${secret}`) {
-      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
-    }
+  // Fail closed: without a configured secret there is no way to authenticate the
+  // caller, so refuse rather than run polling unauthenticated.
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Cron polling is not configured." },
+      { status: 503 },
+    );
+  }
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
   }
 
   try {


### PR DESCRIPTION
## Summary
Makes the cron `poll-status` endpoint **fail closed** with respect to `CRON_SECRET`.

Previously the endpoint only enforced the `Authorization: Bearer <secret>` check *when* `CRON_SECRET` was set (`if (secret) { ... }`). If the env var was unset/empty, all auth was skipped and any unauthenticated caller could trigger polling for every report — driving external Open311 calls (DoS / information leakage). See #99.

### What changed
`src/app/api/cron/poll-status/route.ts` only:
- If `CRON_SECRET` is unset/empty, return **503** (`Cron polling is not configured.`) and do **not** run any polling.
- If `CRON_SECRET` is set, keep requiring a matching `Authorization: Bearer <secret>` header; return **401** otherwise.
- Added a fail-closed comment to the route header and inline at the auth check.

Polling logic is unchanged.

## Acceptance criteria (#99)
- [x] When `CRON_SECRET` is unset/empty, the endpoint returns a non-200 error (503) and does NOT poll
- [x] When set, requests without the matching `Authorization: Bearer <secret>` header still return 401
- [x] Behavior documented in the route comment

## Verification
- `npx tsc --noEmit` — clean (exit 0) after `prisma generate`
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in unrelated files)
- `npm run build` — succeeds; `/api/cron/poll-status` route compiles

A vitest regression test (unset secret -> 503, set secret + wrong header -> 401, set secret + correct header -> polls) is **deferred to post-#112** (test infra not yet on main).

## Base-branch note for reviewer
The `poll-status` route does **not** currently exist on `main`: it was merged via #79 and then reverted via #84. It lives only on `feat/status-polling-service`, which is pending re-merge. This PR is therefore based on `feat/status-polling-service` so the diff is exactly the one-file security fix; it should ride along with (or merge before) the re-introduction of the polling service to `main`.
