### PR TITLE
feat(config): typed env config module + boot validation + error boundary [#109][#131]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -18,9 +18,16 @@ JWT_SECRET=
 # --- LLM providers ---
 # OpenAI is required for /api/reports/classify in production.
 # Anthropic + Google are only needed on the llm-comparison branch.
+# GOOGLE_API_KEY is the Gemini / Google AI key (classification) — distinct from
+# GOOGLE_MAPS_API_KEY below.
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
+
+# --- Maps / Places ---
+# Optional. Enables Google Places address autocomplete in /api/location/suggest;
+# falls back to Nominatim when unset. Separate key from GOOGLE_API_KEY above.
+GOOGLE_MAPS_API_KEY=
 
 # --- Telemetry (PostHog) ---
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getGoogleMapsApiKey } from "@/lib/config";
 
 type NominatimSearchResult = {
   display_name?: string;
@@ -148,7 +149,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ suggestions: [] });
     }
 
-    const googleApiKey = process.env.GOOGLE_MAPS_API_KEY;
+    const googleApiKey = getGoogleMapsApiKey();
     let suggestions: LocationSuggestion[] = [];
 
     if (googleApiKey) {

--- a/nexa/src/app/error.tsx
+++ b/nexa/src/app/error.tsx
@@ -1,0 +1,45 @@
+"use client"; // Error boundaries must be Client Components
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Route-segment error boundary. Next.js renders this as the fallback UI when an
+ * unhandled error throws while rendering a page or nested layout in this
+ * segment. It logs the error (so blank-screen crashes leave a trace) and offers
+ * the user a way to recover via Next 16's `unstable_retry`, which re-fetches and
+ * re-renders the failed segment.
+ */
+export default function Error({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    // Surface the error to the console / error reporting. `digest` correlates a
+    // client-side message with the corresponding server-side log entry.
+    console.error("Unhandled application error:", error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 py-10 text-center">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4">
+        <h1 className="text-2xl font-semibold">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          An unexpected error occurred. You can try again, and if the problem
+          persists, please come back in a little while.
+        </p>
+        {error.digest && (
+          <p className="font-mono text-xs text-muted-foreground">
+            Reference: {error.digest}
+          </p>
+        )}
+        <Button onClick={() => unstable_retry()} className="mt-2">
+          Try again
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -132,8 +132,9 @@ export default function ReportPage() {
         if (requestId !== addressLookupRequestRef.current) return;
 
         setAddressSuggestions(data.suggestions ?? []);
-      } catch {
+      } catch (e) {
         if (requestId !== addressLookupRequestRef.current) return;
+        console.error("Address suggestion lookup failed:", e);
         setAddressSuggestions([]);
       } finally {
         if (requestId !== addressLookupRequestRef.current) return;
@@ -173,6 +174,7 @@ export default function ReportPage() {
       const result: OfficialFormLookupResult = await res.json();
       setOfficialForm(result);
     } catch (err) {
+      console.error("Official form lookup failed:", err);
       setOfficialForm({
         status: "not_found",
         cityName: null,
@@ -253,6 +255,7 @@ export default function ReportPage() {
         has_location: !!geo.latitude,
       });
     } catch (e) {
+      console.error("Report classification failed:", e);
       setClassifyError(
         e instanceof Error ? e.message : t("common.somethingWrong"),
       );
@@ -300,6 +303,7 @@ export default function ReportPage() {
         has_location: !!geo.latitude,
       });
     } catch (e) {
+      console.error("Report submission failed:", e);
       // No connectivity: park the report locally and confirm optimistically.
       // PwaSetup replays the queue once the browser is back online.
       if (typeof navigator !== "undefined" && !navigator.onLine) {

--- a/nexa/src/lib/auth.ts
+++ b/nexa/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
+import { getJwtSecret } from "@/lib/config";
 
 // The name of the cookie that holds the session token
 export const SESSION_COOKIE = "nexa-session";
@@ -13,11 +14,10 @@ export interface SessionPayload {
   email: string;
 }
 
-// Encode the secret once — jose requires a Uint8Array
+// Encode the secret once — jose requires a Uint8Array.
+// getJwtSecret() throws a clear, named error when JWT_SECRET is unset.
 function getSecret() {
-  const secret = process.env.JWT_SECRET;
-  if (!secret) throw new Error("JWT_SECRET environment variable is not set");
-  return new TextEncoder().encode(secret);
+  return new TextEncoder().encode(getJwtSecret());
 }
 
 // Signs a JWT containing the user's id and email, valid for 7 days

--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { getAnthropicKey } from "@/lib/config";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -6,7 +7,7 @@ import {
 } from "./types";
 
 function getClient() {
-  return new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return new Anthropic({ apiKey: getAnthropicKey() });
 }
 
 function extractMediaType(

--- a/nexa/src/lib/classify/google-provider.ts
+++ b/nexa/src/lib/classify/google-provider.ts
@@ -1,4 +1,5 @@
 import { GoogleGenAI } from "@google/genai";
+import { getGoogleApiKey } from "@/lib/config";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -6,7 +7,7 @@ import {
 } from "./types";
 
 function getClient() {
-  return new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+  return new GoogleGenAI({ apiKey: getGoogleApiKey() });
 }
 
 function stripPrefix(base64: string): string {

--- a/nexa/src/lib/classify/openai-provider.ts
+++ b/nexa/src/lib/classify/openai-provider.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { getOpenAiKey } from "@/lib/config";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -6,7 +7,7 @@ import {
 } from "./types";
 
 function getClient() {
-  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return new OpenAI({ apiKey: getOpenAiKey() });
 }
 
 export async function classifyWithOpenAI(

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -8,7 +8,7 @@
  *   - the literal env var names live in exactly one place.
  *
  * Getters are lazy and cached — they read `process.env` on first access and
- * memoize the result, mirroring the lazy-client pattern in `src/lib/openai.ts`.
+ * memoize the result.
  * Laziness matters because some env vars are only present at runtime (e.g. on
  * Vercel) and not during the build, so we must not read them at module load.
  */

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -1,0 +1,91 @@
+/**
+ * Typed, centralized access to environment variables.
+ *
+ * Every env var read by the app should go through a getter here so that:
+ *   - required vars fail fast with a clear, named error when missing (rather
+ *     than surfacing as a confusing runtime failure deep in a query/SDK call);
+ *   - optional vars have a single, consistent shape (`string | undefined`);
+ *   - the literal env var names live in exactly one place.
+ *
+ * Getters are lazy and cached — they read `process.env` on first access and
+ * memoize the result, mirroring the lazy-client pattern in `src/lib/openai.ts`.
+ * Laziness matters because some env vars are only present at runtime (e.g. on
+ * Vercel) and not during the build, so we must not read them at module load.
+ */
+
+/** Thrown when a required environment variable is missing or empty. */
+export class MissingEnvError extends Error {
+  constructor(name: string) {
+    super(`Required environment variable ${name} is not set`);
+    this.name = "MissingEnvError";
+  }
+}
+
+/**
+ * Read a required env var, throwing {@link MissingEnvError} when it is missing
+ * or empty. Treats whitespace-only values as missing.
+ */
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new MissingEnvError(name);
+  return value;
+}
+
+/** Read an optional env var, returning a trimmed value or `undefined`. */
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+/**
+ * Wrap a getter so its result is computed once and cached. The first call
+ * resolves the value (and may throw for required vars); later calls return the
+ * memoized result.
+ */
+function cached<T>(read: () => T): () => T {
+  let resolved = false;
+  let value: T;
+  return () => {
+    if (!resolved) {
+      value = read();
+      resolved = true;
+    }
+    return value;
+  };
+}
+
+// --- Required: app cannot function without these ---
+
+/** Postgres connection string used by the Prisma adapter. Required. */
+export const getDatabaseUrl = cached(() => requireEnv("DATABASE_URL"));
+
+/** Secret used to sign and verify session JWTs. Required. */
+export const getJwtSecret = cached(() => requireEnv("JWT_SECRET"));
+
+// --- Optional: features degrade or are skipped when absent ---
+
+/**
+ * Shared secret guarding cron endpoints. Optional today — exposed here so the
+ * cron route can adopt it once #99 lands.
+ */
+export const getCronSecret = cached(() => optionalEnv("CRON_SECRET"));
+
+/** OpenAI API key (GPT classification + stage-1 observation). */
+export const getOpenAiKey = cached(() => optionalEnv("OPENAI_API_KEY"));
+
+/** Anthropic API key (Claude classification). */
+export const getAnthropicKey = cached(() => optionalEnv("ANTHROPIC_API_KEY"));
+
+/**
+ * Google AI / Gemini API key — used by the Gemini classification provider.
+ * Distinct from {@link getGoogleMapsApiKey}: this is the generative AI key.
+ */
+export const getGoogleApiKey = cached(() => optionalEnv("GOOGLE_API_KEY"));
+
+/**
+ * Google Maps / Places API key — used for address autocomplete.
+ * Distinct from {@link getGoogleApiKey}: this is the Maps Platform key.
+ */
+export const getGoogleMapsApiKey = cached(() =>
+  optionalEnv("GOOGLE_MAPS_API_KEY"),
+);

--- a/nexa/src/lib/openai.ts
+++ b/nexa/src/lib/openai.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
+import { getOpenAiKey } from "@/lib/config";
 
 export function getOpenAI(): OpenAI {
-  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return new OpenAI({ apiKey: getOpenAiKey() });
 }

--- a/nexa/src/lib/prisma.ts
+++ b/nexa/src/lib/prisma.ts
@@ -1,11 +1,12 @@
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { getDatabaseUrl } from "@/lib/config";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 function createPrismaClient() {
   const adapter = new PrismaPg({
-    connectionString: process.env.DATABASE_URL,
+    connectionString: getDatabaseUrl(),
   });
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## Summary

One PR closing both #109 (boot validation + error boundary) and #131 (typed config module), which overlap on the new typed env config module.

Closes #109
Closes #131

## What changed

- **New `src/lib/config.ts`** — typed, lazy, cached env getters following the existing `src/lib/openai.ts` lazy-client pattern. Each getter reads `process.env` once and memoizes:
  - Required (throw a named `MissingEnvError` when missing/empty, fail-fast): `getDatabaseUrl`, `getJwtSecret`.
  - Optional (`string | undefined`): `getCronSecret`, `getOpenAiKey`, `getAnthropicKey`, `getGoogleApiKey` (Gemini, reads `GOOGLE_API_KEY`), `getGoogleMapsApiKey` (Places, reads `GOOGLE_MAPS_API_KEY`).
  - The two Google keys are kept **separate** (Gemini vs Places).
- **Routed existing env reads through config**: `src/lib/prisma.ts`, `src/lib/auth.ts` (`getSecret` → `getJwtSecret`), the three classify providers (`openai-`/`anthropic-`/`google-provider.ts`), `src/lib/openai.ts`, and `src/app/api/location/suggest/route.ts` (now `getGoogleMapsApiKey()`).
- **New `src/app/error.tsx`** — route-segment error boundary (Next 16.2 `unstable_retry` convention, client component) that logs the error via `console.error` and renders a recovery UI with a "Try again" button.
- **`src/app/report/page.tsx`** — added `console.error` logging in the four catch blocks that previously only set local state (address lookup, official-form lookup, classify, submit).
- **`.env.example`** — documented the previously-missing `GOOGLE_MAPS_API_KEY` (separate from `GOOGLE_API_KEY`). `VERCEL_SETUP.md` already lists both, left unchanged.

## Files changed

- `src/lib/config.ts` (new)
- `src/app/error.tsx` (new)
- `src/lib/prisma.ts`
- `src/lib/auth.ts`
- `src/lib/openai.ts`
- `src/lib/classify/openai-provider.ts`
- `src/lib/classify/anthropic-provider.ts`
- `src/lib/classify/google-provider.ts`
- `src/app/api/location/suggest/route.ts`
- `src/app/report/page.tsx`
- `.env.example`

## Acceptance criteria — #109

- [x] Missing `DATABASE_URL` or auth secret throws a clear, named error (`MissingEnvError`) at first access rather than silently undefined.
- [x] `error.tsx` renders a recovery UI and logs the error.
- [x] Report-page catch blocks log instead of only setting local state.

## Acceptance criteria — #131

- [x] `config.ts` exposes separate `getGoogleApiKey()` and `getGoogleMapsApiKey()`; Places uses the Maps key, Gemini uses the API key; `.env.example` documents both.
- [x] `config.ts` provides typed getters and is the single place reading the listed env vars (remaining `process.env` references are only `NODE_ENV` framework checks).
- [x] Env-access error handling is consistent (required vars throw via `requireEnv`; optional vars return `undefined` via `optionalEnv`).
- [x] `npx tsc --noEmit` passes.

## Verification

- `npx tsc --noEmit` — clean (exit 0).
- `npm run lint` — clean (exit 0; 2 pre-existing `no-img-element` warnings in untouched report components).
- `npm run build` — succeeds (exit 0) with `DATABASE_URL` set, as in the normal Vercel/local build path. Note: the new fail-fast now surfaces during `next build` page-data collection if `DATABASE_URL` is unset (previously it passed `undefined` silently) — this is the intended #109 behavior and not a regression for the standard build, where the var is always present.

## Deferred (out of scope)

- The `poll-status` route's `CRON_SECRET` migration is intentionally **deferred to after #99 merges**. `getCronSecret` is added to `config.ts` but is **not** wired into `src/app/api/cron/poll-status/route.ts` yet, to avoid conflicting with the sibling Wave-1 PR.
- The auth login/register routes were not touched (owned by sibling PRs).
- Vitest tests follow post-#112 (test infra not yet on main).
