### PR TITLE
docs: sync README model versions with implemented providers [#133]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A full-stack Next.js application for reporting and tracking civic issues (road d
 
 - **Frontend**: Next.js 16, React 19, TypeScript, Tailwind CSS v4, shadcn/ui
 - **Backend**: Next.js API Routes (under `src/app/api/`)
-- **AI Classification**: Multi-provider consensus engine (OpenAI GPT-4o-mini, Anthropic Claude 3.5 Haiku, Google Gemini 2.0 Flash)
+- **AI Classification**: Multi-provider consensus engine (OpenAI GPT-4o-mini, Anthropic Claude Haiku 4.5, Google Gemini 2.5 Flash)
 - **Database**: PostgreSQL (Neon on Vercel, Docker for local dev), Prisma ORM
 - **Address Autocomplete**: Google Places API (with Nominatim fallback)
 - **Civic Form Lookup**: OpenAI Responses API with `web_search_preview` tool
@@ -31,8 +31,8 @@ When a user submits a report, the `/api/reports/classify` endpoint sends the ima
 | Provider | Model | Strengths |
 |---|---|---|
 | OpenAI | `gpt-4o-mini` | Fast, strong vision, low cost |
-| Anthropic | `claude-3-5-haiku-20241022` | Fast, careful reasoning, low cost |
-| Google | `gemini-2.0-flash` | Fast, good at structured output |
+| Anthropic | `claude-haiku-4-5` | Fast, careful reasoning, low cost |
+| Google | `gemini-2.5-flash` | Fast, good at structured output |
 
 A **consensus engine** then picks the best result:
 
@@ -129,8 +129,8 @@ Open `.env.local` and fill in your API keys. The app can connect to the producti
 | `DATABASE_URL` | Yes | PostgreSQL connection string (Neon or local Docker) |
 | `JWT_SECRET` | Yes | Session token signing |
 | `OPENAI_API_KEY` | Yes | GPT-4o-mini classification + civic form lookup |
-| `ANTHROPIC_API_KEY` | Yes | Claude 3.5 Haiku classification |
-| `GOOGLE_API_KEY` | Yes | Gemini 2.0 Flash classification |
+| `ANTHROPIC_API_KEY` | Yes | Claude Haiku 4.5 classification |
+| `GOOGLE_API_KEY` | Yes | Gemini 2.5 Flash classification |
 | `GOOGLE_MAPS_API_KEY` | Optional | Google Places address autocomplete (falls back to Nominatim) |
 | `NEXT_PUBLIC_POSTHOG_KEY` | For telemetry | PostHog analytics |
 | `NEXT_PUBLIC_POSTHOG_HOST` | For telemetry | PostHog region host |

--- a/nexa/eval/README.md
+++ b/nexa/eval/README.md
@@ -72,7 +72,7 @@ Aggregated into:
 | `two-stage` | sharp resize/rotate + EXIF GPS extract | gpt-4o-mini observation pass | EXIF/caller GPS folded into stage-2 prompt |
 
 Both runs hit the same three VLMs (OpenAI gpt-4o-mini, Anthropic
-claude-haiku-4-5, Google gemini-2.0-flash) and use the same consensus voting.
+claude-haiku-4-5, Google gemini-2.5-flash) and use the same consensus voting.
 The only differences are the inputs the VLMs receive.
 
 ## Running the eval


### PR DESCRIPTION
Closes #133.

The README model table and prose were stale relative to the implemented classification providers. Reconciled the listed Claude/Gemini versions to match exactly what the code uses (verified against `nexa/src/lib/classify/*-provider.ts`).

## Changes (docs only)

`README.md` — table (line 34-35), tech-stack summary (line 9), and env-var table (line 132-133):

| Provider | Before | After | Source |
|---|---|---|---|
| Anthropic | `claude-3-5-haiku-20241022` | `claude-haiku-4-5` | `anthropic-provider.ts:53` |
| Google | `gemini-2.0-flash` | `gemini-2.5-flash` | `google-provider.ts:50` |
| OpenAI | `gpt-4o-mini` | `gpt-4o-mini` (unchanged) | `openai-provider.ts:43` |

`nexa/eval/README.md` — fixed a stale `gemini-2.0-flash` → `gemini-2.5-flash` reference in the eval VLM description (the Claude ID there was already current).

## Verification
- No code changed — `git diff --stat` shows only `.md` files.
- No remaining stale model strings in any tracked file.