### PR TITLE
fix(submission): atomic CONFIRMED->SUBMITTING transition to prevent duplicate submits [#103]

### DIFF
--- a/nexa/src/app/api/reports/[id]/submit/route.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.ts
@@ -77,11 +77,20 @@ export async function POST(
       );
     }
 
-    // Mark in-flight so concurrent submits don't double-file.
-    await prisma.report.update({
-      where: { id },
+    // Atomically claim the report for submission. A single conditional update
+    // (CONFIRMED -> SUBMITTING) is the DB-level guard against concurrent
+    // submits: only one of two simultaneous POSTs can flip the row, so only
+    // one ever reaches submitToOpen311 below. The loser sees count === 0.
+    const claim = await prisma.report.updateMany({
+      where: { id, status: ReportStatus.CONFIRMED },
       data: { status: ReportStatus.SUBMITTING },
     });
+    if (claim.count !== 1) {
+      return NextResponse.json(
+        { error: "This report is already being submitted." },
+        { status: 409 },
+      );
+    }
 
     const config = parseOpen311Config(agency.requiredFields);
     const result = await submitToOpen311(report, {


### PR DESCRIPTION
## Summary
Closes #103. Makes the report submit route's CONFIRMED -> SUBMITTING transition atomic so two simultaneous POSTs cannot both pass the status check and both file a duplicate Open311 service request.

Previously the route read `report.status` (early in the handler) and only later wrote `SUBMITTING` via an unconditional `prisma.report.update` — two separate statements with no DB-level guard, so both racers could proceed to `submitToOpen311`.

## Change (single file: `src/app/api/reports/[id]/submit/route.ts`)
- Replace the unconditional SUBMITTING `update` with a single conditional `prisma.report.updateMany({ where: { id, status: CONFIRMED }, data: { status: SUBMITTING } })`.
- Proceed to `submitToOpen311` only when exactly one row was claimed (`count === 1`).
- A losing concurrent request (`count === 0`) returns **409** without calling the submission agent.
- Error rollback to CONFIRMED and the SUBMITTED + `externalTrackingId` success write are unchanged.
- No Prisma schema change.

## Acceptance criteria
- [x] Claim is a single conditional `updateMany` (where status=CONFIRMED -> SUBMITTING), proceeds only when exactly one row updated
- [x] Losing concurrent request returns 409 without calling `submitToOpen311`
- [x] On submit error, status rolls back to CONFIRMED as today

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing unrelated `<img>` warnings)
- `npm run format:check` — all files match Prettier style

## Notes
- No vitest tests added: the test infra (#112) is not on `main`; unit coverage for the concurrency guard is deferred until that lands.