### PR TITLE
refactor: extract report-page API orchestration into hooks [#128]

### DIFF
--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -8,56 +8,10 @@ import { ReviewStep } from "@/components/report/review-step";
 import { ConfirmedStep } from "@/components/report/confirmed-step";
 import { useImageUpload } from "@/hooks/use-image-upload";
 import { useGeolocation } from "@/hooks/use-geolocation";
+import { useAddressLookup } from "@/hooks/use-address-lookup";
+import { useFormLookup } from "@/hooks/use-form-lookup";
+import { useReportSubmission } from "@/hooks/use-report-submission";
 import { useI18n } from "@/i18n/provider";
-import { queueReport } from "@/lib/offline-queue";
-
-interface ClassificationResult {
-  issueType: string;
-  aiDescription: string;
-  severity: "low" | "medium" | "high";
-  confidence?: number;
-}
-
-interface ProviderResult extends ClassificationResult {
-  provider: string;
-  latencyMs: number;
-}
-
-interface ComparisonResponse {
-  winner: ClassificationResult;
-  allResults: ProviderResult[];
-  consensus: boolean;
-  method: string;
-}
-
-interface CreatedReport {
-  id: string;
-  issueType: string | null;
-  description: string | null;
-  aiDescription: string | null;
-  createdAt: string;
-}
-
-type OfficialFormLookupResult =
-  | {
-      status: "found";
-      cityName: string;
-      formUrl: string;
-      reason: string;
-      confidence: "low" | "medium" | "high";
-    }
-  | {
-      status: "not_found";
-      cityName: string | null;
-      message: string;
-      reason?: string;
-    };
-
-interface AddressSuggestion {
-  displayName: string;
-  latitude: number;
-  longitude: number;
-}
 
 export default function ReportPage() {
   const posthog = usePostHog();
@@ -72,124 +26,14 @@ export default function ReportPage() {
 
   const image = useImageUpload();
   const geo = useGeolocation();
-
-  const [classifying, setClassifying] = useState(false);
-  const [classification, setClassification] =
-    useState<ClassificationResult | null>(null);
-  const [comparison, setComparison] = useState<ComparisonResponse | null>(null);
-  const [classifyError, setClassifyError] = useState<string | null>(null);
-
-  const [submitting, setSubmitting] = useState(false);
-  const [createdReport, setCreatedReport] = useState<CreatedReport | null>(
-    null,
-  );
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submittedOffline, setSubmittedOffline] = useState(false);
-  const [officialForm, setOfficialForm] =
-    useState<OfficialFormLookupResult | null>(null);
-  const [officialFormLoading, setOfficialFormLoading] = useState(false);
-  const [addressSuggestions, setAddressSuggestions] = useState<
-    AddressSuggestion[]
-  >([]);
-  const [locationSuggesting, setLocationSuggesting] = useState(false);
-  const addressLookupTimerRef = useRef<number | null>(null);
-  const addressLookupRequestRef = useRef(0);
-
-  useEffect(() => {
-    return () => {
-      if (addressLookupTimerRef.current) {
-        window.clearTimeout(addressLookupTimerRef.current);
-      }
-    };
-  }, []);
-
-  const lookupAddressSuggestions = (query: string) => {
-    if (addressLookupTimerRef.current) {
-      window.clearTimeout(addressLookupTimerRef.current);
-      addressLookupTimerRef.current = null;
-    }
-
-    const trimmed = query.trim();
-    if (trimmed.length < 3) {
-      setAddressSuggestions([]);
-      setLocationSuggesting(false);
-      return;
-    }
-
-    setLocationSuggesting(true);
-    addressLookupTimerRef.current = window.setTimeout(async () => {
-      const requestId = ++addressLookupRequestRef.current;
-
-      try {
-        const response = await fetch(
-          `/api/location/suggest?q=${encodeURIComponent(trimmed)}`,
-        );
-        if (!response.ok) throw new Error("Location suggestion lookup failed.");
-
-        const data = (await response.json()) as {
-          suggestions?: AddressSuggestion[];
-        };
-        if (requestId !== addressLookupRequestRef.current) return;
-
-        setAddressSuggestions(data.suggestions ?? []);
-      } catch (e) {
-        if (requestId !== addressLookupRequestRef.current) return;
-        console.error("Address suggestion lookup failed:", e);
-        setAddressSuggestions([]);
-      } finally {
-        if (requestId !== addressLookupRequestRef.current) return;
-        setLocationSuggesting(false);
-      }
-    }, 250);
-  };
-
-  const lookupOfficialForm = async (issueType: string) => {
-    const hasLocation =
-      !!geo.address.trim() ||
-      (typeof geo.latitude === "number" && typeof geo.longitude === "number");
-
-    if (!hasLocation) {
-      setOfficialForm({
-        status: "not_found",
-        cityName: null,
-        message: t("report.noOfficialForm"),
-        reason: t("report.locationPlaceholder"),
-      });
-      return;
-    }
-
-    setOfficialFormLoading(true);
-    try {
-      const res = await fetch("/api/reports/form-link", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          issueType,
-          address: geo.address || undefined,
-          latitude: geo.latitude ?? undefined,
-          longitude: geo.longitude ?? undefined,
-        }),
-      });
-      if (!res.ok) throw new Error(t("report.noOfficialForm"));
-      const result: OfficialFormLookupResult = await res.json();
-      setOfficialForm(result);
-    } catch (err) {
-      console.error("Official form lookup failed:", err);
-      setOfficialForm({
-        status: "not_found",
-        cityName: null,
-        message: t("report.noOfficialForm"),
-        reason: err instanceof Error ? err.message : t("report.noOfficialForm"),
-      });
-    } finally {
-      setOfficialFormLoading(false);
-    }
-  };
+  const addressLookup = useAddressLookup();
+  const formLookup = useFormLookup();
+  const submission = useReportSubmission();
 
   const handleAddressChange = (value: string) => {
     geo.setAddress(value);
 
-    const selectedSuggestion = addressSuggestions.find(
+    const selectedSuggestion = addressLookup.suggestions.find(
       (suggestion) => suggestion.displayName === value,
     );
 
@@ -198,138 +42,83 @@ export default function ReportPage() {
         selectedSuggestion.latitude,
         selectedSuggestion.longitude,
       );
-      setAddressSuggestions([]);
-      setLocationSuggesting(false);
+      addressLookup.setSuggestions([]);
+      addressLookup.setSuggesting(false);
       return;
     }
 
     geo.setCoordinates(null, null);
-    lookupAddressSuggestions(value);
+    addressLookup.lookup(value);
   };
 
   const handleClassify = async () => {
-    setClassifying(true);
-    setClassifyError(null);
-    try {
-      setOfficialForm(null);
-      const res = await fetch("/api/reports/classify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          description,
-          imageBase64: image.imageBase64,
-          latitude: geo.latitude ?? undefined,
-          longitude: geo.longitude ?? undefined,
-          address: geo.address || undefined,
-        }),
-      });
-
-      // Read the raw body once so non-JSON responses surface a useful error
-      // instead of Safari's cryptic "did not match the expected pattern".
-      const rawBody = await res.text();
-      let payload: unknown = null;
-      try {
-        payload = rawBody ? JSON.parse(rawBody) : null;
-      } catch {
-        throw new Error(
-          `Classification failed (HTTP ${res.status}). Server returned a non-JSON response.`,
-        );
-      }
-
-      if (!res.ok) {
-        const message =
-          (payload as { error?: string } | null)?.error ??
-          `Classification failed (HTTP ${res.status}).`;
-        throw new Error(message);
-      }
-
-      const data = payload as ComparisonResponse;
-      setComparison(data);
-      setClassification(data.winner);
-      void lookupOfficialForm(data.winner.issueType);
-      setStep("review");
-      posthog?.capture("report_classified", {
-        issue_type: data.winner.issueType,
-        severity: data.winner.severity,
-        has_image: !!image.imageBase64,
-        has_location: !!geo.latitude,
-      });
-    } catch (e) {
-      console.error("Report classification failed:", e);
-      setClassifyError(
-        e instanceof Error ? e.message : t("common.somethingWrong"),
-      );
-    } finally {
-      setClassifying(false);
-    }
+    formLookup.setOfficialForm(null);
+    await submission.classify(
+      {
+        description,
+        imageBase64: image.imageBase64,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        address: geo.address,
+      },
+      {
+        onSuccess: (data) => {
+          void formLookup.lookup(data.winner.issueType, {
+            address: geo.address,
+            latitude: geo.latitude,
+            longitude: geo.longitude,
+          });
+          setStep("review");
+          posthog?.capture("report_classified", {
+            issue_type: data.winner.issueType,
+            severity: data.winner.severity,
+            has_image: !!image.imageBase64,
+            has_location: !!geo.latitude,
+          });
+        },
+        errorFallback: t("common.somethingWrong"),
+      },
+    );
   };
 
   const handleSubmit = async () => {
-    if (!classification) return;
-    setSubmitting(true);
-    setSubmitError(null);
-
-    const payload = {
-      description,
-      aiDescription: classification.aiDescription,
-      issueType: classification.issueType,
-      latitude: geo.latitude,
-      longitude: geo.longitude,
-      address: geo.address,
-      imageUrl: image.imageBase64,
-    };
-
-    try {
-      const res = await fetch("/api/reports", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error || t("report.submit"));
-      }
-
-      const report: CreatedReport = await res.json();
-      setCreatedReport(report);
-      setSubmittedOffline(false);
-      setStep("confirmed");
-      posthog?.capture("report_submitted", {
-        report_id: report.id,
-        issue_type: classification.issueType,
-        time_to_submit_ms: Date.now() - flowStartedAt.current,
-        has_image: !!image.imageBase64,
-        has_location: !!geo.latitude,
-      });
-    } catch (e) {
-      console.error("Report submission failed:", e);
-      // No connectivity: park the report locally and confirm optimistically.
-      // PwaSetup replays the queue once the browser is back online.
-      if (typeof navigator !== "undefined" && !navigator.onLine) {
-        queueReport(payload);
-        setCreatedReport({
-          id: "Pending sync",
-          issueType: classification.issueType,
-          description,
-          aiDescription: classification.aiDescription,
-          createdAt: new Date().toISOString(),
-        });
-        setSubmittedOffline(true);
-        setStep("confirmed");
-        posthog?.capture("report_queued_offline", {
-          issue_type: classification.issueType,
-          has_image: !!image.imageBase64,
-          has_location: !!geo.latitude,
-        });
-      } else {
-        setSubmitError(
-          e instanceof Error ? e.message : t("common.somethingWrong"),
-        );
-      }
-    } finally {
-      setSubmitting(false);
-    }
+    if (!submission.classification) return;
+    const classification = submission.classification;
+    await submission.submit(
+      {
+        description,
+        classification,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        address: geo.address,
+        imageBase64: image.imageBase64,
+      },
+      {
+        onSuccess: (report) => {
+          setStep("confirmed");
+          posthog?.capture("report_submitted", {
+            report_id: report.id,
+            issue_type: classification.issueType,
+            time_to_submit_ms: Date.now() - flowStartedAt.current,
+            has_image: !!image.imageBase64,
+            has_location: !!geo.latitude,
+          });
+        },
+        onQueuedOffline: () => {
+          setStep("confirmed");
+          posthog?.capture("report_queued_offline", {
+            issue_type: classification.issueType,
+            has_image: !!image.imageBase64,
+            has_location: !!geo.latitude,
+          });
+        },
+        // Two intentionally distinct fallbacks (do not merge):
+        // `okFallback` covers the `/api/reports` `!res.ok` branch, while
+        // `offlineElseFallback` covers the catch's online (offline-ELSE) path.
+        okFallback: t("report.submit"),
+        offlineElseFallback: t("common.somethingWrong"),
+      },
+    );
   };
 
   const resetForm = () => {
@@ -338,20 +127,9 @@ export default function ReportPage() {
     setDescription("");
     image.clearImage();
     geo.reset();
-    setAddressSuggestions([]);
-    setLocationSuggesting(false);
-    if (addressLookupTimerRef.current) {
-      window.clearTimeout(addressLookupTimerRef.current);
-      addressLookupTimerRef.current = null;
-    }
-    setClassification(null);
-    setComparison(null);
-    setCreatedReport(null);
-    setClassifyError(null);
-    setSubmitError(null);
-    setSubmittedOffline(false);
-    setOfficialForm(null);
-    setOfficialFormLoading(false);
+    addressLookup.reset();
+    submission.reset();
+    formLookup.reset();
   };
 
   return (
@@ -372,13 +150,13 @@ export default function ReportPage() {
             longitude={geo.longitude}
             accuracy={geo.accuracy}
             locationLoading={geo.loading}
-            locationSuggesting={locationSuggesting}
-            addressSuggestions={addressSuggestions.map(
+            locationSuggesting={addressLookup.suggesting}
+            addressSuggestions={addressLookup.suggestions.map(
               (suggestion) => suggestion.displayName,
             )}
             locationError={geo.error}
-            classifying={classifying}
-            classifyError={classifyError}
+            classifying={submission.classifying}
+            classifyError={submission.classifyError}
             canSubmit={!!(image.imageBase64 || description.trim())}
             onImageClick={() => document.getElementById("photo-input")?.click()}
             onDrop={image.handleDrop}
@@ -391,85 +169,90 @@ export default function ReportPage() {
           />
         )}
 
-        {step === "review" && classification && (
+        {step === "review" && submission.classification && (
           <>
             <ReviewStep
-              classification={classification}
+              classification={submission.classification}
               imagePreview={image.imagePreview}
               description={description}
               address={geo.address}
-              submitting={submitting}
-              submitError={submitError}
-              officialForm={officialForm}
-              officialFormLoading={officialFormLoading}
+              submitting={submission.submitting}
+              submitError={submission.submitError}
+              officialForm={formLookup.officialForm}
+              officialFormLoading={formLookup.loading}
               onDescriptionChange={setDescription}
               onAddressChange={geo.setAddress}
               onBack={() => setStep("describe")}
               onSubmit={handleSubmit}
             />
 
-            {comparison && comparison.allResults.length > 1 && (
-              <div className="mt-10">
-                <span className="section-label">
-                  {t("report.aiComparison")}
-                </span>
-                <p className="mt-2 mb-4 text-sm text-muted-foreground">
-                  {t("report.decisionMethod")}{" "}
-                  <span className="font-medium text-foreground">
-                    {comparison.method}
-                  </span>
-                  {comparison.consensus && t("report.modelsAgreed")}
-                </p>
-                <div className="flex flex-col gap-3">
-                  {comparison.allResults.map((r) => (
-                    <div
-                      key={r.provider}
-                      className={`ep-card p-4 ${r.issueType === comparison.winner.issueType ? "ring-2 ring-ep-green/40" : "opacity-60"}`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="font-mono text-xs font-medium uppercase tracking-wider">
-                          {r.provider}
-                        </span>
-                        <span className="font-mono text-xs text-muted-foreground">
-                          {r.latencyMs}ms
-                        </span>
-                      </div>
-                      <div className="mt-2 flex items-center gap-3">
-                        <span className="text-sm font-semibold">
-                          {t(`issue.${r.issueType}`)}
-                        </span>
-                        <span
-                          className={`rounded-full px-2 py-0.5 font-mono text-xs uppercase ${
-                            r.severity === "high"
-                              ? "bg-red-50 text-red-600"
-                              : r.severity === "medium"
-                                ? "bg-yellow-50 text-yellow-600"
-                                : "bg-ep-green-light text-ep-green"
-                          }`}
+            {submission.comparison &&
+              submission.comparison.allResults.length > 1 &&
+              (() => {
+                const comparison = submission.comparison;
+                return (
+                  <div className="mt-10">
+                    <span className="section-label">
+                      {t("report.aiComparison")}
+                    </span>
+                    <p className="mt-2 mb-4 text-sm text-muted-foreground">
+                      {t("report.decisionMethod")}{" "}
+                      <span className="font-medium text-foreground">
+                        {comparison.method}
+                      </span>
+                      {comparison.consensus && t("report.modelsAgreed")}
+                    </p>
+                    <div className="flex flex-col gap-3">
+                      {comparison.allResults.map((r) => (
+                        <div
+                          key={r.provider}
+                          className={`ep-card p-4 ${r.issueType === comparison.winner.issueType ? "ring-2 ring-ep-green/40" : "opacity-60"}`}
                         >
-                          {t(`severity.${r.severity}`)}
-                        </span>
-                        <span className="font-mono text-xs text-muted-foreground">
-                          {t("report.confident", {
-                            percent: Math.round((r.confidence ?? 0) * 100),
-                          })}
-                        </span>
-                      </div>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {r.aiDescription}
-                      </p>
+                          <div className="flex items-center justify-between">
+                            <span className="font-mono text-xs font-medium uppercase tracking-wider">
+                              {r.provider}
+                            </span>
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {r.latencyMs}ms
+                            </span>
+                          </div>
+                          <div className="mt-2 flex items-center gap-3">
+                            <span className="text-sm font-semibold">
+                              {t(`issue.${r.issueType}`)}
+                            </span>
+                            <span
+                              className={`rounded-full px-2 py-0.5 font-mono text-xs uppercase ${
+                                r.severity === "high"
+                                  ? "bg-red-50 text-red-600"
+                                  : r.severity === "medium"
+                                    ? "bg-yellow-50 text-yellow-600"
+                                    : "bg-ep-green-light text-ep-green"
+                              }`}
+                            >
+                              {t(`severity.${r.severity}`)}
+                            </span>
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {t("report.confident", {
+                                percent: Math.round((r.confidence ?? 0) * 100),
+                              })}
+                            </span>
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {r.aiDescription}
+                          </p>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              </div>
-            )}
+                  </div>
+                );
+              })()}
           </>
         )}
 
-        {step === "confirmed" && createdReport && (
+        {step === "confirmed" && submission.createdReport && (
           <ConfirmedStep
-            report={createdReport}
-            offline={submittedOffline}
+            report={submission.createdReport}
+            offline={submission.submittedOffline}
             onReportAnother={resetForm}
           />
         )}

--- a/nexa/src/hooks/use-address-lookup.ts
+++ b/nexa/src/hooks/use-address-lookup.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface AddressSuggestion {
+  displayName: string;
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Debounced address-suggestion lookup against `/api/location/suggest`.
+ *
+ * Extracted from the report page so the component stays focused on UI/step
+ * state. Owns the debounce timer and a monotonic request counter so a slow
+ * earlier response never overwrites a newer one.
+ */
+export function useAddressLookup() {
+  const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
+  const [suggesting, setSuggesting] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const lookup = useCallback((query: string) => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    const trimmed = query.trim();
+    if (trimmed.length < 3) {
+      setSuggestions([]);
+      setSuggesting(false);
+      return;
+    }
+
+    setSuggesting(true);
+    timerRef.current = window.setTimeout(async () => {
+      const requestId = ++requestRef.current;
+
+      try {
+        const response = await fetch(
+          `/api/location/suggest?q=${encodeURIComponent(trimmed)}`,
+        );
+        if (!response.ok) throw new Error("Location suggestion lookup failed.");
+
+        const data = (await response.json()) as {
+          suggestions?: AddressSuggestion[];
+        };
+        if (requestId !== requestRef.current) return;
+
+        setSuggestions(data.suggestions ?? []);
+      } catch (e) {
+        if (requestId !== requestRef.current) return;
+        console.error("Address suggestion lookup failed:", e);
+        setSuggestions([]);
+      } finally {
+        if (requestId !== requestRef.current) return;
+        setSuggesting(false);
+      }
+    }, 250);
+  }, []);
+
+  const reset = useCallback(() => {
+    setSuggestions([]);
+    setSuggesting(false);
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return {
+    suggestions,
+    suggesting,
+    lookup,
+    setSuggestions,
+    setSuggesting,
+    reset,
+  };
+}

--- a/nexa/src/hooks/use-form-lookup.ts
+++ b/nexa/src/hooks/use-form-lookup.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useI18n } from "@/i18n/provider";
+
+export type OfficialFormLookupResult =
+  | {
+      status: "found";
+      cityName: string;
+      formUrl: string;
+      reason: string;
+      confidence: "low" | "medium" | "high";
+    }
+  | {
+      status: "not_found";
+      cityName: string | null;
+      message: string;
+      reason?: string;
+    };
+
+export interface FormLookupLocation {
+  address: string;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+/**
+ * Looks up the official municipal reporting form for an issue + location via
+ * `/api/reports/form-link`. Extracted from the report page; owns the
+ * `officialForm` result and its loading flag.
+ */
+export function useFormLookup() {
+  const { t } = useI18n();
+  const [officialForm, setOfficialForm] =
+    useState<OfficialFormLookupResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const lookup = useCallback(
+    async (issueType: string, location: FormLookupLocation) => {
+      const hasLocation =
+        !!location.address.trim() ||
+        (typeof location.latitude === "number" &&
+          typeof location.longitude === "number");
+
+      if (!hasLocation) {
+        setOfficialForm({
+          status: "not_found",
+          cityName: null,
+          message: t("report.noOfficialForm"),
+          reason: t("report.locationPlaceholder"),
+        });
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const res = await fetch("/api/reports/form-link", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            issueType,
+            address: location.address || undefined,
+            latitude: location.latitude ?? undefined,
+            longitude: location.longitude ?? undefined,
+          }),
+        });
+        if (!res.ok) throw new Error(t("report.noOfficialForm"));
+        const result: OfficialFormLookupResult = await res.json();
+        setOfficialForm(result);
+      } catch (err) {
+        console.error("Official form lookup failed:", err);
+        setOfficialForm({
+          status: "not_found",
+          cityName: null,
+          message: t("report.noOfficialForm"),
+          reason:
+            err instanceof Error ? err.message : t("report.noOfficialForm"),
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [t],
+  );
+
+  const reset = useCallback(() => {
+    setOfficialForm(null);
+    setLoading(false);
+  }, []);
+
+  return { officialForm, loading, lookup, setOfficialForm, reset };
+}

--- a/nexa/src/hooks/use-report-submission.ts
+++ b/nexa/src/hooks/use-report-submission.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { queueReport } from "@/lib/offline-queue";
+
+export interface ClassificationResult {
+  issueType: string;
+  aiDescription: string;
+  severity: "low" | "medium" | "high";
+  confidence?: number;
+}
+
+export interface ProviderResult extends ClassificationResult {
+  provider: string;
+  latencyMs: number;
+}
+
+export interface ComparisonResponse {
+  winner: ClassificationResult;
+  allResults: ProviderResult[];
+  consensus: boolean;
+  method: string;
+}
+
+export interface CreatedReport {
+  id: string;
+  issueType: string | null;
+  description: string | null;
+  aiDescription: string | null;
+  createdAt: string;
+}
+
+export interface ClassifyInput {
+  description: string;
+  imageBase64: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  address: string;
+}
+
+export interface SubmitInput {
+  description: string;
+  classification: ClassificationResult;
+  latitude: number | null;
+  longitude: number | null;
+  address: string;
+  imageBase64: string | null;
+}
+
+export interface ClassifyCallbacks {
+  /** Called with the winning result so the page can sync derived state. */
+  onSuccess: (data: ComparisonResponse) => void;
+  /** Localized fallback message when the error is not an `Error` instance. */
+  errorFallback: string;
+}
+
+export interface SubmitCallbacks {
+  onSuccess: (report: CreatedReport) => void;
+  onQueuedOffline: (report: CreatedReport) => void;
+  /**
+   * Fallback for the `/api/reports` `!res.ok` branch — used when the server
+   * response omits an `error`. Distinct from {@link offlineElseFallback}.
+   */
+  okFallback: string;
+  /**
+   * Fallback for the catch's offline-ELSE branch (online failure) — distinct
+   * from {@link okFallback}; the two are intentionally NOT merged.
+   */
+  offlineElseFallback: string;
+}
+
+/**
+ * Owns the classify + submit API orchestration for the report flow:
+ * fetch/parse/error handling and the loading/result/error state. Extracted
+ * from the report page so the component stays a thin consumer.
+ */
+export function useReportSubmission() {
+  const [classifying, setClassifying] = useState(false);
+  const [classification, setClassification] =
+    useState<ClassificationResult | null>(null);
+  const [comparison, setComparison] = useState<ComparisonResponse | null>(null);
+  const [classifyError, setClassifyError] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [createdReport, setCreatedReport] = useState<CreatedReport | null>(
+    null,
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submittedOffline, setSubmittedOffline] = useState(false);
+
+  const classify = useCallback(
+    async (input: ClassifyInput, callbacks: ClassifyCallbacks) => {
+      setClassifying(true);
+      setClassifyError(null);
+      try {
+        const res = await fetch("/api/reports/classify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            description: input.description,
+            imageBase64: input.imageBase64,
+            latitude: input.latitude ?? undefined,
+            longitude: input.longitude ?? undefined,
+            address: input.address || undefined,
+          }),
+        });
+
+        // Read the raw body once so non-JSON responses surface a useful error
+        // instead of Safari's cryptic "did not match the expected pattern".
+        const rawBody = await res.text();
+        let payload: unknown = null;
+        try {
+          payload = rawBody ? JSON.parse(rawBody) : null;
+        } catch {
+          throw new Error(
+            `Classification failed (HTTP ${res.status}). Server returned a non-JSON response.`,
+          );
+        }
+
+        if (!res.ok) {
+          const message =
+            (payload as { error?: string } | null)?.error ??
+            `Classification failed (HTTP ${res.status}).`;
+          throw new Error(message);
+        }
+
+        const data = payload as ComparisonResponse;
+        setComparison(data);
+        setClassification(data.winner);
+        callbacks.onSuccess(data);
+      } catch (e) {
+        console.error("Report classification failed:", e);
+        setClassifyError(
+          e instanceof Error ? e.message : callbacks.errorFallback,
+        );
+      } finally {
+        setClassifying(false);
+      }
+    },
+    [],
+  );
+
+  const submit = useCallback(
+    async (input: SubmitInput, callbacks: SubmitCallbacks) => {
+      setSubmitting(true);
+      setSubmitError(null);
+
+      const payload = {
+        description: input.description,
+        aiDescription: input.classification.aiDescription,
+        issueType: input.classification.issueType,
+        latitude: input.latitude,
+        longitude: input.longitude,
+        address: input.address,
+        imageUrl: input.imageBase64,
+      };
+
+      try {
+        const res = await fetch("/api/reports", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err.error || callbacks.okFallback);
+        }
+
+        const report: CreatedReport = await res.json();
+        setCreatedReport(report);
+        setSubmittedOffline(false);
+        callbacks.onSuccess(report);
+      } catch (e) {
+        console.error("Report submission failed:", e);
+        // No connectivity: park the report locally and confirm optimistically.
+        // PwaSetup replays the queue once the browser is back online.
+        if (typeof navigator !== "undefined" && !navigator.onLine) {
+          queueReport(payload);
+          const queued: CreatedReport = {
+            id: "Pending sync",
+            issueType: input.classification.issueType,
+            description: input.description,
+            aiDescription: input.classification.aiDescription,
+            createdAt: new Date().toISOString(),
+          };
+          setCreatedReport(queued);
+          setSubmittedOffline(true);
+          callbacks.onQueuedOffline(queued);
+        } else {
+          setSubmitError(
+            e instanceof Error ? e.message : callbacks.offlineElseFallback,
+          );
+        }
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setClassification(null);
+    setComparison(null);
+    setCreatedReport(null);
+    setClassifyError(null);
+    setSubmitError(null);
+    setSubmittedOffline(false);
+  }, []);
+
+  return {
+    classifying,
+    classification,
+    comparison,
+    classifyError,
+    submitting,
+    createdReport,
+    submitError,
+    submittedOffline,
+    classify,
+    submit,
+    reset,
+  };
+}


### PR DESCRIPTION
Closes #128.

## What
`src/app/report/page.tsx` conflated UI/step state with direct API-client orchestration. This extracts the client-side classify / submit / location-suggest / form-link orchestration (fetch + parse + error + loading/result state) into three custom hooks under `src/hooks/`, leaving the page a thin consumer. **Refactor only — behavior preserved exactly.**

The page shrinks from 488 LOC to ~270 (148 insertions / 365 deletions) and its direct `useState` count drops as orchestration state moves into the hooks. The page no longer issues any `fetch` calls directly.

## Hooks created
- `src/hooks/use-address-lookup.ts` — debounced `/api/location/suggest` lookup; owns the debounce timer + monotonic request-id refs and `suggestions`/`suggesting` state (was page lines 102-139 + the cleanup effect).
- `src/hooks/use-form-lookup.ts` — `/api/reports/form-link` lookup; owns `officialForm` + `loading` (was page lines 141-184).
- `src/hooks/use-report-submission.ts` — classify + submit; owns `classifying`/`classification`/`comparison`/`classifyError` and `submitting`/`createdReport`/`submitError`/`submittedOffline` (was page lines 207-300).

All three follow the existing `src/hooks/` conventions (`"use client"`, `useState`/`useCallback`/`useRef`, named export, object return).

## Behavior equivalence — before → after call sites
| Original (page) | After |
|---|---|
| `lookupAddressSuggestions(q)` (102-139) | `addressLookup.lookup(q)` |
| inline `setAddressSuggestions([])` / `setLocationSuggesting(false)` on suggestion select | `addressLookup.setSuggestions([])` / `addressLookup.setSuggesting(false)` |
| `lookupOfficialForm(issueType)` (141-184) | `formLookup.lookup(issueType, { address, latitude, longitude })` |
| `setOfficialForm(null)` at start of classify | `formLookup.setOfficialForm(null)` before `submission.classify(...)` |
| `handleClassify` fetch/parse (207-259) | `submission.classify(input, { onSuccess, errorFallback })` — page's `onSuccess` keeps `formLookup.lookup`, `setStep("review")` and the `report_classified` PostHog capture |
| `handleSubmit` fetch/parse (261-300) | `submission.submit(input, { onSuccess, onQueuedOffline, okFallback, offlineElseFallback })` — page callbacks keep `setStep("confirmed")` and the `report_submitted` / `report_queued_offline` PostHog captures |
| `resetForm` per-field resets | `addressLookup.reset()` + `submission.reset()` + `formLookup.reset()` (same fields cleared) |

The classify/submit request payloads, the raw-body-then-JSON parse guard (Safari non-JSON handling), the offline-queue path (`queueReport` + optimistic "Pending sync" confirmation), and the AI-comparison render block are all unchanged.

## Two flagged points explicitly preserved
1. **`console.error` logging preserved.** Each catch block's logging moved verbatim into the owning hook:
   - `"Address suggestion lookup failed:"` → `use-address-lookup.ts`
   - `"Official form lookup failed:"` → `use-form-lookup.ts`
   - `"Report classification failed:"` and `"Report submission failed:"` → `use-report-submission.ts`
2. **The two submit fallbacks are NOT collapsed.** They are kept as two distinct hook inputs:
   - `okFallback` = `t("report.submit")` → used in the `/api/reports` `!res.ok` branch (`err.error || okFallback`).
   - `offlineElseFallback` = `t("common.somethingWrong")` → used in the catch's offline-ELSE (online-failure) branch.

## Verification
- `npx tsc --noEmit` — passes (clean after `prisma generate`).
- `npm run lint` — 0 errors (2 pre-existing `no-img-element` warnings in unrelated files).
- `npm run format:check` — all files match Prettier.
- `npm test` — 4 files / 9 tests pass.
- `npm run build` — compiles + TypeScript phase pass; fails only later at page-data collection due to a missing `DATABASE_URL` env var (infra, unrelated to this change).

Out of scope (per issue): hook tests (#118), server-side `form-link` helpers, type/response-envelope centralization.