### PR TITLE
chore: add typecheck script and engines field [#136][#137]

### DIFF
--- a/nexa/package.json
+++ b/nexa/package.json
@@ -7,6 +7,7 @@
     "build": "prisma generate && ([ -n \"$DATABASE_URL\" ] && prisma migrate deploy || true) && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "db:seed": "prisma db seed",
@@ -18,6 +19,9 @@
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.2",


### PR DESCRIPTION
## Summary

Two package.json-only DevOps changes (scope limited to `nexa/package.json`):

- **#136** — add a `typecheck` npm script that runs the same check as CI (`tsc --noEmit`, per `.github/workflows/ci.yml` line 34), so developers can run the CI type-check locally via `npm run typecheck`.
- **#137** — add an `engines` field pinning `node` to `>=22.0.0`, matching the CI Node version (`node-version: 22`) and the README requirement, so installs on older Node emit an early engine warning.

## Exact additions
```json
"typecheck": "tsc --noEmit",
```
```json
"engines": {
  "node": ">=22.0.0"
},
```

## Verification
- `npm run typecheck` — passes (exit 0)
- `npm run lint` — clean (0 errors)
- `npm run format:check` — clean

Closes #136
Closes #137