### PR TITLE
docs(classify): add JSDoc to provider entry points [#135]

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -23,6 +23,21 @@ function stripPrefix(base64: string): string {
   return idx >= 0 ? base64.slice(idx + 1) : base64;
 }
 
+/**
+ * Classify a civic issue with Anthropic (claude-haiku-4-5).
+ *
+ * Sends the prompt, optional user `description`, and optional image to the
+ * model, then parses the JSON reply into a normalized {@link ProviderResult}
+ * tagged with `provider: "anthropic/claude-haiku-4-5"` and the measured
+ * `latencyMs`.
+ *
+ * @param description - User-supplied text describing the issue (skipped when empty).
+ * @param imageBase64 - Image as a base64 data URL, or null for text-only.
+ * @param options.prompt - Overrides the default `CLASSIFICATION_PROMPT` when set.
+ * @returns The model's classification merged with provider id and latency.
+ *          Rejects if the Anthropic call throws; callers wrap it in their own
+ *          error handling.
+ */
 export async function classifyWithAnthropic(
   description: string,
   imageBase64: string | null,

--- a/nexa/src/lib/classify/google-provider.ts
+++ b/nexa/src/lib/classify/google-provider.ts
@@ -19,6 +19,21 @@ function extractMimeType(base64: string): string {
   return match?.[1] ?? "image/jpeg";
 }
 
+/**
+ * Classify a civic issue with Google (gemini-2.5-flash).
+ *
+ * Sends the prompt, optional user `description`, and optional image to the
+ * model, then parses the JSON reply into a normalized {@link ProviderResult}
+ * tagged with `provider: "google/gemini-2.5-flash"` and the measured
+ * `latencyMs`.
+ *
+ * @param description - User-supplied text describing the issue (skipped when empty).
+ * @param imageBase64 - Image as a base64 data URL, or null for text-only.
+ * @param options.prompt - Overrides the default `CLASSIFICATION_PROMPT` when set.
+ * @returns The model's classification merged with provider id and latency.
+ *          Rejects if the Google call throws; callers wrap it in their own
+ *          error handling.
+ */
 export async function classifyWithGoogle(
   description: string,
   imageBase64: string | null,

--- a/nexa/src/lib/classify/openai-provider.ts
+++ b/nexa/src/lib/classify/openai-provider.ts
@@ -9,6 +9,20 @@ function getClient() {
   return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 }
 
+/**
+ * Classify a civic issue with OpenAI (gpt-4o-mini).
+ *
+ * Sends the prompt, optional user `description`, and optional image to the
+ * model, then parses the JSON reply into a normalized {@link ProviderResult}
+ * tagged with `provider: "openai/gpt-4o-mini"` and the measured `latencyMs`.
+ *
+ * @param description - User-supplied text describing the issue (skipped when empty).
+ * @param imageBase64 - Image as a base64 data URL, or null for text-only.
+ * @param options.prompt - Overrides the default `CLASSIFICATION_PROMPT` when set.
+ * @returns The model's classification merged with provider id and latency.
+ *          Rejects if the OpenAI call throws; callers wrap it in their own
+ *          error handling.
+ */
 export async function classifyWithOpenAI(
   description: string,
   imageBase64: string | null,


### PR DESCRIPTION
## Summary
Adds a concise JSDoc block to each of the three classify provider entry-point functions, closing #135. Documentation-only — no behavior or signature changes.

- \`classifyWithOpenAI\` (\`src/lib/classify/openai-provider.ts\`)
- \`classifyWithAnthropic\` (\`src/lib/classify/anthropic-provider.ts\`)
- \`classifyWithGoogle\` (\`src/lib/classify/google-provider.ts\`)

Each block documents purpose, params (including the \`options.prompt\` override of the default \`CLASSIFICATION_PROMPT\`), the normalized \`ProviderResult\` return shape (provider id + measured \`latencyMs\`), and the reject-on-error behavior. Style matches the existing JSDoc on \`classifyWithConsensus\` in \`consensus.ts\`.

## Acceptance criteria
- [x] Each of the three provider functions has a JSDoc block covering purpose, params (incl. \`options.prompt\`), and return shape.
- [x] Style is consistent with \`consensus.ts\`.

## Verification
- \`npx tsc --noEmit\` — clean
- \`npm run lint\` — 0 errors (2 pre-existing \`<img>\` warnings in unrelated components)
- \`npm run format:check\` — clean

Closes #135