### PR TITLE
fix(a11y): dark-mode WCAG AA contrast for severity/accuracy badges [#110]

### DIFF
--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -223,10 +223,10 @@ export default function ReportPage() {
                             <span
                               className={`rounded-full px-2 py-0.5 font-mono text-xs uppercase ${
                                 r.severity === "high"
-                                  ? "bg-red-50 text-red-600"
+                                  ? "bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-300"
                                   : r.severity === "medium"
-                                    ? "bg-yellow-50 text-yellow-600"
-                                    : "bg-ep-green-light text-ep-green"
+                                    ? "bg-yellow-50 text-yellow-600 dark:bg-yellow-950 dark:text-yellow-300"
+                                    : "bg-ep-green-light text-ep-green dark:bg-green-950 dark:text-green-300"
                               }`}
                             >
                               {t(`severity.${r.severity}`)}

--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -341,7 +341,7 @@ export function DescribeStep({
                   aria-label={t("report.gpsAccuracy", {
                     meters: Math.round(accuracy),
                   })}
-                  className={`rounded-full px-2 py-0.5 ${accuracy <= 20 ? "bg-ep-green-light text-ep-green" : accuracy <= 100 ? "bg-yellow-50 text-yellow-600" : "bg-red-50 text-red-600"}`}
+                  className={`rounded-full px-2 py-0.5 ${accuracy <= 20 ? "bg-ep-green-light text-ep-green dark:bg-green-950 dark:text-green-300" : accuracy <= 100 ? "bg-yellow-50 text-yellow-600 dark:bg-yellow-950 dark:text-yellow-300" : "bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-300"}`}
                 >
                   ±{Math.round(accuracy)}m
                 </span>

--- a/nexa/src/components/report/review-step.tsx
+++ b/nexa/src/components/report/review-step.tsx
@@ -91,10 +91,10 @@ export function ReviewStep({
           <span
             className={`inline-flex items-center rounded-full px-3 py-1 font-mono text-xs font-medium uppercase tracking-wider ${
               classification.severity === "high"
-                ? "bg-red-50 text-red-600"
+                ? "bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-300"
                 : classification.severity === "medium"
-                  ? "bg-yellow-50 text-yellow-600"
-                  : "bg-ep-green-light text-ep-green"
+                  ? "bg-yellow-50 text-yellow-600 dark:bg-yellow-950 dark:text-yellow-300"
+                  : "bg-ep-green-light text-ep-green dark:bg-green-950 dark:text-green-300"
             }`}
           >
             {t(`severity.${classification.severity}`)}


### PR DESCRIPTION
## Summary

Severity and GPS-accuracy badges use light-tinted backgrounds (`bg-red-50`, `bg-yellow-50`, `bg-ep-green-light`) that break contrast in dark mode (`ep-green-light` resolves to a very dark `#052e16` against light foreground, failing WCAG AA). This adds minimal **additive** `dark:` Tailwind variants to every badge instance so each variant keeps >= 4.5:1 contrast in both light and dark mode. Light mode and all other behavior are unchanged. No `constants.ts` changes — every badge uses an inline ternary, not `SEVERITY_COLORS`.

## Badge sites fixed + dark pair used

| Site | Badge | Variants → dark pair |
|------|-------|----------------------|
| `src/app/report/page.tsx:225-229` | comparison-results severity badge | high → `dark:bg-red-950 dark:text-red-300`, medium → `dark:bg-yellow-950 dark:text-yellow-300`, low → `dark:bg-green-950 dark:text-green-300` |
| `src/components/report/review-step.tsx:93-97` | review-step severity badge | high → `dark:bg-red-950 dark:text-red-300`, medium → `dark:bg-yellow-950 dark:text-yellow-300`, low → `dark:bg-green-950 dark:text-green-300` |
| `src/components/report/describe-step.tsx:344` | GPS-accuracy badge | over → `dark:bg-red-950 dark:text-red-300`, mid → `dark:bg-yellow-950 dark:text-yellow-300`, ok → `dark:bg-green-950 dark:text-green-300` |

(Confirmed there is no separate report-list severity badge in `page.tsx`; the only severity badge there is the comparison-results one inside the `submission.comparison` block.)

## Verification

- `npx tsc --noEmit` — clean (after `prisma generate`)
- `npm run lint` — no new errors (2 pre-existing `<img>` warnings on untouched lines)
- `npm run format:check` — changed files pass (pre-existing `proxy.test.ts` warning is on origin/main, untouched)
- `npm test` — 210 passed (18 files)

Closes #110