### PR TITLE
feat(api): schema-driven request parsing [#124]

### DIFF
--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -32,7 +32,8 @@
         "shadcn": "^4.3.1",
         "sharp": "^0.34.5",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -59,6 +60,9 @@
         "typescript": "^5",
         "vitest": "^4.1.8",
         "vitest-mock-extended": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14318,9 +14322,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -53,7 +53,8 @@
     "shadcn": "^4.3.1",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/nexa/src/app/api/auth/login/route.ts
+++ b/nexa/src/app/api/auth/login/route.ts
@@ -2,10 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { LoginSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 export async function POST(request: NextRequest) {
   try {
-    const { email, password } = await request.json();
+    const { email, password } = await parseJsonRequest(request, LoginSchema);
 
     if (!email || !password) {
       return NextResponse.json(
@@ -44,6 +50,9 @@ export async function POST(request: NextRequest) {
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Login error:", error);
     return NextResponse.json(
       { error: "Login failed. Please try again." },

--- a/nexa/src/app/api/auth/register/route.ts
+++ b/nexa/src/app/api/auth/register/route.ts
@@ -2,10 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
+import { RegisterSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 export async function POST(request: NextRequest) {
   try {
-    const { name, email, password } = await request.json();
+    const { name, email, password } = await parseJsonRequest(
+      request,
+      RegisterSchema,
+    );
 
     if (!email || !password) {
       return NextResponse.json(
@@ -47,6 +56,9 @@ export async function POST(request: NextRequest) {
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Registration error:", error);
     return NextResponse.json(
       { error: "Registration failed. Please try again." },

--- a/nexa/src/app/api/reports/[id]/resolution/route.ts
+++ b/nexa/src/app/api/reports/[id]/resolution/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
+import { ResolutionSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 export async function POST(
   request: NextRequest,
@@ -16,16 +22,7 @@ export async function POST(
     }
 
     const { id } = await context.params;
-    const body = (await request.json().catch(() => null)) as {
-      resolved?: unknown;
-    } | null;
-
-    if (!body || typeof body.resolved !== "boolean") {
-      return NextResponse.json(
-        { error: "Field `resolved` must be a boolean." },
-        { status: 400 },
-      );
-    }
+    const { resolved } = await parseJsonRequest(request, ResolutionSchema);
 
     const report = await prisma.report.findUnique({
       where: { id },
@@ -49,7 +46,7 @@ export async function POST(
     // resolved, the whole case resolves for every reporter linked to it. The
     // group is flagged resolved and every non-closed member report is updated to
     // match. Reports with no group keep the single-report behavior below.
-    if (report.issueGroupId && body.resolved) {
+    if (report.issueGroupId && resolved) {
       await prisma.$transaction([
         prisma.issueGroup.update({
           where: { id: report.issueGroupId },
@@ -80,12 +77,12 @@ export async function POST(
     }
 
     const nextStatus =
-      body.resolved && report.status !== "CLOSED" ? "RESOLVED" : report.status;
+      resolved && report.status !== "CLOSED" ? "RESOLVED" : report.status;
 
     const updated = await prisma.report.update({
       where: { id },
       data: {
-        userResolved: body.resolved,
+        userResolved: resolved,
         userResolvedAt: resolvedAt,
         status: nextStatus,
       },
@@ -94,6 +91,9 @@ export async function POST(
 
     return NextResponse.json(updated);
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Report resolution update error:", error);
     return NextResponse.json(
       { error: "Failed to update resolution. Please try again." },

--- a/nexa/src/app/api/reports/classify/route.ts
+++ b/nexa/src/app/api/reports/classify/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { classifyWithConsensus } from "@/lib/classify/consensus";
 import type { LocationContext } from "@/lib/classify/types";
+import { ClassifyRequestSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
     const {
       description,
       imageBase64,
@@ -12,14 +17,7 @@ export async function POST(request: NextRequest) {
       longitude,
       address,
       jurisdiction,
-    } = body as {
-      description?: string;
-      imageBase64?: string;
-      latitude?: number;
-      longitude?: number;
-      address?: string;
-      jurisdiction?: string;
-    };
+    } = await parseJsonRequest(request, ClassifyRequestSchema);
 
     if (!description && !imageBase64) {
       return NextResponse.json(
@@ -29,13 +27,13 @@ export async function POST(request: NextRequest) {
     }
 
     const location: LocationContext | null =
-      typeof latitude === "number" ||
-      typeof longitude === "number" ||
+      latitude !== undefined ||
+      longitude !== undefined ||
       address ||
       jurisdiction
         ? {
-            latitude: typeof latitude === "number" ? latitude : null,
-            longitude: typeof longitude === "number" ? longitude : null,
+            latitude: latitude ?? null,
+            longitude: longitude ?? null,
             address: address ?? null,
             jurisdiction: jurisdiction ?? null,
           }
@@ -49,6 +47,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("[classify] Unexpected error:", error);
     return NextResponse.json(
       { error: "Classification failed. Please try again." },

--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -3,6 +3,12 @@ import { getOpenAI } from "@/lib/openai";
 import { ISSUE_TYPE_LABELS, US_STATE_CODES } from "@/lib/constants";
 import { IssueType } from "@/generated/prisma/enums";
 import { resolveJurisdiction } from "@/lib/jurisdictions/resolve";
+import { FormLinkRequestSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 type Confidence = "low" | "medium" | "high";
 
@@ -418,18 +424,12 @@ Do not say "not_found" just because there is no "${issueLabel}"-specific form â€
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { issueType, address, latitude, longitude } = body as {
-      issueType?: string;
-      address?: string;
-      latitude?: number;
-      longitude?: number;
-    };
+    const { issueType, address, latitude, longitude } = await parseJsonRequest(
+      request,
+      FormLinkRequestSchema,
+    );
 
-    if (
-      !issueType ||
-      !Object.values(IssueType).includes(issueType as IssueType)
-    ) {
+    if (!issueType) {
       return NextResponse.json(
         { error: "Valid issueType is required." },
         { status: 400 },
@@ -480,7 +480,7 @@ export async function POST(request: NextRequest) {
     const lookup = await lookupOfficialForm({
       cityName: location.cityName,
       stateName: location.stateName,
-      issueType: issueType as IssueType,
+      issueType,
       address,
     });
 
@@ -503,6 +503,9 @@ export async function POST(request: NextRequest) {
     };
     return NextResponse.json(result);
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Official form lookup error:", error);
     return NextResponse.json(
       { error: "Failed to look up official city form." },

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { IssueType } from "@/generated/prisma/enums";
 import { getSession } from "@/lib/auth";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 import { findOrCreateIssueGroup } from "@/lib/issues/dedupe";
+import { CreateReportSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 
 export async function POST(request: NextRequest) {
   try {
     const session = await getSession();
-    const body = await request.json();
     const {
       description,
       aiDescription,
@@ -17,20 +21,9 @@ export async function POST(request: NextRequest) {
       longitude,
       address,
       imageUrl,
-    } = body as {
-      description?: string;
-      aiDescription?: string;
-      issueType?: string;
-      latitude?: number;
-      longitude?: number;
-      address?: string;
-      imageUrl?: string;
-    };
+    } = await parseJsonRequest(request, CreateReportSchema);
 
-    const validIssueType =
-      issueType && Object.values(IssueType).includes(issueType as IssueType)
-        ? (issueType as IssueType)
-        : null;
+    const validIssueType = issueType ?? null;
 
     // Route the report to the responsible agency from its location + issue
     // type so the submission pipeline has somewhere to file it.
@@ -67,6 +60,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(report, { status: 201 });
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Report creation error:", error);
     return NextResponse.json(
       { error: "Failed to create report. Please try again." },

--- a/nexa/src/lib/api/request-parser.ts
+++ b/nexa/src/lib/api/request-parser.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import type { ZodType } from "zod";
+
+/**
+ * Error thrown when a request body fails schema validation. Carries the
+ * human-readable validation messages so the route can surface a consistent
+ * 400 response without re-deriving the failure reason.
+ */
+export class RequestParseError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(issues[0] ?? "Invalid request body.");
+    this.name = "RequestParseError";
+    this.issues = issues;
+  }
+}
+
+/**
+ * Parse an already-decoded request body against a schema, returning the typed
+ * value. Throws {@link RequestParseError} when the body does not match so
+ * callers get a single, consistent failure path instead of scattered inline
+ * `typeof`/enum checks.
+ */
+export function parseRequestBody<T>(body: unknown, schema: ZodType<T>): T {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    const issues = result.error.issues.map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    });
+    throw new RequestParseError(issues);
+  }
+  return result.data;
+}
+
+/**
+ * Read and validate a JSON request body in one step. Returns the typed value
+ * or throws {@link RequestParseError} (including when the body is not valid
+ * JSON), so every route shares the same parse-and-fail behavior.
+ */
+export async function parseJsonRequest<T>(
+  request: Request,
+  schema: ZodType<T>,
+): Promise<T> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new RequestParseError(["Request body must be valid JSON."]);
+  }
+  return parseRequestBody(body, schema);
+}
+
+/**
+ * Build the consistent 400 response returned whenever request parsing fails.
+ * Keeps the error shape identical across every route in one place.
+ */
+export function parseErrorResponse(error: RequestParseError): NextResponse {
+  return NextResponse.json({ error: error.message }, { status: 400 });
+}

--- a/nexa/src/lib/api/schemas.ts
+++ b/nexa/src/lib/api/schemas.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { IssueType } from "@/generated/prisma/enums";
+
+/**
+ * Per-route request schemas. Each route declares its body shape here once and
+ * parses through `parseRequestBody`, replacing the inline `as { ... }` casts
+ * and ad-hoc `typeof`/enum narrowing that previously lived in the handlers.
+ *
+ * Field optionality mirrors the contracts the routes already accepted; this
+ * layer adds typing and `issueType` enum validation, not new runtime bounds
+ * (those are tracked separately in #106).
+ */
+
+/** `POST /api/reports` — create a report. */
+export const CreateReportSchema = z.object({
+  description: z.string().optional(),
+  aiDescription: z.string().optional(),
+  issueType: z.enum(IssueType).optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+  address: z.string().optional(),
+  imageUrl: z.string().optional(),
+});
+export type CreateReportInput = z.infer<typeof CreateReportSchema>;
+
+/** `POST /api/reports/classify` — classify a description/image. */
+export const ClassifyRequestSchema = z.object({
+  description: z.string().optional(),
+  imageBase64: z.string().optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+  address: z.string().optional(),
+  jurisdiction: z.string().optional(),
+});
+export type ClassifyRequestInput = z.infer<typeof ClassifyRequestSchema>;
+
+/** `POST /api/reports/form-link` — look up an official city form. */
+export const FormLinkRequestSchema = z.object({
+  issueType: z.enum(IssueType).optional(),
+  address: z.string().optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+});
+export type FormLinkRequestInput = z.infer<typeof FormLinkRequestSchema>;
+
+/** `POST /api/auth/register` — create an account. */
+export const RegisterSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().optional(),
+  password: z.string().optional(),
+});
+export type RegisterInput = z.infer<typeof RegisterSchema>;
+
+/** `POST /api/auth/login` — authenticate an existing account. */
+export const LoginSchema = z.object({
+  email: z.string().optional(),
+  password: z.string().optional(),
+});
+export type LoginInput = z.infer<typeof LoginSchema>;
+
+/** `POST /api/reports/[id]/resolution` — mark a report resolved/unresolved. */
+export const ResolutionSchema = z.object({
+  resolved: z.boolean({
+    error: "Field `resolved` must be a boolean.",
+  }),
+});
+export type ResolutionInput = z.infer<typeof ResolutionSchema>;


### PR DESCRIPTION
Closes #124.

## What
Introduces a single shared request-parsing layer so each API route declares its body shape once and parses it with type inference, replacing the inline \`as { ... }\` casts and scattered ad-hoc \`typeof\`/enum narrowing that bypassed TypeScript's type safety.

## Changes
- **New \`src/lib/api/schemas.ts\`** — per-route zod schemas: \`CreateReportSchema\`, \`ClassifyRequestSchema\`, \`FormLinkRequestSchema\`, \`RegisterSchema\`, \`LoginSchema\`, \`ResolutionSchema\`. \`issueType\` is validated against the \`IssueType\` enum at parse time.
- **New \`src/lib/api/request-parser.ts\`** — shared \`parseRequestBody\`/\`parseJsonRequest\` helpers plus a \`RequestParseError\` and a \`parseErrorResponse\` that returns a consistent 400.
- Updated the 6 POST routes to parse via the shared helper and removed the now-redundant inline casts and \`typeof\`/enum checks:
  - \`reports/route.ts\`, \`reports/classify/route.ts\`, \`reports/form-link/route.ts\`, \`auth/register/route.ts\`, \`auth/login/route.ts\`, \`reports/[id]/resolution/route.ts\`.
- Added \`zod\` (endorsed by the issue; reused by follow-ups #125/#129).

## Contract preservation
- Request contracts are unchanged — fields and optionality mirror what each route already accepted; only typing + \`issueType\` enum validation were added (runtime bounds remain out of scope per #106).
- **Login auth logic preserved exactly**: the \`#89\` fix (\`findUnique\` + \`bcrypt.compare\` against \`passwordHash\`, generic 401) is untouched; only the request body is now typed/parsed.

## Verification
- \`npx tsc --noEmit\` — passes
- \`npm run lint\` — 0 errors (only pre-existing \`<img>\` warnings in unrelated components)
- \`npm run format:check\` — clean
- \`npm run build\` — succeeds

## Deferred
Vitest coverage deferred: test infra (#112) is not yet on main.