### PR TITLE
test: unit tests for open311/jurisdictions/auth-token [#114]

### DIFF
--- a/nexa/src/lib/auth.test.ts
+++ b/nexa/src/lib/auth.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MissingEnvError } from "@/lib/config";
+
+import { createToken, verifyToken, type SessionPayload } from "./auth";
+
+// auth.ts reads the JWT secret via @/lib/config's getJwtSecret (cached/memoized
+// in the real module). We mock that one getter so each test controls the secret
+// deterministically — including simulating a missing JWT_SECRET — without
+// touching process.env or fighting the cache. The real jose library still
+// signs/verifies, so the round-trip and tamper/expiry behavior is exercised
+// end to end.
+const getJwtSecret = vi.fn(() => "unit-test-secret");
+vi.mock("@/lib/config", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/config")>("@/lib/config");
+  return { ...actual, getJwtSecret: () => getJwtSecret() };
+});
+
+const payload: SessionPayload = {
+  userId: "user-123",
+  email: "person@example.com",
+};
+
+describe("createToken / verifyToken", () => {
+  beforeEach(() => {
+    getJwtSecret.mockReturnValue("unit-test-secret");
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("round-trips the userId and email through a signed token", async () => {
+    // Arrange / Act
+    const token = await createToken(payload);
+    const decoded = await verifyToken(token);
+
+    // Assert
+    expect(decoded?.userId).toBe(payload.userId);
+    expect(decoded?.email).toBe(payload.email);
+  });
+
+  it("produces a three-segment HS256 JWT string", async () => {
+    // Arrange / Act
+    const token = await createToken(payload);
+
+    // Assert: header.payload.signature.
+    expect(token.split(".")).toHaveLength(3);
+  });
+
+  it("returns null for a token signed with a different secret (tampered/invalid signature)", async () => {
+    // Arrange: sign under one secret, verify under another.
+    getJwtSecret.mockReturnValue("secret-A");
+    const token = await createToken(payload);
+    getJwtSecret.mockReturnValue("secret-B");
+
+    // Act
+    const decoded = await verifyToken(token);
+
+    // Assert
+    expect(decoded).toBeNull();
+  });
+
+  it("returns null for a structurally malformed token", async () => {
+    // Arrange / Act
+    const decoded = await verifyToken("not.a.jwt");
+
+    // Assert
+    expect(decoded).toBeNull();
+  });
+
+  it("returns null for an expired token", async () => {
+    // Arrange: mint a token, then advance time past the 7-day expiry.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const token = await createToken(payload);
+    // 8 days later — beyond the 7d expiry baked into createToken.
+    vi.setSystemTime(new Date("2026-01-09T00:00:00Z"));
+
+    // Act
+    const decoded = await verifyToken(token);
+
+    // Assert
+    expect(decoded).toBeNull();
+  });
+
+  it("throws when the JWT secret is missing (observed through createToken)", async () => {
+    // Arrange: getJwtSecret throws MissingEnvError when JWT_SECRET is unset.
+    getJwtSecret.mockImplementation(() => {
+      throw new MissingEnvError("JWT_SECRET");
+    });
+
+    // Act / Assert
+    await expect(createToken(payload)).rejects.toThrow(MissingEnvError);
+  });
+});

--- a/nexa/src/lib/jurisdictions/registry.test.ts
+++ b/nexa/src/lib/jurisdictions/registry.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { getPortal, JURISDICTIONS } from "./registry";
+import type { JurisdictionId } from "./types";
+
+// getPortal is a pure data lookup over the static JURISDICTIONS registry.
+describe("getPortal", () => {
+  it("returns the default endpoint when no issue-specific entry exists", () => {
+    // Arrange / Act: Palo Alto only defines a `default` endpoint.
+    const portal = getPortal("city-palo-alto", "ROAD_DAMAGE");
+
+    // Assert
+    expect(portal).toEqual(JURISDICTIONS["city-palo-alto"].endpoints.default);
+    expect(portal?.url).toContain("paloalto.gov");
+  });
+
+  it("returns null when the matched jurisdiction's default endpoint is null", () => {
+    // Arrange / Act: East Palo Alto has an unverified (null) default portal.
+    const portal = getPortal("city-east-palo-alto", "ROAD_DAMAGE");
+
+    // Assert
+    expect(portal).toBeNull();
+  });
+
+  it("returns null for an unknown jurisdiction id", () => {
+    // Arrange / Act
+    const portal = getPortal("nope" as JurisdictionId, "ROAD_DAMAGE");
+
+    // Assert
+    expect(portal).toBeNull();
+  });
+
+  it("ignores the issue type when only a default endpoint is configured", () => {
+    // Arrange / Act: an arbitrary issue type still resolves to the default.
+    const portal = getPortal("city-menlo-park", "STREETLIGHT_OUTAGE");
+
+    // Assert
+    expect(portal).toEqual(JURISDICTIONS["city-menlo-park"].endpoints.default);
+  });
+});

--- a/nexa/src/lib/jurisdictions/resolve.test.ts
+++ b/nexa/src/lib/jurisdictions/resolve.test.ts
@@ -3,10 +3,24 @@ import { describe, expect, it } from "vitest";
 import { resolveJurisdiction } from "./resolve";
 
 // Unit test (node project): a real exported pure function, no mocks needed.
+// Coordinates below were chosen against the committed boundaries.json so the
+// tests are deterministic and offline.
 describe("resolveJurisdiction", () => {
-  it("returns null for non-finite coordinates", () => {
+  it("returns null for NaN coordinates", () => {
     // Arrange / Act
     const result = resolveJurisdiction(Number.NaN, -122.17, "ROAD_DAMAGE");
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("returns null for Infinity coordinates", () => {
+    // Arrange / Act
+    const result = resolveJurisdiction(
+      37.4275,
+      Number.POSITIVE_INFINITY,
+      "ROAD_DAMAGE",
+    );
 
     // Assert
     expect(result).toBeNull();
@@ -29,5 +43,35 @@ describe("resolveJurisdiction", () => {
     // Assert
     expect(result).not.toBeNull();
     expect(result?.jurisdiction.id).toBe("stanford-campus");
+  });
+
+  it("prefers the higher-priority (lower number) polygon when polygons overlap", () => {
+    // Arrange: the Stanford point also falls within the county fallback
+    // polygon (priority 900); priority ordering must pick Stanford (10).
+    // Act
+    const result = resolveJurisdiction(37.4275, -122.17, "ROAD_DAMAGE");
+
+    // Assert
+    expect(result?.jurisdiction.id).toBe("stanford-campus");
+  });
+
+  it("attaches the resolved portal for a city with a verified endpoint", () => {
+    // Arrange: a point inside the Palo Alto city boundary.
+    // Act
+    const result = resolveJurisdiction(37.4419, -122.143, "ROAD_DAMAGE");
+
+    // Assert
+    expect(result?.jurisdiction.id).toBe("city-palo-alto");
+    expect(result?.portal?.url).toContain("paloalto.gov");
+  });
+
+  it("returns a null portal when the matched jurisdiction has no verified endpoint", () => {
+    // Arrange: East Palo Alto matches a polygon but its registry portal is null.
+    // Act
+    const result = resolveJurisdiction(37.4688, -122.1411, "ROAD_DAMAGE");
+
+    // Assert
+    expect(result?.jurisdiction.id).toBe("city-east-palo-alto");
+    expect(result?.portal).toBeNull();
   });
 });

--- a/nexa/src/lib/submission/open311.test.ts
+++ b/nexa/src/lib/submission/open311.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest";
+
+import { IssueType, ReportStatus } from "@/generated/prisma/enums";
+import { open311Config } from "@/test/fixtures/open311";
+
+import {
+  buildRequestParams,
+  mapOpen311Status,
+  parseOpen311Config,
+  resolveServiceCode,
+  STATUS_RANK,
+  type Open311Config,
+  type SubmittableReport,
+} from "./open311";
+
+// A report with every field present; tests override only what they exercise.
+function makeSubmittable(
+  overrides: Partial<SubmittableReport> = {},
+): SubmittableReport {
+  return {
+    issueType: IssueType.ROAD_DAMAGE,
+    description: "Big pothole on Main St",
+    aiDescription: "AI: large pothole",
+    latitude: 37.44,
+    longitude: -122.14,
+    address: "123 Main St",
+    ...overrides,
+  };
+}
+
+describe("resolveServiceCode", () => {
+  it("returns the built-in default code for a known issue type", () => {
+    // Arrange / Act
+    const code = resolveServiceCode(IssueType.ROAD_DAMAGE, undefined);
+
+    // Assert
+    expect(code).toBe("POTHOLES");
+  });
+
+  it("prefers the agency config override over the default", () => {
+    // Arrange
+    const config: Open311Config = {
+      serviceCodes: { [IssueType.ROAD_DAMAGE]: "CITY-POTHOLE-001" },
+    };
+
+    // Act
+    const code = resolveServiceCode(IssueType.ROAD_DAMAGE, config);
+
+    // Assert
+    expect(code).toBe("CITY-POTHOLE-001");
+  });
+
+  it("falls back to the default when the config has no override for the type", () => {
+    // Arrange: override exists for a different issue type only.
+    const config: Open311Config = {
+      serviceCodes: { [IssueType.OTHER]: "MISC" },
+    };
+
+    // Act
+    const code = resolveServiceCode(IssueType.STREETLIGHT_OUTAGE, config);
+
+    // Assert
+    expect(code).toBe("STREETLIGHTS");
+  });
+
+  it("returns null for a null issue type", () => {
+    // Arrange / Act
+    const code = resolveServiceCode(null, open311Config);
+
+    // Assert
+    expect(code).toBeNull();
+  });
+
+  it("returns null for an undefined issue type", () => {
+    // Arrange / Act
+    const code = resolveServiceCode(undefined, undefined);
+
+    // Assert
+    expect(code).toBeNull();
+  });
+});
+
+describe("buildRequestParams", () => {
+  it("always sets the service_code param", () => {
+    // Arrange / Act
+    const params = buildRequestParams(makeSubmittable(), "POTHOLES", undefined);
+
+    // Assert
+    expect(params.get("service_code")).toBe("POTHOLES");
+  });
+
+  it("prefers the citizen description over the AI description", () => {
+    // Arrange
+    const report = makeSubmittable({
+      description: "  citizen words  ",
+      aiDescription: "ai summary",
+    });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert: trimmed citizen text wins.
+    expect(params.get("description")).toBe("citizen words");
+  });
+
+  it("falls back to the AI description when the citizen description is blank", () => {
+    // Arrange
+    const report = makeSubmittable({
+      description: "   ",
+      aiDescription: "  ai summary  ",
+    });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.get("description")).toBe("ai summary");
+  });
+
+  it("omits description when both citizen and AI text are empty", () => {
+    // Arrange
+    const report = makeSubmittable({ description: null, aiDescription: null });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.has("description")).toBe(false);
+  });
+
+  it("sets lat and long when both coordinates are finite numbers", () => {
+    // Arrange
+    const report = makeSubmittable({ latitude: 37.44, longitude: -122.14 });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.get("lat")).toBe("37.44");
+    expect(params.get("long")).toBe("-122.14");
+  });
+
+  it("omits lat/long when only one coordinate is present", () => {
+    // Arrange: latitude present, longitude missing.
+    const report = makeSubmittable({ latitude: 37.44, longitude: null });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.has("lat")).toBe(false);
+    expect(params.has("long")).toBe(false);
+  });
+
+  it("sets a trimmed address_string when an address is present", () => {
+    // Arrange
+    const report = makeSubmittable({ address: "  123 Main St  " });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.get("address_string")).toBe("123 Main St");
+  });
+
+  it("omits address_string when the address is whitespace only", () => {
+    // Arrange
+    const report = makeSubmittable({ address: "   " });
+
+    // Act
+    const params = buildRequestParams(report, "POTHOLES", undefined);
+
+    // Assert
+    expect(params.has("address_string")).toBe(false);
+  });
+
+  it("includes api_key and jurisdiction_id from the config", () => {
+    // Arrange
+    const config: Open311Config = {
+      apiKey: "secret-key",
+      jurisdictionId: "city-palo-alto",
+    };
+
+    // Act
+    const params = buildRequestParams(makeSubmittable(), "POTHOLES", config);
+
+    // Assert
+    expect(params.get("api_key")).toBe("secret-key");
+    expect(params.get("jurisdiction_id")).toBe("city-palo-alto");
+  });
+
+  it("omits api_key and jurisdiction_id when the config is undefined", () => {
+    // Arrange / Act
+    const params = buildRequestParams(makeSubmittable(), "POTHOLES", undefined);
+
+    // Assert
+    expect(params.has("api_key")).toBe(false);
+    expect(params.has("jurisdiction_id")).toBe(false);
+  });
+
+  it("serializes to an x-www-form-urlencoded string", () => {
+    // Arrange
+    const report = makeSubmittable({
+      description: "a b",
+      latitude: null,
+      longitude: null,
+      address: null,
+    });
+
+    // Act
+    const serialized = buildRequestParams(
+      report,
+      "POTHOLES",
+      undefined,
+    ).toString();
+
+    // Assert: URLSearchParams percent-encodes the space.
+    expect(serialized).toBe("service_code=POTHOLES&description=a+b");
+  });
+});
+
+describe("parseOpen311Config", () => {
+  it("returns undefined when requiredFields is not an object", () => {
+    // Arrange / Act / Assert
+    expect(parseOpen311Config(null)).toBeUndefined();
+    expect(parseOpen311Config("nope")).toBeUndefined();
+    expect(parseOpen311Config(42)).toBeUndefined();
+  });
+
+  it("returns undefined when the open311 block is missing or not an object", () => {
+    // Arrange / Act / Assert
+    expect(parseOpen311Config({})).toBeUndefined();
+    expect(parseOpen311Config({ open311: "x" })).toBeUndefined();
+    expect(parseOpen311Config({ open311: null })).toBeUndefined();
+  });
+
+  it("extracts endpoint, apiKey and jurisdictionId string fields", () => {
+    // Arrange
+    const requiredFields = {
+      open311: {
+        endpoint: "https://example.test/v2",
+        apiKey: "key-1",
+        jurisdictionId: "city-palo-alto",
+      },
+    };
+
+    // Act
+    const config = parseOpen311Config(requiredFields);
+
+    // Assert
+    expect(config).toEqual({
+      endpoint: "https://example.test/v2",
+      apiKey: "key-1",
+      jurisdictionId: "city-palo-alto",
+    });
+  });
+
+  it("ignores non-string scalar fields (bad requiredFields types)", () => {
+    // Arrange: numeric/boolean values for fields that must be strings.
+    const requiredFields = {
+      open311: { endpoint: 123, apiKey: true, jurisdictionId: {} },
+    };
+
+    // Act
+    const config = parseOpen311Config(requiredFields);
+
+    // Assert: nothing extracted, but a config object is still returned.
+    expect(config).toEqual({});
+  });
+
+  it("keeps only valid IssueType/string pairs in serviceCodes", () => {
+    // Arrange
+    const requiredFields = {
+      open311: {
+        serviceCodes: {
+          ROAD_DAMAGE: "POTHOLES",
+          NOT_A_TYPE: "IGNORED",
+          OTHER: 999,
+        },
+      },
+    };
+
+    // Act
+    const config = parseOpen311Config(requiredFields);
+
+    // Assert: unknown key and non-string value are dropped.
+    expect(config?.serviceCodes).toEqual({ ROAD_DAMAGE: "POTHOLES" });
+  });
+
+  it("leaves serviceCodes undefined when it is not an object", () => {
+    // Arrange
+    const requiredFields = { open311: { serviceCodes: "nope" } };
+
+    // Act
+    const config = parseOpen311Config(requiredFields);
+
+    // Assert
+    expect(config?.serviceCodes).toBeUndefined();
+  });
+});
+
+describe("mapOpen311Status", () => {
+  it("maps open to ACKNOWLEDGED", () => {
+    expect(mapOpen311Status("open")).toBe(ReportStatus.ACKNOWLEDGED);
+  });
+
+  it("maps closed to RESOLVED", () => {
+    expect(mapOpen311Status("closed")).toBe(ReportStatus.RESOLVED);
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    // Arrange / Act / Assert
+    expect(mapOpen311Status("  OPEN  ")).toBe(ReportStatus.ACKNOWLEDGED);
+    expect(mapOpen311Status("Closed")).toBe(ReportStatus.RESOLVED);
+  });
+
+  it("returns null for an unrecognized status", () => {
+    expect(mapOpen311Status("pending")).toBeNull();
+  });
+});
+
+describe("STATUS_RANK", () => {
+  it("strictly increases along the report lifecycle so status only advances", () => {
+    // Arrange: the lifecycle order the cron poller relies on.
+    const lifecycle: ReportStatus[] = [
+      ReportStatus.DRAFT,
+      ReportStatus.CLASSIFYING,
+      ReportStatus.CONFIRMED,
+      ReportStatus.SUBMITTING,
+      ReportStatus.SUBMITTED,
+      ReportStatus.ACKNOWLEDGED,
+      ReportStatus.IN_PROGRESS,
+      ReportStatus.RESOLVED,
+      ReportStatus.CLOSED,
+    ];
+
+    // Act / Assert: each step ranks strictly above the previous one.
+    for (let i = 1; i < lifecycle.length; i++) {
+      expect(STATUS_RANK[lifecycle[i]]).toBeGreaterThan(
+        STATUS_RANK[lifecycle[i - 1]],
+      );
+    }
+  });
+
+  it("ranks the poller-relevant states SUBMITTED < ACKNOWLEDGED < IN_PROGRESS < RESOLVED", () => {
+    // Assert
+    expect(STATUS_RANK[ReportStatus.SUBMITTED]).toBeLessThan(
+      STATUS_RANK[ReportStatus.ACKNOWLEDGED],
+    );
+    expect(STATUS_RANK[ReportStatus.ACKNOWLEDGED]).toBeLessThan(
+      STATUS_RANK[ReportStatus.IN_PROGRESS],
+    );
+    expect(STATUS_RANK[ReportStatus.IN_PROGRESS]).toBeLessThan(
+      STATUS_RANK[ReportStatus.RESOLVED],
+    );
+  });
+
+  it("assigns a unique rank to every ReportStatus", () => {
+    // Arrange
+    const ranks = Object.values(STATUS_RANK);
+
+    // Assert: no two states share a rank.
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});


### PR DESCRIPTION
## Summary
Colocated unit tests for the submission/jurisdictions/auth-token domain logic, per issue #114. Pure/near-pure logic only — network functions (\`submitToOpen311\`/\`fetchOpen311Status\`) and \`getSession\` cookie wiring are intentionally left to the API-integration issue.

## Files added / changed
- \`src/lib/submission/open311.test.ts\` (new) — \`resolveServiceCode\`, \`buildRequestParams\`, \`parseOpen311Config\`, \`mapOpen311Status\`, and \`STATUS_RANK\` monotonicity/uniqueness. Private helpers (\`resolveEndpoint\`/\`stringOrNull\`/\`readErrorDescription\`) are exercised through these exported callers per the issue's reviewer correction.
- \`src/lib/jurisdictions/registry.test.ts\` (new) — \`getPortal\`: default endpoint, null endpoint, unknown id, issue-type fallthrough.
- \`src/lib/jurisdictions/resolve.test.ts\` (extended) — \`resolveJurisdiction\`: in/out of polygon, NaN, Infinity, priority ordering (Stanford over county overlap), portal attach, null-portal jurisdiction.
- \`src/lib/auth.test.ts\` (new) — \`createToken\`/\`verifyToken\` round-trip, tampered signature → null, malformed → null, expired (fake timers) → null, missing \`JWT_SECRET\` throws (observed via \`createToken\`).

## Conventions
- Colocated \`*.test.ts\`, AAA, deterministic and offline.
- Reuses \`src/test\` fixtures (\`open311Config\`) and generated enums; no duplicate mocks. \`jose\` runs for real; only \`@/lib/config\`'s \`getJwtSecret\` is mocked to control the secret deterministically. Jurisdiction coordinates verified against the committed \`boundaries.json\`.

## Verification
- New files: 46 tests pass. Full suite: 52 tests pass (7 files).
- \`npx tsc --noEmit\` clean. Prettier + ESLint clean.

Closes #114