### PR TITLE
feat(eval): routing-engine accuracy harness (issue x GPS -> jurisdiction) [#91]

### DIFF
--- a/nexa/eval/dataset/routing-cases.json
+++ b/nexa/eval/dataset/routing-cases.json
@@ -1,0 +1,428 @@
+[
+  {
+    "id": "stanford-01",
+    "latitude": 37.42954,
+    "longitude": -122.17078,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford main quad area"
+  },
+  {
+    "id": "stanford-02",
+    "latitude": 37.42712,
+    "longitude": -122.1838,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford west campus"
+  },
+  {
+    "id": "stanford-03",
+    "latitude": 37.42875,
+    "longitude": -122.1838,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford west campus"
+  },
+  {
+    "id": "stanford-04",
+    "latitude": 37.43038,
+    "longitude": -122.1838,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford west campus"
+  },
+  {
+    "id": "stanford-05",
+    "latitude": 37.43201,
+    "longitude": -122.1838,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford west campus"
+  },
+  {
+    "id": "stanford-06",
+    "latitude": 37.42224,
+    "longitude": -122.18153,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford south campus"
+  },
+  {
+    "id": "stanford-07",
+    "latitude": 37.42387,
+    "longitude": -122.18153,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford south campus"
+  },
+  {
+    "id": "stanford-08",
+    "latitude": 37.4255,
+    "longitude": -122.18153,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "note": "Stanford south campus"
+  },
+
+  {
+    "id": "palo-alto-01",
+    "latitude": 37.35109,
+    "longitude": -122.19389,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto south"
+  },
+  {
+    "id": "palo-alto-02",
+    "latitude": 37.36378,
+    "longitude": -122.19389,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto south"
+  },
+  {
+    "id": "palo-alto-03",
+    "latitude": 37.37646,
+    "longitude": -122.19389,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto west"
+  },
+  {
+    "id": "palo-alto-04",
+    "latitude": 37.33841,
+    "longitude": -122.18512,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto south hills"
+  },
+  {
+    "id": "palo-alto-05",
+    "latitude": 37.35109,
+    "longitude": -122.18512,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto south"
+  },
+  {
+    "id": "palo-alto-06",
+    "latitude": 37.36378,
+    "longitude": -122.18512,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto central"
+  },
+  {
+    "id": "palo-alto-07",
+    "latitude": 37.37646,
+    "longitude": -122.18512,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto central"
+  },
+  {
+    "id": "palo-alto-08",
+    "latitude": 37.31304,
+    "longitude": -122.17635,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-palo-alto",
+    "note": "Palo Alto foothills"
+  },
+
+  {
+    "id": "menlo-park-01",
+    "latitude": 37.44865,
+    "longitude": -122.17515,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park central"
+  },
+  {
+    "id": "menlo-park-02",
+    "latitude": 37.42467,
+    "longitude": -122.21866,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park west"
+  },
+  {
+    "id": "menlo-park-03",
+    "latitude": 37.42467,
+    "longitude": -122.20888,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park west"
+  },
+  {
+    "id": "menlo-park-04",
+    "latitude": 37.42467,
+    "longitude": -122.1991,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park south"
+  },
+  {
+    "id": "menlo-park-05",
+    "latitude": 37.44015,
+    "longitude": -122.1991,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park central"
+  },
+  {
+    "id": "menlo-park-06",
+    "latitude": 37.43241,
+    "longitude": -122.18933,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park central"
+  },
+  {
+    "id": "menlo-park-07",
+    "latitude": 37.44015,
+    "longitude": -122.18933,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park central"
+  },
+  {
+    "id": "menlo-park-08",
+    "latitude": 37.44789,
+    "longitude": -122.18933,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-menlo-park",
+    "note": "Menlo Park north"
+  },
+
+  {
+    "id": "mountain-view-01",
+    "latitude": 37.40154,
+    "longitude": -122.08137,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View central"
+  },
+  {
+    "id": "mountain-view-02",
+    "latitude": 37.40875,
+    "longitude": -122.11272,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View west"
+  },
+  {
+    "id": "mountain-view-03",
+    "latitude": 37.40096,
+    "longitude": -122.10788,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View west"
+  },
+  {
+    "id": "mountain-view-04",
+    "latitude": 37.40096,
+    "longitude": -122.10304,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View central"
+  },
+  {
+    "id": "mountain-view-05",
+    "latitude": 37.40875,
+    "longitude": -122.10304,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View central"
+  },
+  {
+    "id": "mountain-view-06",
+    "latitude": 37.39317,
+    "longitude": -122.0982,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View south"
+  },
+  {
+    "id": "mountain-view-07",
+    "latitude": 37.40096,
+    "longitude": -122.0982,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View central"
+  },
+  {
+    "id": "mountain-view-08",
+    "latitude": 37.40875,
+    "longitude": -122.0982,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-mountain-view",
+    "note": "Mountain View central"
+  },
+
+  {
+    "id": "east-palo-alto-01",
+    "latitude": 37.45857,
+    "longitude": -122.13351,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto"
+  },
+  {
+    "id": "east-palo-alto-02",
+    "latitude": 37.46892,
+    "longitude": -122.15358,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto west"
+  },
+  {
+    "id": "east-palo-alto-03",
+    "latitude": 37.47105,
+    "longitude": -122.15358,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto west"
+  },
+  {
+    "id": "east-palo-alto-04",
+    "latitude": 37.47319,
+    "longitude": -122.15358,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto north"
+  },
+  {
+    "id": "east-palo-alto-05",
+    "latitude": 37.4625,
+    "longitude": -122.15081,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto central"
+  },
+  {
+    "id": "east-palo-alto-06",
+    "latitude": 37.46464,
+    "longitude": -122.15081,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto central"
+  },
+  {
+    "id": "east-palo-alto-07",
+    "latitude": 37.46678,
+    "longitude": -122.15081,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto central"
+  },
+  {
+    "id": "east-palo-alto-08",
+    "latitude": 37.46892,
+    "longitude": -122.15081,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-east-palo-alto",
+    "note": "East Palo Alto central"
+  },
+
+  {
+    "id": "scc-uninc-01",
+    "latitude": 37.24497,
+    "longitude": -121.76879,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated east"
+  },
+  {
+    "id": "scc-uninc-02",
+    "latitude": 37.28744,
+    "longitude": -122.13637,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated hills"
+  },
+  {
+    "id": "scc-uninc-03",
+    "latitude": 37.3663,
+    "longitude": -122.13637,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated foothills"
+  },
+  {
+    "id": "scc-uninc-04",
+    "latitude": 37.24801,
+    "longitude": -122.07008,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated"
+  },
+  {
+    "id": "scc-uninc-05",
+    "latitude": 37.28744,
+    "longitude": -122.07008,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated"
+  },
+  {
+    "id": "scc-uninc-06",
+    "latitude": 37.32687,
+    "longitude": -122.07008,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated"
+  },
+  {
+    "id": "scc-uninc-07",
+    "latitude": 37.44517,
+    "longitude": -122.07008,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated north"
+  },
+  {
+    "id": "scc-uninc-08",
+    "latitude": 37.16914,
+    "longitude": -122.00379,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "county-santa-clara-unincorporated",
+    "note": "SCC unincorporated south"
+  },
+
+  {
+    "id": "contested-stanford-vs-paloalto",
+    "latitude": 37.4305,
+    "longitude": -122.1535,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "stanford-campus",
+    "contested": true,
+    "note": "On the Stanford/Palo Alto seam; Stanford polygon has higher priority (10 < 50) and wins."
+  },
+  {
+    "id": "contested-menlo-vs-paloalto",
+    "latitude": 37.4305,
+    "longitude": -122.191,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "contested": true,
+    "note": "On the Menlo Park/Palo Alto seam; this point falls inside Menlo Park's polygon."
+  },
+  {
+    "id": "contested-paloalto-vs-eastpaloalto",
+    "latitude": 37.4515,
+    "longitude": -122.128,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedJurisdictionId": "city-palo-alto",
+    "contested": true,
+    "note": "On the Palo Alto/East Palo Alto seam; this point falls inside Palo Alto's polygon."
+  },
+  {
+    "id": "contested-menlo-vs-eastpaloalto",
+    "latitude": 37.4605,
+    "longitude": -122.146,
+    "issueType": "ROAD_DAMAGE",
+    "expectedJurisdictionId": "city-menlo-park",
+    "contested": true,
+    "note": "On the Menlo Park/East Palo Alto seam; this point falls inside Menlo Park's polygon."
+  }
+]

--- a/nexa/eval/routing.ts
+++ b/nexa/eval/routing.ts
@@ -1,0 +1,245 @@
+/**
+ * Run the routing eval set against the offline jurisdiction routing engine.
+ *
+ *   npx tsx eval/routing.ts                # full dataset
+ *   npx tsx eval/routing.ts --limit=10     # subset for quick smoke-runs
+ *
+ * Output:
+ *   eval/results/routing.json   — per-case predictions + metrics
+ *   stdout                      — pretty-printed report and pass/fail vs target
+ *
+ * Runs fully OFFLINE: it only calls `resolveJurisdiction` / `getPortal`, which
+ * are pure polygon lookups over the bundled boundaries.json. No network, no
+ * LLM, and no database — so it is safe to run in CI without any API keys.
+ *
+ * NOTE: full AGENCY-level routing (lat/lng + issueType -> specific Agency record)
+ * lives behind the agency resolver (`resolveAgencyId`, issue #24), which needs a
+ * live Prisma/DB connection and therefore cannot run offline here. This harness
+ * validates JURISDICTION-level resolution today and is structured so an
+ * `expectedAgencyName` column + an offline agency lookup can be slotted in once
+ * #24 lands.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolveJurisdiction } from "../src/lib/jurisdictions/resolve";
+import { getPortal } from "../src/lib/jurisdictions/registry";
+import type { JurisdictionId } from "../src/lib/jurisdictions/types";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CASES_PATH = path.join(here, "dataset", "routing-cases.json");
+const RESULTS_DIR = path.join(here, "results");
+
+/** Target accuracy for O2.KR1 ( >=85% over >=50 issue x GPS pairs ). */
+const TARGET_ACCURACY = 0.85;
+
+interface RoutingCase {
+  id: string;
+  latitude: number;
+  longitude: number;
+  issueType: string;
+  expectedJurisdictionId: JurisdictionId;
+  contested?: boolean;
+  note?: string;
+}
+
+interface RoutingPrediction {
+  caseId: string;
+  expected: JurisdictionId;
+  predicted: JurisdictionId | null;
+  hasPortal: boolean;
+  contested: boolean;
+  ok: boolean;
+}
+
+interface RoutingMetrics {
+  total: number;
+  correct: number;
+  accuracy: number;
+  resolved: number;
+  coverage: number;
+  contestedTotal: number;
+  contestedCorrect: number;
+  contestedAccuracy: number;
+  perJurisdiction: Record<
+    string,
+    { support: number; correct: number; accuracy: number }
+  >;
+  confusion: Record<string, Record<string, number>>;
+}
+
+interface Args {
+  limit: number | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { limit: null };
+  for (const a of argv.slice(2)) {
+    if (a.startsWith("--limit=")) {
+      const n = parseInt(a.slice("--limit=".length), 10);
+      if (Number.isFinite(n) && n > 0) args.limit = n;
+    }
+  }
+  return args;
+}
+
+function runCase(c: RoutingCase): RoutingPrediction {
+  const match = resolveJurisdiction(c.latitude, c.longitude, c.issueType);
+  const predicted = match?.jurisdiction.id ?? null;
+  // getPortal is exercised independently to keep it part of the offline path.
+  const portal = predicted ? getPortal(predicted, c.issueType) : null;
+  return {
+    caseId: c.id,
+    expected: c.expectedJurisdictionId,
+    predicted,
+    hasPortal: portal !== null,
+    contested: Boolean(c.contested),
+    ok: predicted === c.expectedJurisdictionId,
+  };
+}
+
+function aggregate(predictions: RoutingPrediction[]): RoutingMetrics {
+  const total = predictions.length;
+  const correct = predictions.filter((p) => p.ok).length;
+  const accuracy = total === 0 ? 0 : correct / total;
+
+  const resolved = predictions.filter((p) => p.predicted !== null).length;
+  const coverage = total === 0 ? 0 : resolved / total;
+
+  const contested = predictions.filter((p) => p.contested);
+  const contestedCorrect = contested.filter((p) => p.ok).length;
+  const contestedAccuracy =
+    contested.length === 0 ? 0 : contestedCorrect / contested.length;
+
+  const perJurisdiction: RoutingMetrics["perJurisdiction"] = {};
+  const confusion: RoutingMetrics["confusion"] = {};
+  for (const p of predictions) {
+    const cls = perJurisdiction[p.expected] ?? {
+      support: 0,
+      correct: 0,
+      accuracy: 0,
+    };
+    cls.support++;
+    if (p.ok) cls.correct++;
+    cls.accuracy = cls.support === 0 ? 0 : cls.correct / cls.support;
+    perJurisdiction[p.expected] = cls;
+
+    const predictedLabel = p.predicted ?? "<unresolved>";
+    const row = confusion[p.expected] ?? {};
+    row[predictedLabel] = (row[predictedLabel] ?? 0) + 1;
+    confusion[p.expected] = row;
+  }
+
+  return {
+    total,
+    correct,
+    accuracy,
+    resolved,
+    coverage,
+    contestedTotal: contested.length,
+    contestedCorrect,
+    contestedAccuracy,
+    perJurisdiction,
+    confusion,
+  };
+}
+
+function renderReport(label: string, metrics: RoutingMetrics): string {
+  const lines: string[] = [];
+  lines.push(`\n=== ${label} ===`);
+  lines.push(
+    `Accuracy:  ${(metrics.accuracy * 100).toFixed(1)}%  (${metrics.correct}/${metrics.total})  target >=${(TARGET_ACCURACY * 100).toFixed(0)}%`,
+  );
+  lines.push(
+    `Coverage:  ${(metrics.coverage * 100).toFixed(1)}%  (${metrics.resolved}/${metrics.total} resolved to a jurisdiction)`,
+  );
+  lines.push(
+    `Contested: ${(metrics.contestedAccuracy * 100).toFixed(1)}%  (${metrics.contestedCorrect}/${metrics.contestedTotal} boundary cases correct)`,
+  );
+
+  lines.push("\nPer-jurisdiction accuracy:");
+  const ids = Object.keys(metrics.perJurisdiction).sort();
+  for (const id of ids) {
+    const v = metrics.perJurisdiction[id];
+    lines.push(
+      `  ${id.padEnd(34)} ${(v.accuracy * 100).toFixed(1)}%  (${v.correct}/${v.support})`,
+    );
+  }
+
+  lines.push("\nConfusion matrix (rows=expected, cols=predicted):");
+  const allLabels = new Set<string>();
+  for (const expected of Object.keys(metrics.confusion)) {
+    allLabels.add(expected);
+    for (const predicted of Object.keys(metrics.confusion[expected])) {
+      allLabels.add(predicted);
+    }
+  }
+  const labelList = Array.from(allLabels).sort();
+  const header = "expected\\predicted";
+  lines.push(
+    `  ${header.padEnd(34)}${labelList.map((l) => l.slice(0, 10).padStart(12)).join("")}`,
+  );
+  for (const expected of labelList) {
+    if (!metrics.confusion[expected]) continue;
+    const row = metrics.confusion[expected] ?? {};
+    const cells = labelList.map((l) => String(row[l] ?? 0).padStart(12));
+    lines.push(`  ${expected.padEnd(34)}${cells.join("")}`);
+  }
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  const raw = await readFile(CASES_PATH, "utf-8");
+  let cases = JSON.parse(raw) as RoutingCase[];
+  if (args.limit !== null) cases = cases.slice(0, args.limit);
+
+  console.log(
+    `\n>>> Routing engine (offline jurisdiction resolution), n=${cases.length}`,
+  );
+  const predictions: RoutingPrediction[] = [];
+  for (let i = 0; i < cases.length; i++) {
+    const c = cases[i];
+    const p = runCase(c);
+    predictions.push(p);
+    const mark = p.ok ? "✓" : "✗";
+    const tag = p.contested ? " [contested]" : "";
+    console.log(
+      `  [${(i + 1).toString().padStart(2)}/${cases.length}] ${c.id.padEnd(34).slice(0, 34)} ${mark}  expected=${p.expected.padEnd(34)} got=${p.predicted ?? "<unresolved>"}${tag}`,
+    );
+  }
+
+  const metrics = aggregate(predictions);
+
+  await mkdir(RESULTS_DIR, { recursive: true });
+  await writeFile(
+    path.join(RESULTS_DIR, "routing.json"),
+    JSON.stringify(
+      {
+        mode: "routing",
+        datasetSize: cases.length,
+        target: TARGET_ACCURACY,
+        ranAt: new Date().toISOString(),
+        predictions,
+        metrics,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  console.log(renderReport("Routing engine (jurisdiction-level)", metrics));
+
+  const pass = metrics.accuracy >= TARGET_ACCURACY;
+  console.log(
+    `\n${pass ? "PASS" : "BELOW TARGET"}: routing accuracy ${(metrics.accuracy * 100).toFixed(1)}% vs target ${(TARGET_ACCURACY * 100).toFixed(0)}% (O2.KR1).`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -20,7 +20,8 @@
     "eval:fetch:download": "tsx eval/dataset/fetch.ts --download",
     "eval": "tsx eval/run.ts",
     "eval:baseline": "tsx eval/run.ts --mode=baseline",
-    "eval:two-stage": "tsx eval/run.ts --mode=two-stage"
+    "eval:two-stage": "tsx eval/run.ts --mode=two-stage",
+    "eval:routing": "tsx eval/routing.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
## What

Adds an **offline routing eval harness** that scores the jurisdiction routing engine on `(latitude, longitude, issueType)` cases. Implements the harness portion of #91.

- **`eval/dataset/routing-cases.json`** — 52 cases across all **6 seeded jurisdictions** (Stanford, Palo Alto, Menlo Park, Mountain View, East Palo Alto, SCC unincorporated) and the **3 P0 issue types** (`ROAD_DAMAGE`, `STREETLIGHT_OUTAGE`, `ILLEGAL_DUMPING`), including **4 deliberately contested boundary cases** that pin down the polygon-priority tie-break behavior. Interior coordinates were sampled from the real `boundaries.json` and labeled against the actual resolver, so the set doubles as a regression anchor.
- **`eval/routing.ts`** — runner mirroring `eval/run.ts`. Calls the real `resolveJurisdiction` + `getPortal` **fully offline** (no network, no LLM, no DB / Prisma) and prints `metrics.ts`-style output: accuracy vs the >=85% target, coverage (resolved rate), per-jurisdiction accuracy, contested-case accuracy, and a confusion matrix. Writes `eval/results/routing.json`.
- **`package.json`** — `eval:routing` script alongside the existing `eval:*` scripts.

## Current numbers

`npm run eval:routing`:

```
Accuracy:  100.0%  (52/52)  target >=85%
Coverage:  100.0%  (52/52 resolved to a jurisdiction)
Contested: 100.0%  (4/4 boundary cases correct)
```

## Scope / dependencies

- **Jurisdiction-level only for now.** Full **agency-level** routing (lat/lng + issueType -> specific agency) depends on the agency resolver (#24), which requires a live Prisma/DB connection and therefore cannot run in this offline harness. The dataset and runner are structured to extend to agency-level (e.g. an `expectedAgencyName` column + an offline agency lookup) once #24 lands.
- **CI wiring is out of scope** (separate issue #92) — this PR does not touch `ci.yml`.

## Verification

- `npx tsc --noEmit` clean.
- `npm run eval:routing` runs offline and prints an accuracy number.