### PR TITLE
test: auth middleware (proxy.ts) + getSession tests [#121]

### DIFF
--- a/nexa/src/lib/auth-session.test.ts
+++ b/nexa/src/lib/auth-session.test.ts
@@ -1,0 +1,92 @@
+import { cookies } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SESSION_COOKIE, createToken, getSession } from "@/lib/auth";
+
+// Unit test (node project) for getSession(): cookie -> verifyToken wiring.
+// next/headers is globally mocked in vitest.setup.tsx with cookies() resolving
+// to a store whose get() returns undefined by default; we override get() per
+// test to control which cookie value getSession sees. Tokens are signed with
+// the test JWT_SECRET set by src/test/env.ts so verifyToken runs for real.
+
+const mockedCookies = vi.mocked(cookies);
+
+// Point the mocked cookies() store's get() at a fixed return value and hand
+// back the spy so tests can assert how getSession called it.
+function setCookie(value: { value: string } | undefined) {
+  const get = vi.fn(() => value);
+  mockedCookies.mockResolvedValue({
+    get,
+  } as unknown as Awaited<ReturnType<typeof cookies>>);
+  return get;
+}
+
+describe("getSession()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no session cookie is present", async () => {
+    // Arrange
+    const get = setCookie(undefined);
+
+    // Act
+    const session = await getSession();
+
+    // Assert
+    expect(session).toBeNull();
+    expect(mockedCookies).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith(SESSION_COOKIE);
+  });
+
+  it("returns the decoded payload for a valid token", async () => {
+    // Arrange
+    const token = await createToken({
+      userId: "user_42",
+      email: "valid@example.com",
+    });
+    const get = setCookie({ value: token });
+
+    // Act
+    const session = await getSession();
+
+    // Assert
+    expect(get).toHaveBeenCalledWith(SESSION_COOKIE);
+    expect(session).toMatchObject({
+      userId: "user_42",
+      email: "valid@example.com",
+    });
+  });
+
+  it("returns null for an invalid (unverifiable) token", async () => {
+    // Arrange
+    setCookie({ value: "not-a-jwt" });
+
+    // Act
+    const session = await getSession();
+
+    // Assert
+    expect(session).toBeNull();
+  });
+
+  it("returns null for an expired token", async () => {
+    // Arrange — sign a token that expired in the past with the test secret.
+    const { SignJWT } = await import("jose");
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const expired = await new SignJWT({
+      userId: "user_1",
+      email: "old@example.com",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 1000)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 10)
+      .sign(secret);
+    setCookie({ value: expired });
+
+    // Act
+    const session = await getSession();
+
+    // Assert
+    expect(session).toBeNull();
+  });
+});

--- a/nexa/src/proxy.test.ts
+++ b/nexa/src/proxy.test.ts
@@ -1,0 +1,210 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { SESSION_COOKIE, createToken } from "@/lib/auth";
+
+import { config, proxy } from "./proxy";
+
+// Unit test (node project) for the Next.js auth middleware. We exercise every
+// branch by constructing a real NextRequest, attaching (or omitting) the
+// session cookie, and signing a genuine JWT with the test JWT_SECRET that
+// src/test/env.ts sets — so verifyToken runs for real, no mocking needed.
+
+const BASE = "http://localhost";
+
+// Build a NextRequest for `path`, optionally carrying a session cookie value.
+function makeRequest(path: string, sessionToken?: string): NextRequest {
+  const request = new NextRequest(new URL(path, BASE));
+  if (sessionToken !== undefined) {
+    request.cookies.set(SESSION_COOKIE, sessionToken);
+  }
+  return request;
+}
+
+// A real, valid 7-day token signed with the test secret.
+async function validToken(): Promise<string> {
+  return createToken({ userId: "user_1", email: "a@example.com" });
+}
+
+describe("proxy() middleware", () => {
+  describe("protected routes", () => {
+    it.each(["/report", "/dashboard", "/dashboard/reports/abc", "/report/new"])(
+      "redirects %s with no session to /login preserving redirect=path",
+      async (path) => {
+        // Arrange
+        const request = makeRequest(path);
+
+        // Act
+        const response = await proxy(request);
+        const location = new URL(response.headers.get("location")!);
+
+        // Assert
+        expect(response.status).toBe(307);
+        expect(location.pathname).toBe("/login");
+        expect(location.searchParams.get("redirect")).toBe(path);
+      },
+    );
+
+    it("redirects to /login when the session cookie is an invalid token", async () => {
+      // Arrange — a cookie present but not a verifiable JWT.
+      const request = makeRequest("/dashboard", "not-a-real-jwt");
+
+      // Act
+      const response = await proxy(request);
+      const location = new URL(response.headers.get("location")!);
+
+      // Assert
+      expect(response.status).toBe(307);
+      expect(location.pathname).toBe("/login");
+      expect(location.searchParams.get("redirect")).toBe("/dashboard");
+    });
+
+    it("calls next() (no redirect) for a protected route with a valid session", async () => {
+      // Arrange
+      const request = makeRequest("/dashboard", await validToken());
+
+      // Act
+      const response = await proxy(request);
+
+      // Assert — NextResponse.next() carries no location and is not a redirect.
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+  });
+
+  describe("auth routes", () => {
+    it.each(["/login", "/register"])(
+      "redirects %s to / when already logged in",
+      async (path) => {
+        // Arrange
+        const request = makeRequest(path, await validToken());
+
+        // Act
+        const response = await proxy(request);
+        const location = new URL(response.headers.get("location")!);
+
+        // Assert
+        expect(response.status).toBe(307);
+        expect(location.pathname).toBe("/");
+        expect(location.searchParams.has("redirect")).toBe(false);
+      },
+    );
+
+    it.each(["/login", "/register"])(
+      "calls next() for %s with no session",
+      async (path) => {
+        // Arrange
+        const request = makeRequest(path);
+
+        // Act
+        const response = await proxy(request);
+
+        // Assert
+        expect(response.headers.get("location")).toBeNull();
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+      },
+    );
+
+    it("calls next() for an auth route when the cookie token is invalid", async () => {
+      // Arrange — invalid token means no session, so the auth route is shown.
+      const request = makeRequest("/login", "garbage");
+
+      // Act
+      const response = await proxy(request);
+
+      // Assert
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+  });
+
+  describe("prefix (startsWith) semantics", () => {
+    it("treats /reportage as protected because it starts with /report", async () => {
+      // Arrange — documents the as-implemented startsWith behavior.
+      const request = makeRequest("/reportage");
+
+      // Act
+      const response = await proxy(request);
+      const location = new URL(response.headers.get("location")!);
+
+      // Assert
+      expect(response.status).toBe(307);
+      expect(location.pathname).toBe("/login");
+      expect(location.searchParams.get("redirect")).toBe("/reportage");
+    });
+
+    it("does NOT treat /registerish as an auth route redirect when logged out", async () => {
+      // Arrange — startsWith would match, but with no session auth routes pass
+      // through; this asserts a logged-out user is not bounced.
+      const request = makeRequest("/registerish");
+
+      // Act
+      const response = await proxy(request);
+
+      // Assert
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+  });
+
+  describe("pass-through (non-protected, non-auth) paths", () => {
+    it.each(["/", "/about", "/api/health"])(
+      "calls next() for %s regardless of session",
+      async (path) => {
+        // Arrange
+        const request = makeRequest(path);
+
+        // Act
+        const response = await proxy(request);
+
+        // Assert
+        expect(response.headers.get("location")).toBeNull();
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+      },
+    );
+
+    it("calls next() for a pass-through path even with a valid session", async () => {
+      // Arrange
+      const request = makeRequest("/about", await validToken());
+
+      // Act
+      const response = await proxy(request);
+
+      // Assert
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+  });
+});
+
+describe("config.matcher", () => {
+  it("is a single negative-lookahead matcher excluding Next internals and static assets", () => {
+    // Assert
+    expect(config.matcher).toEqual([
+      "/((?!_next/static|_next/image|favicon.ico|public).*)",
+    ]);
+  });
+
+  it.each(["_next/static/chunk.js", "_next/image", "favicon.ico", "public/logo.png"])(
+    "does not match excluded asset path %s",
+    (path) => {
+      // Arrange — reconstruct the matcher regex and anchor it like Next does.
+      const pattern = new RegExp(`^${config.matcher[0]}$`);
+
+      // Act / Assert — the negative lookahead means these are NOT matched.
+      expect(pattern.test(`/${path}`)).toBe(false);
+    },
+  );
+
+  it.each(["/", "/report", "/dashboard/x", "/login"])(
+    "matches application path %s",
+    (path) => {
+      // Arrange
+      const pattern = new RegExp(`^${config.matcher[0]}$`);
+
+      // Act / Assert
+      expect(pattern.test(path)).toBe(true);
+    },
+  );
+});

--- a/nexa/vitest.config.ts
+++ b/nexa/vitest.config.ts
@@ -32,7 +32,11 @@ export default defineConfig({
         test: {
           name: "node",
           environment: "node",
-          include: ["src/lib/**/*.test.{ts,tsx}", "src/app/**/*.test.{ts,tsx}"],
+          include: [
+            "src/*.test.{ts,tsx}",
+            "src/lib/**/*.test.{ts,tsx}",
+            "src/app/**/*.test.{ts,tsx}",
+          ],
           exclude: SHARED_EXCLUDE,
         },
       },


### PR DESCRIPTION
## Summary
Implements #121 — unit tests for the Next.js auth middleware (`src/proxy.ts`) and the deferred `getSession()` cookie wiring in `src/lib/auth.ts`. Both were previously untested despite being the single point of route-protection gating.

## What's covered
**`src/proxy.test.ts`** — every middleware branch:
- Protected routes (`/report`, `/dashboard`, and subpaths) with no/invalid session -> 307 redirect to `/login` with `redirect` query == the original pathname.
- Protected route + valid session -> `next()` (no redirect).
- Auth routes (`/login`, `/register`) + valid session -> redirect to `/`.
- Auth route + no/invalid session -> `next()`.
- `startsWith` prefix semantics as implemented (e.g. `/reportage` is protected).
- Pass-through (non-protected, non-auth) paths -> `next()`.
- `config.matcher` excludes `_next/static`, `_next/image`, `favicon.ico`, `public` (and matches app paths).

**`src/lib/auth-session.test.ts`** — `getSession()`:
- No cookie -> `null`.
- Valid token -> decoded `{ userId, email }` payload.
- Invalid and expired tokens -> `null`.
- Asserts `cookies()` / `get(SESSION_COOKIE)` call args.

## Approach
- Reuses the existing test foundation (#112): the global `next/headers` mock and the `JWT_SECRET` set in `src/test/env.ts`.
- Signs real JWTs via `createToken` / `jose` against the test secret, so `verifyToken` runs for real — deterministic, offline, no DB/network.
- AAA, colocated `*.test.ts`, node project.
- Extends the node project's `include` glob to discover the top-level `src/proxy.test.ts` (proxy.ts lives at the `src/` root, outside the existing `src/lib/**` and `src/app/**` globs).

## Verification
- `npm test` -> 6 files, 39 tests pass (30 new).
- `npx tsc --noEmit` -> clean.

Closes #121.