### PR TITLE
refactor: centralize image/geolocation magic numbers in constants.ts [#132]

### DIFF
--- a/nexa/src/hooks/use-geolocation.ts
+++ b/nexa/src/hooks/use-geolocation.ts
@@ -2,6 +2,10 @@
 
 import { useState, useCallback, useRef } from "react";
 import { reverseGeocode } from "@/lib/reverse-geocode";
+import {
+  GEOLOCATION_TIMEOUT_MS,
+  GEOLOCATION_CACHE_AGE_MS,
+} from "@/lib/constants";
 
 export function useGeolocation() {
   const [address, setAddress] = useState("");
@@ -66,8 +70,8 @@ export function useGeolocation() {
       },
       {
         enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 60000,
+        timeout: GEOLOCATION_TIMEOUT_MS,
+        maximumAge: GEOLOCATION_CACHE_AGE_MS,
       },
     );
   }, [setCoordinates, refreshAddress]);

--- a/nexa/src/hooks/use-image-upload.ts
+++ b/nexa/src/hooks/use-image-upload.ts
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { IMAGE_PROCESSING } from "@/lib/constants";
 
 // Server enforces a ~4.5MB request body limit (Vercel default). Modern phone
 // photos are 5–10MB after base64, so we resize before sending.
-const MAX_DIMENSION = 1280;
-const JPEG_QUALITY = 0.82;
+const MAX_DIMENSION = IMAGE_PROCESSING.CLIENT_MAX_DIMENSION;
+const JPEG_QUALITY = IMAGE_PROCESSING.CLIENT_JPEG_QUALITY;
 
 function readAsDataUrl(file: Blob): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/nexa/src/lib/classify/preprocess.ts
+++ b/nexa/src/lib/classify/preprocess.ts
@@ -1,5 +1,6 @@
 import sharp from "sharp";
 import exifr from "exifr";
+import { IMAGE_PROCESSING } from "@/lib/constants";
 
 export interface PreprocessedImage {
   // base64 data URL ready to be passed to VLMs as image_url
@@ -18,8 +19,8 @@ export interface PreprocessedImage {
   originalHeight: number | null;
 }
 
-const MAX_DIMENSION = 1024;
-const JPEG_QUALITY = 80;
+const MAX_DIMENSION = IMAGE_PROCESSING.SERVER_MAX_DIMENSION;
+const JPEG_QUALITY = IMAGE_PROCESSING.SERVER_JPEG_QUALITY;
 
 /**
  * Strip a `data:image/...;base64,` prefix if present and return the raw base64

--- a/nexa/src/lib/constants.ts
+++ b/nexa/src/lib/constants.ts
@@ -1,3 +1,29 @@
+/**
+ * Image-processing tuning constants.
+ *
+ * Client and server values intentionally diverge:
+ *   - CLIENT_* runs in the browser canvas (quality is a 0–1 fraction) and is
+ *     sized to fit under the server's ~4.5MB request-body limit (Vercel
+ *     default) so uploads don't 413.
+ *   - SERVER_* runs in sharp (quality is a 0–100 scale) and is tuned smaller to
+ *     cut VLM token cost and latency on every classification call.
+ */
+export const IMAGE_PROCESSING = {
+  /** Longest-edge cap (px) for the browser-side resize before upload. */
+  CLIENT_MAX_DIMENSION: 1280,
+  /** JPEG quality (0–1) for the browser canvas re-encode. */
+  CLIENT_JPEG_QUALITY: 0.82,
+  /** Longest-edge cap (px) for the server-side sharp downscale. */
+  SERVER_MAX_DIMENSION: 1024,
+  /** JPEG quality (0–100) for the server-side sharp re-encode. */
+  SERVER_JPEG_QUALITY: 80,
+} as const;
+
+/** Browser geolocation request timeout (ms). */
+export const GEOLOCATION_TIMEOUT_MS = 10000;
+/** Max age (ms) of a cached browser position we'll accept before re-fetching. */
+export const GEOLOCATION_CACHE_AGE_MS = 60000;
+
 export const ISSUE_TYPE_LABELS: Record<string, string> = {
   ROAD_DAMAGE: "Road Damage",
   STREETLIGHT_OUTAGE: "Streetlight Outage",


### PR DESCRIPTION
## Summary
Hoists hard-coded image-processing and browser-geolocation tuning values into named exports in `src/lib/constants.ts` and imports them at the call sites. Closes #132 (image + geolocation portion; see scope note below).

Behavior is byte-for-byte equivalent — every numeric value is unchanged, only relocated to named constants.

## Constants added (`src/lib/constants.ts`)
- `IMAGE_PROCESSING` object with a comment documenting the intentional client/server divergence:
  - `CLIENT_MAX_DIMENSION = 1280`, `CLIENT_JPEG_QUALITY = 0.82` (browser canvas, 0–1 scale)
  - `SERVER_MAX_DIMENSION = 1024`, `SERVER_JPEG_QUALITY = 80` (sharp, 0–100 scale)
- `GEOLOCATION_TIMEOUT_MS = 10000`
- `GEOLOCATION_CACHE_AGE_MS = 60000`

## Files changed
- `src/lib/constants.ts` — new constants + rationale comments
- `src/hooks/use-image-upload.ts` — uses `IMAGE_PROCESSING.CLIENT_*`
- `src/lib/classify/preprocess.ts` — uses `IMAGE_PROCESSING.SERVER_*`
- `src/hooks/use-geolocation.ts` — uses `GEOLOCATION_TIMEOUT_MS` / `GEOLOCATION_CACHE_AGE_MS`

## Scope note
The issue also mentioned `NOMINATIM_ZOOM_LEVEL` (`zoom=18`) and `LOCATION_QUERY_MIN_LENGTH` (`< 3`). On inspection those literals live in `src/lib/reverse-geocode.ts`, `src/app/api/location/suggest/route.ts`, and `src/app/report/page.tsx` — not in the geolocation hook. This PR is scoped to the files that actually hold the image/geolocation-hook literals; the zoom/query-length de-dup can follow as a small separate change.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated)
- `npm run format:check` — clean
- Diff reviewed: no numeric value changed.