### PR TITLE
feat(data): seed verified Menlo Park Open311 API agency + correct emissions authority to CARB [#98]

### DIFF
--- a/nexa/prisma/seed.ts
+++ b/nexa/prisma/seed.ts
@@ -41,14 +41,22 @@ const AGENCIES: AgencySeed[] = [
     },
   },
   {
-    name: "California BAR Smoking Vehicle Hotline",
+    // CORRECTION (verified per issue #23 agency-research comment, 2026-06-09):
+    // the smoking-vehicle complaint authority is the California Air Resources
+    // Board (CARB), NOT the Bureau of Automotive Repair (BAR). The live program
+    // is the CARB "Smoking Vehicle Complaint", phone (800) 242-4450.
+    // The source comment did not provide an exact CARB web-form URL, so we keep
+    // intakeUrl null (unverified) rather than invent one; the verified phone
+    // number is recorded below as the authoritative contact channel.
+    name: "CARB Smoking Vehicle Complaint",
     jurisdiction: "city-palo-alto",
     issueTypes: ["VEHICLE_EMISSIONS"],
     intakeMethod: "WEB_FORM",
-    intakeUrl:
-      "https://www.bar.ca.gov/Consumer/Smoking_Vehicles/Report_Smoking_Vehicle",
+    intakeUrl: null,
     intakeEmail: null,
     requiredFields: {
+      // Verified CARB Smoking Vehicle Complaint hotline (issue #23).
+      contact_phone: { type: "string", value: "(800) 242-4450" },
       license_plate: { type: "string", required: true },
       vehicle_make: { type: "string", required: true },
       vehicle_model: { type: "string", required: false },
@@ -69,6 +77,49 @@ const AGENCIES: AgencySeed[] = [
       location_address: { type: "string", required: true },
       photo: { type: "file", required: false },
       contact_email: { type: "string", required: false },
+    },
+  },
+  {
+    // Verified Menlo Park SeeClickFix Open311 endpoint (issue #98 comment
+    // "Verified Open311 API options", source-verified 2026-06-09). Distinct
+    // `name` from the existing "Menlo Park ACT" WEB_FORM row so the
+    // @@unique([jurisdiction, name]) key does not collide.
+    //
+    // Verified facts (all confirmed via services.json HTTP 200, org "Menlo Park"):
+    //   - base endpoint     https://seeclickfix.com/open311/v2
+    //   - sandbox endpoint  https://int.seeclickfix.com/open311/v2
+    //   - no auth required  (a valid User-Agent is required for public POST)
+    //   - service_code ROAD_DAMAGE    = 94213 (Potholes)
+    //   - service_code ILLEGAL_DUMPING = 94210 (Dumping)
+    //
+    // CAVEAT (UNVERIFIED): the exact `jurisdiction_id` token required by
+    // POST /requests.json was NOT confirmed — numeric 76196 and the slug both
+    // 404 on per-jurisdiction GET, and no live POST was performed. We therefore
+    // do NOT seed a jurisdictionId (omitting it is correct for single-tenant
+    // posting; confirm with SeeClickFix support and test against the sandbox
+    // before relying on the production write path).
+    //
+    // The `open311` block below matches the shape consumed by
+    // parseOpen311Config()/Open311Config in src/lib/submission/open311.ts:
+    // { endpoint, serviceCodes: Partial<Record<IssueType, string>> }. The base
+    // endpoint is also mirrored in `intakeUrl` (the client falls back to it).
+    name: "Menlo Park SeeClickFix (Open311)",
+    jurisdiction: "city-menlo-park",
+    issueTypes: ["ROAD_DAMAGE", "ILLEGAL_DUMPING"],
+    intakeMethod: "API",
+    intakeUrl: "https://seeclickfix.com/open311/v2",
+    intakeEmail: null,
+    requiredFields: {
+      open311: {
+        endpoint: "https://seeclickfix.com/open311/v2",
+        // Sandbox endpoint for safe testing (not consumed by the client yet;
+        // kept here as verified provenance per the #98 caveat).
+        sandboxEndpoint: "https://int.seeclickfix.com/open311/v2",
+        serviceCodes: {
+          ROAD_DAMAGE: "94213",
+          ILLEGAL_DUMPING: "94210",
+        },
+      },
     },
   },
   {


### PR DESCRIPTION
Implements #98: makes the Open311 API submission path reachable by seeding the first `intakeMethod: "API"` agency, and applies the verified CARB correction from #23.

## Changes (`nexa/prisma/seed.ts` only)
- **New API agency — "Menlo Park SeeClickFix (Open311)"** (`city-menlo-park`, `intakeMethod: "API"`). Uses source-verified values from the #98 "Verified Open311 API options" comment:
  - base endpoint `https://seeclickfix.com/open311/v2` (sandbox `https://int.seeclickfix.com/open311/v2`), no auth
  - `service_code` ROAD_DAMAGE = `94213`, ILLEGAL_DUMPING = `94210`
  - Distinct `name` so the `@@unique([jurisdiction, name])` key does not collide with the existing "Menlo Park ACT" row.
  - The hookup config lives inside the existing `requiredFields` Json under the `open311` key — **no schema change / no migration**. The shape exactly matches what `parseOpen311Config()` in `src/lib/submission/open311.ts` consumes (`endpoint`, `serviceCodes` keyed by `IssueType`).
  - **Caveat preserved:** the exact POST `jurisdiction_id` token is unverified, so none is seeded; recorded as a code comment.
- **CARB correction:** the mislabeled "California BAR Smoking Vehicle Hotline" is renamed to the verified authority **CARB Smoking Vehicle Complaint**, with the verified hotline (800) 242-4450 recorded. The source did not provide an exact CARB web-form URL, so `intakeUrl` is set to `null` (unverified) rather than inventing one.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (only 2 pre-existing unrelated `<img>` warnings)
- `npm run format:check` — clean
- `db:seed` needs a live DB, so a throwaway tsx snippet (not committed) imported `parseOpen311Config` against the new row's config. Result: parsed `{ endpoint, serviceCodes: { ROAD_DAMAGE: "94213", ILLEGAL_DUMPING: "94210" } }`, `jurisdictionId` correctly `undefined`, and `resolveServiceCode` returns 94213/94210 — **all assertions passed**.

No values were invented; all unverified caveats from the source comments are preserved.