### PR TITLE
feat(routing): assign agency to reports on creation [#24]

### DIFF
--- a/nexa/src/app/api/reports/[id]/submission-fields/route.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.ts
@@ -36,7 +36,7 @@ export async function GET(
     // Resolve the agency for display without persisting (this is a read).
     let agency = report.agency;
     if (!agency) {
-      const agencyId = await resolveAgencyId({
+      const { agencyId } = await resolveAgencyId({
         latitude: report.latitude,
         longitude: report.longitude,
         issueType: report.issueType,

--- a/nexa/src/app/api/reports/[id]/submit/route.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.ts
@@ -52,7 +52,7 @@ export async function POST(
     // was added later) may not have an agency yet — resolve it on demand.
     let agency = report.agency;
     if (!agency) {
-      const agencyId = await resolveAgencyId({
+      const { agencyId } = await resolveAgencyId({
         latitude: report.latitude,
         longitude: report.longitude,
         issueType: report.issueType,

--- a/nexa/src/app/api/reports/route.test.ts
+++ b/nexa/src/app/api/reports/route.test.ts
@@ -16,7 +16,7 @@ describe("POST /api/reports", () => {
       issueType: "ROAD_DAMAGE",
     });
     // Routing/dedupe helpers query prisma too — stub them so the route runs.
-    prismaMock.agency.findFirst.mockResolvedValue(null);
+    prismaMock.agency.findMany.mockResolvedValue([]);
     prismaMock.issueGroup.findMany.mockResolvedValue([]);
     // findOrCreateIssueGroup selects only { id }, so a narrowed shape is correct.
     prismaMock.issueGroup.create.mockResolvedValue({
@@ -46,7 +46,7 @@ describe("POST /api/reports", () => {
 
   it("returns 500 when the database write throws", async () => {
     // Arrange
-    prismaMock.agency.findFirst.mockResolvedValue(null);
+    prismaMock.agency.findMany.mockResolvedValue([]);
     prismaMock.issueGroup.findMany.mockResolvedValue([]);
     prismaMock.report.create.mockRejectedValue(new Error("db down"));
 

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -26,12 +26,23 @@ export async function POST(request: NextRequest) {
     const validIssueType = issueType ?? null;
 
     // Route the report to the responsible agency from its location + issue
-    // type so the submission pipeline has somewhere to file it.
-    const agencyId = await resolveAgencyId({
+    // type so the submission pipeline has somewhere to file it. When routing is
+    // unresolved or ambiguous we persist agencyId=null and log why rather than
+    // failing the request — the report can still be created and routed later.
+    const { agencyId, candidates } = await resolveAgencyId({
       latitude,
       longitude,
       issueType: validIssueType,
     });
+    if (!agencyId) {
+      const reason =
+        candidates.length > 1
+          ? `ambiguous: ${candidates.length} candidate agencies (${candidates.join(", ")})`
+          : "no agency covers this jurisdiction + issue type";
+      console.warn(
+        `Report routing unresolved (issueType=${validIssueType}, lat=${latitude}, lng=${longitude}): ${reason}`,
+      );
+    }
 
     // Group this report with any existing open report about the same nearby
     // issue so duplicate reports from different people share one case. Returns

--- a/nexa/src/lib/jurisdictions/agency.ts
+++ b/nexa/src/lib/jurisdictions/agency.ts
@@ -12,44 +12,74 @@ const AGENCY_FALLBACKS: Partial<Record<JurisdictionId, JurisdictionId[]>> = {
 };
 
 /**
+ * The outcome of resolving which agency a report should be filed with.
+ *
+ * - `agencyId` is set only when exactly one agency confidently covers the
+ *   report's jurisdiction + issue type. It is null when nothing matches OR when
+ *   the match is ambiguous (more than one agency covers it) — ambiguity
+ *   resolution is a separate concern and is left to a future caller.
+ * - `candidates` lists every agency id that covers the jurisdiction + issue
+ *   type (in the tier that produced the matches), so that downstream ambiguity
+ *   handling has the full set to choose from.
+ */
+export type AgencyResolution = {
+  agencyId: string | null;
+  candidates: string[];
+};
+
+/**
  * Resolves the Agency a report should be filed with, based on its location and
  * issue type. This is the link between the polygon routing engine
  * (`resolveJurisdiction`) and the seeded Agency records that the submission
  * pipeline needs.
  *
- * Returns the agency id, or null when there is no location/issue type or no
- * agency covers that jurisdiction + issue type.
+ * Returns a single confident `agencyId` (with the full `candidates` list) when
+ * exactly one agency covers the jurisdiction + issue type. Returns
+ * `agencyId: null` when there is no location/issue type, no jurisdiction match,
+ * no agency covers it, or the match is ambiguous (multiple candidates).
  */
 export async function resolveAgencyId(args: {
   latitude?: number | null;
   longitude?: number | null;
   issueType?: IssueType | null;
-}): Promise<string | null> {
+}): Promise<AgencyResolution> {
   const { latitude, longitude, issueType } = args;
   if (
     typeof latitude !== "number" ||
     typeof longitude !== "number" ||
     !issueType
   ) {
-    return null;
+    return { agencyId: null, candidates: [] };
   }
 
   const match = resolveJurisdiction(latitude, longitude, issueType);
-  if (!match) return null;
+  if (!match) return { agencyId: null, candidates: [] };
 
-  // Try the matched jurisdiction first, then any fallback jurisdictions.
-  const candidates: JurisdictionId[] = [
+  // Try the matched jurisdiction first, then any fallback jurisdictions. We use
+  // the first jurisdiction tier that yields any agency so that a fallback only
+  // applies when the primary jurisdiction has no coverage at all.
+  const jurisdictions: JurisdictionId[] = [
     match.jurisdiction.id,
     ...(AGENCY_FALLBACKS[match.jurisdiction.id] ?? []),
   ];
 
-  for (const jurisdiction of candidates) {
-    const agency = await prisma.agency.findFirst({
+  for (const jurisdiction of jurisdictions) {
+    const agencies = await prisma.agency.findMany({
       where: { jurisdiction, issueTypes: { has: issueType } },
       select: { id: true },
+      orderBy: { id: "asc" },
     });
-    if (agency) return agency.id;
+    if (agencies.length === 0) continue;
+
+    const candidates = agencies.map((a) => a.id);
+    // Only a single, unambiguous match becomes the report's agency. Multiple
+    // candidates are surfaced for future ambiguity handling but do not get
+    // auto-assigned here.
+    return {
+      agencyId: candidates.length === 1 ? candidates[0] : null,
+      candidates,
+    };
   }
 
-  return null;
+  return { agencyId: null, candidates: [] };
 }

--- a/nexa/src/lib/jurisdictions/agency.ts
+++ b/nexa/src/lib/jurisdictions/agency.ts
@@ -27,6 +27,9 @@ export type AgencyResolution = {
   candidates: string[];
 };
 
+/** No confident agency match (no input, no jurisdiction, no coverage, or ambiguous). */
+const UNRESOLVED: AgencyResolution = { agencyId: null, candidates: [] };
+
 /**
  * Resolves the Agency a report should be filed with, based on its location and
  * issue type. This is the link between the polygon routing engine
@@ -49,11 +52,11 @@ export async function resolveAgencyId(args: {
     typeof longitude !== "number" ||
     !issueType
   ) {
-    return { agencyId: null, candidates: [] };
+    return UNRESOLVED;
   }
 
   const match = resolveJurisdiction(latitude, longitude, issueType);
-  if (!match) return { agencyId: null, candidates: [] };
+  if (!match) return UNRESOLVED;
 
   // Try the matched jurisdiction first, then any fallback jurisdictions. We use
   // the first jurisdiction tier that yields any agency so that a fallback only
@@ -81,5 +84,5 @@ export async function resolveAgencyId(args: {
     };
   }
 
-  return { agencyId: null, candidates: [] };
+  return UNRESOLVED;
 }


### PR DESCRIPTION
## Summary

Implements the agency-assignment scope of #24: the glue that links the polygon routing engine (`resolveJurisdiction`) to the seeded `Agency` records so a newly-created report gets an `agencyId`, which in turn unblocks `POST /api/reports/[id]/submit` (previously always 400'd with "No agency is assigned to this report").

## The resolver

`src/lib/jurisdictions/agency.ts` — `resolveAgencyId({ latitude, longitude, issueType })` now returns `{ agencyId, candidates }`:

1. Calls `resolveJurisdiction(lat, lng, issueType)` to get the jurisdiction (its signature and behavior are unchanged).
2. Queries `prisma.agency` for agencies whose `jurisdiction` matches AND whose `issueTypes` array `has` the report's `issueType`.
3. `candidates` = every matching agency id (surfaced for the future ambiguity-handling issue).
4. `agencyId` is set **only when exactly one** agency matches. When zero match or the match is **ambiguous** (multiple candidates), `agencyId` is left `null`.

The existing Stanford-campus → Palo Alto fallback is preserved: a fallback jurisdiction is only consulted when the primary jurisdiction has no covering agency at all.

## Wiring

`POST /api/reports` destructures `{ agencyId, candidates }`, persists `agencyId` when a single confident match exists, and otherwise persists `agencyId = null` while `console.warn`-ing the reason (`ambiguous: N candidates …` vs `no agency covers this jurisdiction + issue type`). It never throws — the report is always created and can be routed later.

The `submit` and `submission-fields` routes are updated to the new return shape (`const { agencyId } = …`); their on-demand resolve-and-persist behavior is otherwise unchanged.

## Worked examples (against `prisma/seed.ts`)

- **Palo Alto road-damage report:** `resolveJurisdiction` → `city-palo-alto`. The only Palo Alto agency listing `ROAD_DAMAGE` is **Palo Alto 311** (the CARB Smoking Vehicle agency lists only `VEHICLE_EMISSIONS`). Exactly one candidate → the report is persisted with Palo Alto 311's `agencyId`. (An emissions report in the same spot routes to CARB instead, not 311.)
- **Menlo Park report:** Menlo Park has two seeded agencies — "Menlo Park ACT" (WEB_FORM) and "Menlo Park SeeClickFix (Open311)" (API). A `STREETLIGHT_OUTAGE` report matches only ACT → single confident assignment. A `ROAD_DAMAGE`/`ILLEGAL_DUMPING` report matches **both** → `agencyId` stays `null` with an "ambiguous: 2 candidate agencies" log, and `candidates` carries both ids for the dedicated ambiguity issue to resolve.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated files)
- `npm run format:check` — clean
- `npm test` — 210 passed (18 files); the 11 `resolveJurisdiction`/registry tests are unchanged and green
- `npm run build` — compiles and type-checks successfully; page-data collection step requires a live `DATABASE_URL` not available in this environment (pre-existing constraint, unrelated to this change)

`resolveJurisdiction` and its tests are untouched.