### PR TITLE
test: hook tests for use-reports/geolocation/image-upload/speech [#118]

### DIFF
--- a/nexa/src/hooks/use-geolocation.test.tsx
+++ b/nexa/src/hooks/use-geolocation.test.tsx
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { act, renderHook, waitFor } from "@/test";
+
+// Mock the reverse-geocode path so no real Nominatim/network call is made and
+// the resolved address is fully under test control.
+vi.mock("@/lib/reverse-geocode", () => ({
+  reverseGeocode: vi.fn(),
+}));
+
+import { reverseGeocode } from "@/lib/reverse-geocode";
+import { useGeolocation } from "./use-geolocation";
+
+const mockReverseGeocode = vi.mocked(reverseGeocode);
+
+// GeolocationPositionError-like codes (the spec values the hook switches on).
+const PERMISSION_DENIED = 1;
+const POSITION_UNAVAILABLE = 2;
+const TIMEOUT = 3;
+
+function makePosition(lat: number, lng: number, accuracy: number) {
+  return {
+    coords: { latitude: lat, longitude: lng, accuracy },
+  } as GeolocationPosition;
+}
+
+function makeError(code: number) {
+  return {
+    code,
+    PERMISSION_DENIED,
+    POSITION_UNAVAILABLE,
+    TIMEOUT,
+  } as unknown as GeolocationPositionError;
+}
+
+/** Install a controllable navigator.geolocation mock. */
+function installGeolocation() {
+  const getCurrentPosition = vi.fn();
+  Object.defineProperty(globalThis.navigator, "geolocation", {
+    configurable: true,
+    value: { getCurrentPosition },
+  });
+  return getCurrentPosition;
+}
+
+describe("useGeolocation", () => {
+  beforeEach(() => {
+    mockReverseGeocode.mockResolvedValue("123 Main St, Palo Alto");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Remove the geolocation stub so each test re-installs its own.
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("starts with empty state", () => {
+    // Arrange / Act
+    const { result } = renderHook(() => useGeolocation());
+
+    // Assert
+    expect(result.current.address).toBe("");
+    expect(result.current.latitude).toBeNull();
+    expect(result.current.longitude).toBeNull();
+    expect(result.current.accuracy).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("detect() sets an unsupported error when geolocation is unavailable", () => {
+    // Arrange: geolocation left undefined (afterEach default)
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    expect(result.current.error).toBe("geo.unsupported");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("detect() success sets coords, accuracy, and the reverse-geocoded address", async () => {
+    // Arrange
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((success) => {
+      success(makePosition(37.44, -122.16, 12));
+    });
+    mockReverseGeocode.mockResolvedValue("195 University Ave");
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.latitude).toBe(37.44);
+    expect(result.current.longitude).toBe(-122.16);
+    expect(result.current.accuracy).toBe(12);
+    expect(mockReverseGeocode).toHaveBeenCalledWith(37.44, -122.16);
+    await waitFor(() =>
+      expect(result.current.address).toBe("195 University Ave"),
+    );
+  });
+
+  it("detect() falls back to a coordinate string when reverse-geocode yields the fallback", async () => {
+    // Arrange: reverseGeocode itself returns the coordinate fallback on failure.
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((success) => {
+      success(makePosition(1.23, 4.56, 5));
+    });
+    mockReverseGeocode.mockResolvedValue("1.230000, 4.560000");
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() =>
+      expect(result.current.address).toBe("1.230000, 4.560000"),
+    );
+  });
+
+  it("detect() maps PERMISSION_DENIED to geo.denied", async () => {
+    // Arrange
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((_success, error) => {
+      error(makeError(PERMISSION_DENIED));
+    });
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.error).toBe("geo.denied"));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("detect() maps POSITION_UNAVAILABLE to geo.unavailable", async () => {
+    // Arrange
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((_success, error) => {
+      error(makeError(POSITION_UNAVAILABLE));
+    });
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.error).toBe("geo.unavailable"));
+  });
+
+  it("detect() maps TIMEOUT to geo.timeout", async () => {
+    // Arrange
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((_success, error) => {
+      error(makeError(TIMEOUT));
+    });
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.error).toBe("geo.timeout"));
+  });
+
+  it("setCoordinates() updates latitude and longitude", () => {
+    // Arrange
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.setCoordinates(10, 20);
+    });
+
+    // Assert
+    expect(result.current.latitude).toBe(10);
+    expect(result.current.longitude).toBe(20);
+  });
+
+  it("movePin() sets coords and refreshes the address", async () => {
+    // Arrange
+    mockReverseGeocode.mockResolvedValue("Pinned Address");
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.movePin(5, 6);
+    });
+
+    // Assert
+    expect(result.current.latitude).toBe(5);
+    expect(result.current.longitude).toBe(6);
+    expect(mockReverseGeocode).toHaveBeenCalledWith(5, 6);
+    await waitFor(() => expect(result.current.address).toBe("Pinned Address"));
+  });
+
+  it("reset() clears coords, accuracy, address, and error", async () => {
+    // Arrange: populate some state first.
+    mockReverseGeocode.mockResolvedValue("Some Address");
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.movePin(5, 6);
+    });
+    await waitFor(() => expect(result.current.address).toBe("Some Address"));
+
+    // Act
+    act(() => {
+      result.current.reset();
+    });
+
+    // Assert
+    expect(result.current.latitude).toBeNull();
+    expect(result.current.longitude).toBeNull();
+    expect(result.current.accuracy).toBeNull();
+    expect(result.current.address).toBe("");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("setAddress() lets the caller override the address directly", () => {
+    // Arrange
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.setAddress("Manual Address");
+    });
+
+    // Assert
+    expect(result.current.address).toBe("Manual Address");
+  });
+});

--- a/nexa/src/hooks/use-image-upload.test.tsx
+++ b/nexa/src/hooks/use-image-upload.test.tsx
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { act, renderHook, waitFor } from "@/test";
+
+import { useImageUpload } from "./use-image-upload";
+
+// ---------------------------------------------------------------------------
+// Browser-API doubles. jsdom provides FileReader/Image stubs that never fire
+// load events for our synthetic blobs, so we install controllable fakes.
+// ---------------------------------------------------------------------------
+
+const RAW_DATA_URL = "data:image/jpeg;base64,RAWFILE";
+const RESIZED_DATA_URL = "data:image/jpeg;base64,RESIZED";
+
+let fileReaderShouldFail = false;
+
+class FakeFileReader {
+  result: string | null = null;
+  error: unknown = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readAsDataURL() {
+    queueMicrotask(() => {
+      if (fileReaderShouldFail) {
+        this.error = new Error("read failed");
+        this.onerror?.();
+      } else {
+        this.result = RAW_DATA_URL;
+        this.onload?.();
+      }
+    });
+  }
+}
+
+let imageShouldFail = false;
+let imageNaturalWidth = 2000;
+let imageNaturalHeight = 1000;
+
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  private _src = "";
+  set src(value: string) {
+    this._src = value;
+    queueMicrotask(() => {
+      if (imageShouldFail) {
+        this.onerror?.();
+      } else {
+        this.naturalWidth = imageNaturalWidth;
+        this.naturalHeight = imageNaturalHeight;
+        this.onload?.();
+      }
+    });
+  }
+  get src() {
+    return this._src;
+  }
+}
+
+// Capture canvas geometry + the toDataURL call so we can assert resize math.
+let lastCanvasWidth = 0;
+let lastCanvasHeight = 0;
+let toDataUrlArgs: unknown[] = [];
+let canvasContextNull = false;
+
+const drawImage = vi.fn();
+
+function installCanvasMock() {
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    if (tag !== "canvas") {
+      // Defer to a real element for anything else.
+      return Document.prototype.createElement.call(document, tag);
+    }
+    const canvas = {
+      set width(v: number) {
+        lastCanvasWidth = v;
+      },
+      get width() {
+        return lastCanvasWidth;
+      },
+      set height(v: number) {
+        lastCanvasHeight = v;
+      },
+      get height() {
+        return lastCanvasHeight;
+      },
+      getContext: () => (canvasContextNull ? null : { drawImage }),
+      toDataURL: (...args: unknown[]) => {
+        toDataUrlArgs = args;
+        return RESIZED_DATA_URL;
+      },
+    };
+    return canvas as unknown as HTMLElement;
+  });
+}
+
+function makeFile(type = "image/jpeg"): File {
+  return new File(["x"], "photo.jpg", { type });
+}
+
+describe("useImageUpload", () => {
+  beforeEach(() => {
+    fileReaderShouldFail = false;
+    imageShouldFail = false;
+    imageNaturalWidth = 2000;
+    imageNaturalHeight = 1000;
+    canvasContextNull = false;
+    lastCanvasWidth = 0;
+    lastCanvasHeight = 0;
+    toDataUrlArgs = [];
+    drawImage.mockClear();
+    vi.stubGlobal("FileReader", FakeFileReader);
+    vi.stubGlobal("Image", FakeImage);
+    installCanvasMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no preview or base64", () => {
+    // Arrange / Act
+    const { result } = renderHook(() => useImageUpload());
+
+    // Assert
+    expect(result.current.imagePreview).toBeNull();
+    expect(result.current.imageBase64).toBeNull();
+  });
+
+  it("resizes an oversized image down to MAX_DIMENSION via canvas at quality 0.82", async () => {
+    // Arrange: 2000x1000 -> longest 2000 > 1280, scale = 1280/2000 = 0.64.
+    const { result } = renderHook(() => useImageUpload());
+    const event = {
+      target: { files: [makeFile()] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    // Act
+    act(() => {
+      result.current.handleFileInput(event);
+    });
+
+    // Assert
+    await waitFor(() =>
+      expect(result.current.imagePreview).toBe(RESIZED_DATA_URL),
+    );
+    expect(result.current.imageBase64).toBe(RESIZED_DATA_URL);
+    expect(lastCanvasWidth).toBe(1280); // round(2000 * 0.64)
+    expect(lastCanvasHeight).toBe(640); // round(1000 * 0.64)
+    expect(drawImage).toHaveBeenCalled();
+    expect(toDataUrlArgs).toEqual(["image/jpeg", 0.82]);
+  });
+
+  it("keeps original dimensions when the image is within MAX_DIMENSION", async () => {
+    // Arrange: 800x600, longest 800 <= 1280, scale = 1.
+    imageNaturalWidth = 800;
+    imageNaturalHeight = 600;
+    const { result } = renderHook(() => useImageUpload());
+    const event = {
+      target: { files: [makeFile()] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    // Act
+    act(() => {
+      result.current.handleFileInput(event);
+    });
+
+    // Assert
+    await waitFor(() =>
+      expect(result.current.imagePreview).toBe(RESIZED_DATA_URL),
+    );
+    expect(lastCanvasWidth).toBe(800);
+    expect(lastCanvasHeight).toBe(600);
+  });
+
+  it("falls back to the dataUrl when the 2D context is unavailable", async () => {
+    // Arrange: getContext returns null -> resizeImage returns the raw dataUrl.
+    canvasContextNull = true;
+    const { result } = renderHook(() => useImageUpload());
+    const event = {
+      target: { files: [makeFile()] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    // Act
+    act(() => {
+      result.current.handleFileInput(event);
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.imagePreview).toBe(RAW_DATA_URL));
+    expect(result.current.imageBase64).toBe(RAW_DATA_URL);
+  });
+
+  it("falls back to the raw file when image decode fails in the resize pipeline", async () => {
+    // Arrange: Image decode rejects; processFile catch re-reads the raw file.
+    imageShouldFail = true;
+    const { result } = renderHook(() => useImageUpload());
+    const event = {
+      target: { files: [makeFile()] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    // Act
+    act(() => {
+      result.current.handleFileInput(event);
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.imagePreview).toBe(RAW_DATA_URL));
+    expect(result.current.imageBase64).toBe(RAW_DATA_URL);
+  });
+
+  it("handleFileInput ignores an empty file list", () => {
+    // Arrange
+    const { result } = renderHook(() => useImageUpload());
+    const event = {
+      target: { files: [] },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    // Act
+    act(() => {
+      result.current.handleFileInput(event);
+    });
+
+    // Assert
+    expect(result.current.imagePreview).toBeNull();
+  });
+
+  it("handleDrop processes an image file and prevents default", async () => {
+    // Arrange
+    const { result } = renderHook(() => useImageUpload());
+    const preventDefault = vi.fn();
+    const event = {
+      preventDefault,
+      dataTransfer: { files: [makeFile("image/png")] },
+    } as unknown as React.DragEvent;
+
+    // Act
+    act(() => {
+      result.current.handleDrop(event);
+    });
+
+    // Assert
+    expect(preventDefault).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current.imagePreview).toBe(RESIZED_DATA_URL),
+    );
+  });
+
+  it("handleDrop ignores a non-image file (type filter)", () => {
+    // Arrange
+    const { result } = renderHook(() => useImageUpload());
+    const preventDefault = vi.fn();
+    const event = {
+      preventDefault,
+      dataTransfer: { files: [makeFile("application/pdf")] },
+    } as unknown as React.DragEvent;
+
+    // Act
+    act(() => {
+      result.current.handleDrop(event);
+    });
+
+    // Assert
+    expect(preventDefault).toHaveBeenCalled();
+    expect(result.current.imagePreview).toBeNull();
+    expect(result.current.imageBase64).toBeNull();
+  });
+
+  it("clearImage resets preview and base64", async () => {
+    // Arrange: populate state first.
+    const { result } = renderHook(() => useImageUpload());
+    act(() => {
+      result.current.handleFileInput({
+        target: { files: [makeFile()] },
+      } as unknown as React.ChangeEvent<HTMLInputElement>);
+    });
+    await waitFor(() =>
+      expect(result.current.imagePreview).toBe(RESIZED_DATA_URL),
+    );
+
+    // Act
+    act(() => {
+      result.current.clearImage();
+    });
+
+    // Assert
+    expect(result.current.imagePreview).toBeNull();
+    expect(result.current.imageBase64).toBeNull();
+  });
+});

--- a/nexa/src/hooks/use-reports.test.tsx
+++ b/nexa/src/hooks/use-reports.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { act, renderHook } from "@/test";
+
+import type { StoredReport } from "@/lib/reports-store";
+
+// Mock the persistence layer so the hook is exercised in isolation: every
+// reports-store export is a vi.fn we can drive and assert against.
+vi.mock("@/lib/reports-store", () => ({
+  getReports: vi.fn(),
+  getReport: vi.fn(),
+  saveReport: vi.fn(),
+  seedDemoReports: vi.fn(),
+}));
+
+import {
+  getReport,
+  getReports,
+  saveReport,
+  seedDemoReports,
+} from "@/lib/reports-store";
+import { useReports } from "./use-reports";
+
+const mockGetReports = vi.mocked(getReports);
+const mockGetReport = vi.mocked(getReport);
+const mockSaveReport = vi.mocked(saveReport);
+const mockSeed = vi.mocked(seedDemoReports);
+
+function makeStored(overrides: Partial<StoredReport> = {}): StoredReport {
+  return {
+    id: "RPT-1",
+    issueType: "ROAD_DAMAGE",
+    description: "desc",
+    aiDescription: "ai desc",
+    severity: "low",
+    address: "123 Main St",
+    latitude: 1,
+    longitude: 2,
+    imagePreview: null,
+    status: "SUBMITTED",
+    agency: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("useReports", () => {
+  beforeEach(() => {
+    mockGetReports.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes reports from getReports() on mount", () => {
+    // Arrange
+    const initial = [makeStored({ id: "RPT-A" })];
+    mockGetReports.mockReturnValue(initial);
+
+    // Act
+    const { result } = renderHook(() => useReports());
+
+    // Assert
+    expect(result.current.reports).toEqual(initial);
+    expect(mockGetReports).toHaveBeenCalled();
+  });
+
+  it("refresh() re-reads the store into state", () => {
+    // Arrange
+    mockGetReports.mockReturnValue([]);
+    const { result } = renderHook(() => useReports());
+    const updated = [makeStored({ id: "RPT-B" })];
+    mockGetReports.mockReturnValue(updated);
+
+    // Act
+    act(() => {
+      result.current.refresh();
+    });
+
+    // Assert
+    expect(result.current.reports).toEqual(updated);
+  });
+
+  it("addReport() saves via saveReport, refreshes, and returns the created report", () => {
+    // Arrange
+    const created = makeStored({ id: "RPT-NEW" });
+    mockSaveReport.mockReturnValue(created);
+    mockGetReports.mockReturnValue([]);
+    const { result } = renderHook(() => useReports());
+    mockGetReports.mockReturnValue([created]);
+
+    const input = {
+      issueType: "ROAD_DAMAGE",
+      description: "desc",
+      aiDescription: "ai",
+      severity: "low" as const,
+      address: "addr",
+      latitude: 1,
+      longitude: 2,
+      imagePreview: null,
+      agency: null,
+    };
+
+    // Act
+    let returned: StoredReport | undefined;
+    act(() => {
+      returned = result.current.addReport(input);
+    });
+
+    // Assert
+    expect(mockSaveReport).toHaveBeenCalledWith(input);
+    expect(returned).toEqual(created);
+    expect(result.current.reports).toEqual([created]);
+  });
+
+  it("seed() seeds demo data then refreshes the list", () => {
+    // Arrange
+    mockGetReports.mockReturnValue([]);
+    const { result } = renderHook(() => useReports());
+    const seeded = [makeStored({ id: "RPT-DEMO" })];
+    mockGetReports.mockReturnValue(seeded);
+
+    // Act
+    act(() => {
+      result.current.seed();
+    });
+
+    // Assert
+    expect(mockSeed).toHaveBeenCalledTimes(1);
+    expect(result.current.reports).toEqual(seeded);
+  });
+
+  it("exposes getReport passthrough from the store", () => {
+    // Arrange
+    const one = makeStored({ id: "RPT-X" });
+    mockGetReport.mockReturnValue(one);
+    const { result } = renderHook(() => useReports());
+
+    // Act
+    const found = result.current.getReport("RPT-X");
+
+    // Assert
+    expect(mockGetReport).toHaveBeenCalledWith("RPT-X");
+    expect(found).toEqual(one);
+  });
+});

--- a/nexa/src/hooks/use-speech-recognition.test.tsx
+++ b/nexa/src/hooks/use-speech-recognition.test.tsx
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { act, renderHook } from "@/test";
+
+import { useSpeechRecognition } from "./use-speech-recognition";
+
+// ---------------------------------------------------------------------------
+// Fake SpeechRecognition: captures the configured handlers so a test can fire
+// onresult/onerror/onend and assert the hook's reaction.
+// ---------------------------------------------------------------------------
+
+interface ResultEntry {
+  isFinal: boolean;
+  transcript: string;
+}
+
+class FakeSpeechRecognition {
+  static instances: FakeSpeechRecognition[] = [];
+  static startThrows = false;
+  lang = "";
+  continuous = false;
+  interimResults = false;
+  onresult: ((event: unknown) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  start = vi.fn(() => {
+    if (FakeSpeechRecognition.startThrows) throw new Error("boom");
+  });
+  stop = vi.fn();
+
+  constructor() {
+    FakeSpeechRecognition.instances.push(this);
+  }
+
+  /** Drive onresult with a synthetic result list (resultIndex 0). */
+  fireResult(entries: ResultEntry[]) {
+    const results = entries.map((e) => ({
+      isFinal: e.isFinal,
+      0: { transcript: e.transcript },
+    }));
+    this.onresult?.({
+      resultIndex: 0,
+      results: Object.assign(results, { length: results.length }),
+    });
+  }
+}
+
+function lastInstance() {
+  const all = FakeSpeechRecognition.instances;
+  return all[all.length - 1];
+}
+
+describe("useSpeechRecognition", () => {
+  beforeEach(() => {
+    FakeSpeechRecognition.instances = [];
+    FakeSpeechRecognition.startThrows = false;
+    vi.stubGlobal("SpeechRecognition", FakeSpeechRecognition);
+    // Ensure no webkit-prefixed leftover interferes.
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("reports supported=true via useSyncExternalStore when a ctor exists", () => {
+    // Arrange / Act
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Assert
+    expect(result.current.supported).toBe(true);
+    expect(result.current.listening).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("reports supported=false when no SpeechRecognition ctor exists", () => {
+    // Arrange
+    vi.stubGlobal("SpeechRecognition", undefined);
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+
+    // Act
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Assert
+    expect(result.current.supported).toBe(false);
+  });
+
+  it("start() configures lang/continuous/interim and begins listening", () => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Act
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Assert
+    const instance = lastInstance();
+    expect(instance.start).toHaveBeenCalledTimes(1);
+    expect(instance.continuous).toBe(false);
+    expect(instance.interimResults).toBe(false);
+    expect(instance.lang).toBe(navigator.language);
+    expect(result.current.listening).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("start() sets an error and does not construct when unsupported", () => {
+    // Arrange
+    vi.stubGlobal("SpeechRecognition", undefined);
+    vi.stubGlobal("webkitSpeechRecognition", undefined);
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Act
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Assert
+    expect(result.current.error).toBe("speech.unsupported");
+    expect(result.current.listening).toBe(false);
+  });
+
+  it("start() guards against a double-start (no second instance)", () => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Act: second start while one is active.
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Assert: only one recognition instance was ever constructed.
+    expect(FakeSpeechRecognition.instances).toHaveLength(1);
+  });
+
+  it("onresult invokes the callback only for final results, trimmed", () => {
+    // Arrange
+    const onFinal = vi.fn();
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(onFinal);
+    });
+
+    // Act
+    act(() => {
+      lastInstance().fireResult([
+        { isFinal: false, transcript: "interim text" },
+        { isFinal: true, transcript: "  final text  " },
+      ]);
+    });
+
+    // Assert
+    expect(onFinal).toHaveBeenCalledTimes(1);
+    expect(onFinal).toHaveBeenCalledWith("final text");
+  });
+
+  it("onresult ignores a final result whose transcript is empty after trim", () => {
+    // Arrange
+    const onFinal = vi.fn();
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(onFinal);
+    });
+
+    // Act
+    act(() => {
+      lastInstance().fireResult([{ isFinal: true, transcript: "   " }]);
+    });
+
+    // Assert
+    expect(onFinal).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["not-allowed", "speech.denied"],
+    ["service-not-allowed", "speech.denied"],
+    ["no-speech", "speech.noSpeech"],
+    ["audio-capture", "speech.noMicrophone"],
+    ["network", "speech.failed"],
+  ])("onerror(%s) maps to its message key", (code, message) => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Act
+    act(() => {
+      lastInstance().onerror?.({ error: code });
+    });
+
+    // Assert
+    expect(result.current.error).toBe(message);
+  });
+
+  it("onend clears listening and allows a fresh start afterwards", () => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Act
+    act(() => {
+      lastInstance().onend?.();
+    });
+
+    // Assert: listening false, and ref cleared so a new start builds a 2nd instance.
+    expect(result.current.listening).toBe(false);
+    act(() => {
+      result.current.start(vi.fn());
+    });
+    expect(FakeSpeechRecognition.instances).toHaveLength(2);
+  });
+
+  it("stop() calls stop() on the active recognition instance", () => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(vi.fn());
+    });
+    const instance = lastInstance();
+
+    // Act
+    act(() => {
+      result.current.stop();
+    });
+
+    // Assert
+    expect(instance.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() is a no-op when not listening", () => {
+    // Arrange
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Act / Assert: no instance exists, so nothing throws.
+    expect(() => {
+      act(() => {
+        result.current.stop();
+      });
+    }).not.toThrow();
+  });
+
+  it("sets an error if start() throws while starting", () => {
+    // Arrange: the recognition instance's start() throws.
+    FakeSpeechRecognition.startThrows = true;
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    // Act
+    act(() => {
+      result.current.start(vi.fn());
+    });
+
+    // Assert
+    expect(result.current.error).toBe("speech.startFailed");
+    expect(result.current.listening).toBe(false);
+  });
+
+  it("unmount stops the active recognition (cleanup effect)", () => {
+    // Arrange
+    const { result, unmount } = renderHook(() => useSpeechRecognition());
+    act(() => {
+      result.current.start(vi.fn());
+    });
+    const instance = lastInstance();
+
+    // Act
+    unmount();
+
+    // Assert
+    expect(instance.stop).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #118.

Colocated hook tests in the jsdom Vitest project using \`renderHook\`/\`act\`, with all browser APIs and the persistence/reverse-geocode layers mocked. Reuses the \`src/test\` foundation (#112) — no duplicate mocks.

## Files added
- \`src/hooks/use-reports.test.tsx\`
- \`src/hooks/use-geolocation.test.tsx\`
- \`src/hooks/use-image-upload.test.tsx\`
- \`src/hooks/use-speech-recognition.test.tsx\`

## Coverage
- **use-reports** — `getReports` init, `refresh`, `addReport` (saveReport + refresh + return), `seed`, `getReport` passthrough; \`@/lib/reports-store\` mocked.
- **use-geolocation** — unsupported error, success (coords + accuracy + reverse-geocoded address), reverse-geocode coordinate fallback, PERMISSION_DENIED/POSITION_UNAVAILABLE/TIMEOUT message mapping, `setCoordinates`/`movePin`/`reset`/`setAddress`; \`navigator.geolocation\` and the reverse-geocode path mocked.
- **use-image-upload** — resize >1280 via canvas `toDataURL('image/jpeg', 0.82)`, within-bounds passthrough, null-context fallback, decode-failure raw fallback, empty file-list guard, `handleDrop` image-type filter, `clearImage`; FileReader/Image/canvas faked.
- **use-speech-recognition** — `useSyncExternalStore` supported flag (true/false), start guards (unsupported + double-start), lang/continuous/interim config, final-only `onresult` (trimmed, ignores empty), `onerror` key mapping, `onend`/`stop`/unmount cleanup, start-throws path.

## Verification
- \`npm test\` — 8 files, 51 tests pass (42 new).
- \`npx tsc --noEmit\` — clean.
- eslint + prettier clean on the new files.

Out of scope per #118: component tests, real reports-store unit tests, and the newer report-page hooks (use-address-lookup etc.).