### PR TITLE
refactor(classify): de-duplicate LLM JSON extraction + base64/MIME helpers [#130]

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getAnthropicKey } from "@/lib/config";
+import { stripDataUrlPrefix } from "./image-utils";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -17,11 +18,6 @@ function extractMediaType(
   if (base64.startsWith("data:image/gif")) return "image/gif";
   if (base64.startsWith("data:image/webp")) return "image/webp";
   return "image/jpeg";
-}
-
-function stripPrefix(base64: string): string {
-  const idx = base64.indexOf(",");
-  return idx >= 0 ? base64.slice(idx + 1) : base64;
 }
 
 /**
@@ -54,7 +50,7 @@ export async function classifyWithAnthropic(
       source: {
         type: "base64",
         media_type: extractMediaType(imageBase64),
-        data: stripPrefix(imageBase64),
+        data: stripDataUrlPrefix(imageBase64),
       },
     });
   }

--- a/nexa/src/lib/classify/google-provider.ts
+++ b/nexa/src/lib/classify/google-provider.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import { getGoogleApiKey } from "@/lib/config";
+import { stripDataUrlPrefix } from "./image-utils";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -8,11 +9,6 @@ import {
 
 function getClient() {
   return new GoogleGenAI({ apiKey: getGoogleApiKey() });
-}
-
-function stripPrefix(base64: string): string {
-  const idx = base64.indexOf(",");
-  return idx >= 0 ? base64.slice(idx + 1) : base64;
 }
 
 function extractMimeType(base64: string): string {
@@ -55,7 +51,7 @@ export async function classifyWithGoogle(
     parts.push({
       inlineData: {
         mimeType: extractMimeType(imageBase64),
-        data: stripPrefix(imageBase64),
+        data: stripDataUrlPrefix(imageBase64),
       },
     });
   }

--- a/nexa/src/lib/classify/image-utils.ts
+++ b/nexa/src/lib/classify/image-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Strip a `data:image/...;base64,` prefix if present and return the raw base64
+ * payload. Inputs that are already bare base64 (no `data:` prefix) are returned
+ * unchanged.
+ *
+ * Shared by the preprocessing step and every provider that needs the raw
+ * base64 bytes without the data-URL wrapper.
+ */
+export function stripDataUrlPrefix(input: string): string {
+  const comma = input.indexOf(",");
+  if (input.startsWith("data:") && comma !== -1) {
+    return input.slice(comma + 1);
+  }
+  return input;
+}

--- a/nexa/src/lib/classify/json.ts
+++ b/nexa/src/lib/classify/json.ts
@@ -1,0 +1,30 @@
+/**
+ * Extract a single JSON object from a model response.
+ *
+ * Language models frequently wrap their JSON in markdown code fences
+ * (```json … ```) or surround it with prose. This helper strips the fences,
+ * locates the outermost `{ … }`, and parses it — the shared extraction logic
+ * used by every stage of the classify pipeline so the parsing behavior stays
+ * identical across providers.
+ *
+ * Type-specific validation (field coercion, `Array.isArray` guards, etc.) is
+ * intentionally left to the caller: this returns the raw parsed object.
+ *
+ * @param raw - The model's text response, possibly fenced or padded with prose.
+ * @param what - Noun used in the thrown error message (default `"model"`),
+ *   e.g. `"observation"` to read "No JSON object in observation response".
+ * @throws {SyntaxError} When no `{ … }` object can be located in `raw`.
+ */
+export function extractJsonObject<T>(raw: string, what = "model"): T {
+  const text = raw
+    .trim()
+    .replace(/```(?:json)?\s*/gi, "")
+    .replace(/```/g, "")
+    .trim();
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new SyntaxError(`No JSON object in ${what} response`);
+  }
+  return JSON.parse(text.slice(start, end + 1)) as T;
+}

--- a/nexa/src/lib/classify/observe.ts
+++ b/nexa/src/lib/classify/observe.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { extractJsonObject } from "./json";
 
 export interface Observation {
   objects: string[];
@@ -28,17 +29,7 @@ function getClient() {
 }
 
 function parseObservation(raw: string): Omit<Observation, "latencyMs"> {
-  const text = raw
-    .trim()
-    .replace(/```(?:json)?\s*/gi, "")
-    .replace(/```/g, "")
-    .trim();
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end === -1 || end <= start) {
-    throw new SyntaxError("No JSON object in observation response");
-  }
-  const parsed = JSON.parse(text.slice(start, end + 1));
+  const parsed = extractJsonObject<Record<string, unknown>>(raw, "observation");
   return {
     objects: Array.isArray(parsed.objects) ? parsed.objects.map(String) : [],
     conditions: Array.isArray(parsed.conditions)

--- a/nexa/src/lib/classify/preprocess.ts
+++ b/nexa/src/lib/classify/preprocess.ts
@@ -1,6 +1,7 @@
 import sharp from "sharp";
 import exifr from "exifr";
 import { IMAGE_PROCESSING } from "@/lib/constants";
+import { stripDataUrlPrefix } from "./image-utils";
 
 export interface PreprocessedImage {
   // base64 data URL ready to be passed to VLMs as image_url
@@ -21,18 +22,6 @@ export interface PreprocessedImage {
 
 const MAX_DIMENSION = IMAGE_PROCESSING.SERVER_MAX_DIMENSION;
 const JPEG_QUALITY = IMAGE_PROCESSING.SERVER_JPEG_QUALITY;
-
-/**
- * Strip a `data:image/...;base64,` prefix if present and return the raw base64
- * payload.
- */
-function stripDataUrlPrefix(input: string): string {
-  const comma = input.indexOf(",");
-  if (input.startsWith("data:") && comma !== -1) {
-    return input.slice(comma + 1);
-  }
-  return input;
-}
 
 /**
  * Normalize a user-supplied image for downstream classification:

--- a/nexa/src/lib/classify/types.ts
+++ b/nexa/src/lib/classify/types.ts
@@ -1,3 +1,5 @@
+import { extractJsonObject } from "./json";
+
 export const ISSUE_TYPES = [
   "ROAD_DAMAGE",
   "STREETLIGHT_OUTAGE",
@@ -99,15 +101,5 @@ export function buildClassificationPrompt(
 
 /** Parse model JSON even when wrapped in markdown fences or extra prose. */
 export function parseClassificationResponse(raw: string): ClassificationResult {
-  let text = raw
-    .trim()
-    .replace(/```(?:json)?\s*/gi, "")
-    .replace(/```/g, "");
-  text = text.trim();
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end === -1 || end <= start) {
-    throw new SyntaxError("No JSON object in model response");
-  }
-  return JSON.parse(text.slice(start, end + 1)) as ClassificationResult;
+  return extractJsonObject<ClassificationResult>(raw);
 }


### PR DESCRIPTION
Closes #130.

## What
DRY refactor of the `src/lib/classify` modules — hoists the copy-pasted LLM-output parsing and data-URL manipulation into single shared helpers.

### Shared helpers added
- **`src/lib/classify/json.ts`** — `extractJsonObject<T>(raw, what?)`: the markdown-fence strip (`replace(/\`\`\`(?:json)?\s*/gi, "").replace(/\`\`\`/g, "")`) + outermost `{…}` slice + `JSON.parse`. Returns the raw parsed object; type-specific validation stays in the callers. The optional `what` label preserves the exact original error messages (`"No JSON object in model response"` vs `"…observation response"`).
- **`src/lib/classify/image-utils.ts`** — `stripDataUrlPrefix(input)`: the guarded (`startsWith("data:")`) data-URL strip from `preprocess.ts`.

### Call sites updated
- `types.ts` `parseClassificationResponse` → calls `extractJsonObject`.
- `observe.ts` `parseObservation` → calls `extractJsonObject(raw, "observation")`, keeps its `Array.isArray`/`typeof` field validation.
- `anthropic-provider.ts`, `google-provider.ts` → drop their local `stripPrefix`, import `stripDataUrlPrefix`.
- `preprocess.ts` → drops its local copy, imports the shared one.

### Left unchanged (per the issue)
`extractMediaType` (anthropic) and `extractMimeType` (google) have distinct signatures/semantics and are **not** merged.

## Behavior
No behavior change. The fence-strip/parse produces identical results and the same error messages.

## Verification (all green)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing unrelated `<img>` warnings)
- `npm run format:check` — clean
- `npm test` — 4 files / 9 tests passed