### PR TITLE
feat(resilience): timeouts + retry/backoff for external calls [#102]

### DIFF
--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getGoogleMapsApiKey } from "@/lib/config";
+import { fetchWithTimeout } from "@/lib/http";
 
 type NominatimSearchResult = {
   display_name?: string;
@@ -44,10 +45,15 @@ async function fetchGoogleSuggestions(
     key: apiKey,
   });
 
-  const autocompleteResponse = await fetch(
-    `https://maps.googleapis.com/maps/api/place/autocomplete/json?${autocompleteParams.toString()}`,
-    { cache: "no-store" },
-  );
+  let autocompleteResponse: Response;
+  try {
+    autocompleteResponse = await fetchWithTimeout(
+      `https://maps.googleapis.com/maps/api/place/autocomplete/json?${autocompleteParams.toString()}`,
+      { cache: "no-store" },
+    );
+  } catch {
+    return [];
+  }
 
   if (!autocompleteResponse.ok) {
     return [];
@@ -75,10 +81,15 @@ async function fetchGoogleSuggestions(
         key: apiKey,
       });
 
-      const detailResponse = await fetch(
-        `https://maps.googleapis.com/maps/api/place/details/json?${detailParams.toString()}`,
-        { cache: "no-store" },
-      );
+      let detailResponse: Response;
+      try {
+        detailResponse = await fetchWithTimeout(
+          `https://maps.googleapis.com/maps/api/place/details/json?${detailParams.toString()}`,
+          { cache: "no-store" },
+        );
+      } catch {
+        return null;
+      }
 
       if (!detailResponse.ok) return null;
 
@@ -115,15 +126,20 @@ async function fetchGoogleSuggestions(
 async function fetchNominatimSuggestions(
   query: string,
 ): Promise<LocationSuggestion[]> {
-  const response = await fetch(
-    `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`,
-    {
-      headers: {
-        "User-Agent": "Nexa location suggestions",
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`,
+      {
+        headers: {
+          "User-Agent": "Nexa location suggestions",
+        },
+        cache: "no-store",
       },
-      cache: "no-store",
-    },
-  );
+    );
+  } catch {
+    return [];
+  }
 
   if (!response.ok) return [];
 

--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getOpenAI } from "@/lib/openai";
+import { fetchWithTimeout, DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { ISSUE_TYPE_LABELS, US_STATE_CODES } from "@/lib/constants";
 import { IssueType } from "@/generated/prisma/enums";
 import { resolveJurisdiction } from "@/lib/jurisdictions/resolve";
@@ -248,13 +249,20 @@ async function reverseLookupCity(
   latitude: number,
   longitude: number,
 ): Promise<ResolvedLocation> {
-  const response = await fetch(
-    `https://nominatim.openstreetmap.org/reverse?format=jsonv2&addressdetails=1&lat=${latitude}&lon=${longitude}`,
-    {
-      headers: { "User-Agent": "Nexa civic form lookup" },
-      cache: "no-store",
-    },
-  );
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      `https://nominatim.openstreetmap.org/reverse?format=jsonv2&addressdetails=1&lat=${latitude}&lon=${longitude}`,
+      {
+        headers: { "User-Agent": "Nexa civic form lookup" },
+        cache: "no-store",
+      },
+    );
+  } catch {
+    // A slow/hung geocoder must not stall the whole form-link request; treat
+    // it as an unresolved location and let the caller fall back.
+    return { ...EMPTY_LOCATION, latitude, longitude };
+  }
 
   if (!response.ok) {
     return { ...EMPTY_LOCATION, latitude, longitude };
@@ -270,13 +278,18 @@ async function reverseLookupCity(
 }
 
 async function geocodeAddress(address: string): Promise<ResolvedLocation> {
-  const response = await fetch(
-    `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=1&q=${encodeURIComponent(address)}`,
-    {
-      headers: { "User-Agent": "Nexa civic form lookup" },
-      cache: "no-store",
-    },
-  );
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      `https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=1&q=${encodeURIComponent(address)}`,
+      {
+        headers: { "User-Agent": "Nexa civic form lookup" },
+        cache: "no-store",
+      },
+    );
+  } catch {
+    return EMPTY_LOCATION;
+  }
 
   if (!response.ok) return EMPTY_LOCATION;
 
@@ -351,21 +364,24 @@ Instructions:
 Do not say "not_found" just because there is no "${issueLabel}"-specific form — the general city 311 / Report-an-Issue page is the correct answer in that case.`;
 
   const client = getOpenAI();
-  const response = await client.responses.create({
-    model: "gpt-4o-mini",
-    input: [
-      {
-        role: "system",
-        content: [{ type: "input_text", text: LOOKUP_SYSTEM_PROMPT }],
-      },
-      {
-        role: "user",
-        content: [{ type: "input_text", text: prompt }],
-      },
-    ],
-    tools: [{ type: "web_search_preview" }],
-    tool_choice: { type: "web_search_preview" },
-  });
+  const response = await client.responses.create(
+    {
+      model: "gpt-4o-mini",
+      input: [
+        {
+          role: "system",
+          content: [{ type: "input_text", text: LOOKUP_SYSTEM_PROMPT }],
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: prompt }],
+        },
+      ],
+      tools: [{ type: "web_search_preview" }],
+      tool_choice: { type: "web_search_preview" },
+    },
+    { timeout: DEFAULT_LLM_TIMEOUT_MS },
+  );
 
   const raw = collectResponsesAssistantText(response);
   if (!raw) {

--- a/nexa/src/lib/classify/anthropic-provider.ts
+++ b/nexa/src/lib/classify/anthropic-provider.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { getAnthropicKey } from "@/lib/config";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { stripDataUrlPrefix } from "./image-utils";
 import {
   CLASSIFICATION_PROMPT,
@@ -61,11 +62,14 @@ export async function classifyWithAnthropic(
   }
   content.push({ type: "text", text: textPrompt });
 
-  const response = await getClient().messages.create({
-    model: "claude-haiku-4-5",
-    max_tokens: 300,
-    messages: [{ role: "user", content }],
-  });
+  const response = await getClient().messages.create(
+    {
+      model: "claude-haiku-4-5",
+      max_tokens: 300,
+      messages: [{ role: "user", content }],
+    },
+    { timeout: DEFAULT_LLM_TIMEOUT_MS },
+  );
 
   const raw =
     response.content[0]?.type === "text" ? response.content[0].text : "{}";

--- a/nexa/src/lib/classify/google-provider.ts
+++ b/nexa/src/lib/classify/google-provider.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import { getGoogleApiKey } from "@/lib/config";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { stripDataUrlPrefix } from "./image-utils";
 import {
   CLASSIFICATION_PROMPT,
@@ -61,6 +62,7 @@ export async function classifyWithGoogle(
   const response = await getClient().models.generateContent({
     model: "gemini-2.5-flash",
     contents: [{ role: "user", parts }],
+    config: { httpOptions: { timeout: DEFAULT_LLM_TIMEOUT_MS } },
   });
 
   const raw = response.text ?? "{}";

--- a/nexa/src/lib/classify/observe.ts
+++ b/nexa/src/lib/classify/observe.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { extractJsonObject } from "./json";
 
 export interface Observation {
@@ -68,12 +69,15 @@ export async function observeImage(
     });
   }
 
-  const response = await getClient().chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [{ role: "user", content }],
-    max_tokens: 250,
-    temperature: 0.1,
-  });
+  const response = await getClient().chat.completions.create(
+    {
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content }],
+      max_tokens: 250,
+      temperature: 0.1,
+    },
+    { timeout: DEFAULT_LLM_TIMEOUT_MS },
+  );
 
   const raw = response.choices[0]?.message?.content ?? "{}";
   const parsed = parseObservation(raw);

--- a/nexa/src/lib/classify/openai-provider.ts
+++ b/nexa/src/lib/classify/openai-provider.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { getOpenAiKey } from "@/lib/config";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import {
   CLASSIFICATION_PROMPT,
   parseClassificationResponse,
@@ -54,12 +55,15 @@ export async function classifyWithOpenAI(
 
   messages.push({ role: "user", content });
 
-  const response = await getClient().chat.completions.create({
-    model: "gpt-4o-mini",
-    messages,
-    max_tokens: 300,
-    temperature: 0.1,
-  });
+  const response = await getClient().chat.completions.create(
+    {
+      model: "gpt-4o-mini",
+      messages,
+      max_tokens: 300,
+      temperature: 0.1,
+    },
+    { timeout: DEFAULT_LLM_TIMEOUT_MS },
+  );
 
   const raw = response.choices[0]?.message?.content ?? "{}";
   const parsed = parseClassificationResponse(raw);

--- a/nexa/src/lib/http.test.ts
+++ b/nexa/src/lib/http.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchWithTimeout,
+  isTransientError,
+  TimeoutError,
+  withRetry,
+} from "./http";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("fetchWithTimeout", () => {
+  it("returns the response when fetch resolves before the deadline", async () => {
+    // Arrange
+    const expected = new Response("ok");
+    const fetchMock = vi.fn().mockResolvedValue(expected);
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Act
+    const res = await fetchWithTimeout("https://example.test", {
+      timeoutMs: 50,
+    });
+
+    // Assert
+    expect(res).toBe(expected);
+    // The call is given an AbortSignal even though the caller passed none.
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("rejects with a TimeoutError when fetch outlives the deadline", async () => {
+    // Arrange: fetch that only rejects once its signal aborts.
+    vi.stubGlobal("fetch", (_input: unknown, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+
+    // Act / Assert
+    await expect(
+      fetchWithTimeout("https://example.test", { timeoutMs: 5 }),
+    ).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("propagates a caller-supplied abort without masking it as a timeout", async () => {
+    // Arrange
+    vi.stubGlobal("fetch", (_input: unknown, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    const external = new AbortController();
+
+    // Act
+    const promise = fetchWithTimeout("https://example.test", {
+      timeoutMs: 10_000,
+      signal: external.signal,
+    });
+    external.abort();
+
+    // Assert: the caller's abort is not relabeled as a TimeoutError.
+    await expect(promise).rejects.toSatisfy(
+      (e: unknown) => e instanceof Error && !(e instanceof TimeoutError),
+    );
+  });
+});
+
+describe("isTransientError", () => {
+  it("treats timeouts and connection errors as transient", () => {
+    expect(isTransientError(new TimeoutError(10))).toBe(true);
+    const connErr = Object.assign(new Error("boom"), { code: "ECONNRESET" });
+    expect(isTransientError(connErr)).toBe(true);
+    expect(isTransientError(new Error("fetch failed"))).toBe(true);
+  });
+
+  it("treats ordinary errors as non-transient", () => {
+    expect(isTransientError(new Error("bad request"))).toBe(false);
+    expect(isTransientError("nope")).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  const noSleep = () => Promise.resolve();
+
+  it("returns the first successful result without retrying", async () => {
+    // Arrange
+    const op = vi.fn().mockResolvedValue("done");
+
+    // Act
+    const result = await withRetry(op, { sleep: noSleep });
+
+    // Assert
+    expect(result).toBe("done");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient failures up to the attempt cap then succeeds", async () => {
+    // Arrange: fail twice with a transient error, then succeed.
+    const transient = Object.assign(new Error("net"), { code: "ECONNRESET" });
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValue("ok");
+
+    // Act
+    const result = await withRetry(op, { attempts: 3, sleep: noSleep });
+
+    // Assert
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry when shouldRetry returns false", async () => {
+    // Arrange
+    const op = vi.fn().mockRejectedValue(new Error("permanent"));
+
+    // Act / Assert
+    await expect(
+      withRetry(op, {
+        attempts: 5,
+        shouldRetry: () => false,
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow("permanent");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws the last error once attempts are exhausted", async () => {
+    // Arrange: always-failing transient op.
+    const transient = Object.assign(new Error("net"), { code: "ECONNRESET" });
+    const op = vi.fn().mockRejectedValue(transient);
+    const onRetry = vi.fn();
+
+    // Act / Assert
+    await expect(
+      withRetry(op, { attempts: 2, sleep: noSleep, onRetry }),
+    ).rejects.toBe(transient);
+    expect(op).toHaveBeenCalledTimes(2);
+    // onRetry fires once: after attempt 1, before the final attempt.
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies capped exponential backoff delays", async () => {
+    // Arrange
+    const transient = Object.assign(new Error("net"), { code: "ECONNRESET" });
+    const op = vi.fn().mockRejectedValue(transient);
+    const delays: number[] = [];
+
+    // Act
+    await withRetry(op, {
+      attempts: 4,
+      baseDelayMs: 100,
+      maxDelayMs: 250,
+      sleep: noSleep,
+      onRetry: (_e, _a, delay) => delays.push(delay),
+    }).catch(() => {});
+
+    // Assert: 100, 200, then capped at 250.
+    expect(delays).toEqual([100, 200, 250]);
+  });
+});

--- a/nexa/src/lib/http.ts
+++ b/nexa/src/lib/http.ts
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------
+// Shared resilience helpers for external HTTP calls.
+//
+// On Vercel Hobby a request is killed after ~30s, so any external dependency
+// that hangs stalls the whole route. These helpers give every outbound call a
+// bounded lifetime (AbortController timeout) and, where the call is safe to
+// repeat, a small exponential-backoff retry for transient/network/5xx errors.
+//
+// Two pieces, kept deliberately small so every call site reuses them rather
+// than rolling its own AbortController:
+//   - fetchWithTimeout: a drop-in `fetch` that aborts after `timeoutMs`.
+//   - withRetry:        wraps any async op in bounded exponential backoff.
+//
+// SDK-based calls (OpenAI / Anthropic / Google) don't go through `fetch`
+// directly; they expose their own per-request timeout/abort options and are
+// wired up at their own call sites using DEFAULT_LLM_TIMEOUT_MS below.
+// ---------------------------------------------------------------------------
+
+/** Default timeout for plain HTTP (geocoding, Open311) — well under Hobby's ~30s. */
+export const DEFAULT_HTTP_TIMEOUT_MS = 12_000;
+
+/** Default timeout for LLM SDK calls, which are slower than a REST hop. */
+export const DEFAULT_LLM_TIMEOUT_MS = 20_000;
+
+/** Thrown when a {@link fetchWithTimeout} call exceeds its deadline. */
+export class TimeoutError extends Error {
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export type FetchWithTimeoutInit = RequestInit & {
+  /** Abort the request after this many ms (default {@link DEFAULT_HTTP_TIMEOUT_MS}). */
+  timeoutMs?: number;
+};
+
+/**
+ * `fetch` with an AbortController deadline. Identical to `fetch` on success;
+ * on timeout it rejects with a {@link TimeoutError} rather than hanging.
+ *
+ * If the caller passes their own `signal`, it is honored alongside the timeout:
+ * whichever aborts first wins.
+ */
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: FetchWithTimeoutInit = {},
+): Promise<Response> {
+  const { timeoutMs = DEFAULT_HTTP_TIMEOUT_MS, signal, ...rest } = init;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  // Chain a caller-supplied signal so an external abort still propagates.
+  const onExternalAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onExternalAbort, { once: true });
+  }
+
+  try {
+    return await fetch(input, { ...rest, signal: controller.signal });
+  } catch (error) {
+    // An abort triggered by *our* timer (not the caller) surfaces as a typed
+    // TimeoutError so callers can distinguish a deadline from other failures.
+    if (
+      controller.signal.aborted &&
+      !(signal?.aborted ?? false) &&
+      error instanceof Error &&
+      error.name === "AbortError"
+    ) {
+      throw new TimeoutError(timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener("abort", onExternalAbort);
+  }
+}
+
+export type RetryOptions = {
+  /** Total attempts, including the first (default 3). */
+  attempts?: number;
+  /** Base backoff in ms; doubles each retry (default 300). */
+  baseDelayMs?: number;
+  /** Cap on any single backoff delay (default 4000). */
+  maxDelayMs?: number;
+  /**
+   * Decides whether a thrown error is worth retrying. Defaults to
+   * {@link isTransientError} (network/timeout). Callers that can see HTTP
+   * status (e.g. Open311) pass a predicate that also retries 5xx.
+   */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  /** Hook for tests / observability; called before each backoff sleep. */
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+  /** Injectable sleep, for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Heuristic for "transient" failures that are safe to retry on an idempotent
+ * call: timeouts and connection-level errors. We intentionally do NOT treat an
+ * arbitrary thrown Error as transient — only failures that strongly suggest the
+ * request never reached / never completed at the server.
+ */
+export function isTransientError(error: unknown): boolean {
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return true;
+    // Node/undici connection errors surface a `code` on the cause or error.
+    const code =
+      (error as { code?: unknown }).code ??
+      (error as { cause?: { code?: unknown } }).cause?.code ??
+      undefined;
+    if (typeof code === "string") {
+      return [
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "ETIMEDOUT",
+        "ENOTFOUND",
+        "EAI_AGAIN",
+        "EPIPE",
+        "UND_ERR_CONNECT_TIMEOUT",
+        "UND_ERR_SOCKET",
+      ].includes(code);
+    }
+    // Generic fetch network failure.
+    if (error.message === "fetch failed" || error.message === "Failed to fetch")
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Runs `op` with bounded exponential backoff. Retries only when `shouldRetry`
+ * returns true (default: transient errors). Re-throws the last error once
+ * attempts are exhausted, so callers see the original failure type.
+ */
+export async function withRetry<T>(
+  op: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    attempts = 3,
+    baseDelayMs = 300,
+    maxDelayMs = 4_000,
+    shouldRetry = isTransientError,
+    onRetry,
+    sleep = defaultSleep,
+  } = options;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await op(attempt);
+    } catch (error) {
+      lastError = error;
+      const isLast = attempt >= attempts;
+      if (isLast || !shouldRetry(error, attempt)) throw error;
+
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      onRetry?.(error, attempt, delay);
+      await sleep(delay);
+    }
+  }
+  // Unreachable (the loop either returns or throws), but satisfies the type.
+  throw lastError;
+}

--- a/nexa/src/lib/reverse-geocode.ts
+++ b/nexa/src/lib/reverse-geocode.ts
@@ -1,6 +1,9 @@
+import { fetchWithTimeout } from "@/lib/http";
+
 /**
  * Reverse-geocode coordinates via Nominatim (same source as Detect Location).
- * Returns a display-name string, or a coordinate fallback on failure.
+ * Returns a display-name string, or a coordinate fallback on failure (including
+ * a timeout, so a hung geocoder never stalls the caller).
  */
 export async function reverseGeocode(
   lat: number,
@@ -8,7 +11,7 @@ export async function reverseGeocode(
 ): Promise<string> {
   const fallback = `${lat.toFixed(6)}, ${lng.toFixed(6)}`;
   try {
-    const res = await fetch(
+    const res = await fetchWithTimeout(
       `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1`,
     );
     if (!res.ok) return fallback;

--- a/nexa/src/lib/submission/open311.ts
+++ b/nexa/src/lib/submission/open311.ts
@@ -1,5 +1,45 @@
 import { IssueType } from "@/generated/prisma/enums";
 import { ReportStatus } from "@/generated/prisma/enums";
+import {
+  fetchWithTimeout,
+  withRetry,
+  TimeoutError,
+  isTransientError,
+  DEFAULT_HTTP_TIMEOUT_MS,
+} from "@/lib/http";
+
+// A POST to Open311 is NOT idempotent: a request that the endpoint already
+// accepted but whose response we lost (timeout, dropped connection mid-reply)
+// could file a duplicate ticket if we blindly retried. So submit retries ONLY
+// on errors that prove the request never reached the server — connection
+// refused / DNS failure before any bytes were sent. A timeout is treated as
+// terminal precisely because the request may already have been accepted.
+const CONNECTION_ONLY_RETRY_CODES = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
+
+function isPreRequestConnectionError(error: unknown): boolean {
+  if (error instanceof TimeoutError) return false;
+  const code =
+    (error as { code?: unknown })?.code ??
+    (error as { cause?: { code?: unknown } })?.cause?.code;
+  return typeof code === "string" && CONNECTION_ONLY_RETRY_CODES.has(code);
+}
+
+// GET status polling IS idempotent, so it retries any transient failure plus
+// 5xx responses. A sentinel error lets us funnel a retryable 5xx through the
+// same withRetry path as a thrown network error.
+class RetryableHttpError extends Error {
+  readonly httpStatus: number;
+  constructor(httpStatus: number) {
+    super(`Open311 endpoint returned HTTP ${httpStatus}.`);
+    this.name = "RetryableHttpError";
+    this.httpStatus = httpStatus;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Open311 GeoReport v2 client
@@ -173,23 +213,42 @@ export async function submitToOpen311(
   }
 
   const params = buildRequestParams(report, serviceCode, options.config);
-  const doFetch = options.fetchImpl ?? fetch;
+  // A custom fetchImpl (tests) is used verbatim; otherwise fetchWithTimeout
+  // gives the POST a bounded deadline so a hung endpoint can't stall the route.
+  const doFetch =
+    options.fetchImpl ??
+    ((input: RequestInfo | URL, init?: RequestInit) =>
+      fetchWithTimeout(input, {
+        ...init,
+        timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+      }));
 
   let response: Response;
   try {
-    response = await doFetch(`${endpoint}/requests.json`, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: params.toString(),
-    });
+    response = await withRetry(
+      () =>
+        doFetch(`${endpoint}/requests.json`, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: params.toString(),
+        }),
+      {
+        attempts: 2,
+        // Retry ONLY when the request provably never reached the server, never
+        // after a timeout or any HTTP response — avoids duplicate filings.
+        shouldRetry: isPreRequestConnectionError,
+      },
+    );
   } catch (error) {
     return {
       status: "error",
       httpStatus: null,
       message:
-        error instanceof Error
-          ? error.message
-          : "Network error contacting Open311 endpoint.",
+        error instanceof TimeoutError
+          ? "Open311 endpoint timed out."
+          : error instanceof Error
+            ? error.message
+            : "Network error contacting Open311 endpoint.",
     };
   }
 
@@ -274,22 +333,52 @@ export async function fetchOpen311Status(
     query.set("jurisdiction_id", options.config.jurisdictionId);
   const suffix = query.toString() ? `?${query.toString()}` : "";
 
-  const doFetch = options.fetchImpl ?? fetch;
+  // A custom fetchImpl (tests) is used verbatim; otherwise fetchWithTimeout
+  // bounds each GET. Polling is idempotent, so we retry transient failures
+  // (network/timeout) and 5xx responses with capped exponential backoff.
+  const doFetch =
+    options.fetchImpl ??
+    ((input: RequestInfo | URL, init?: RequestInit) =>
+      fetchWithTimeout(input, {
+        ...init,
+        timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+      }));
+
+  const url = `${endpoint}/requests/${encodeURIComponent(serviceRequestId)}.json${suffix}`;
 
   let response: Response;
   try {
-    response = await doFetch(
-      `${endpoint}/requests/${encodeURIComponent(serviceRequestId)}.json${suffix}`,
-      { method: "GET", cache: "no-store" },
+    response = await withRetry(
+      async () => {
+        const res = await doFetch(url, { method: "GET", cache: "no-store" });
+        // Surface 5xx as a retryable error so withRetry backs off and retries;
+        // 4xx and 404 are permanent and fall through untouched.
+        if (res.status >= 500) throw new RetryableHttpError(res.status);
+        return res;
+      },
+      {
+        attempts: 3,
+        shouldRetry: (error) =>
+          error instanceof RetryableHttpError || isTransientError(error),
+      },
     );
   } catch (error) {
+    if (error instanceof RetryableHttpError) {
+      return {
+        status: "error",
+        httpStatus: error.httpStatus,
+        message: error.message,
+      };
+    }
     return {
       status: "error",
       httpStatus: null,
       message:
-        error instanceof Error
-          ? error.message
-          : "Network error contacting Open311 endpoint.",
+        error instanceof TimeoutError
+          ? "Open311 endpoint timed out."
+          : error instanceof Error
+            ? error.message
+            : "Network error contacting Open311 endpoint.",
     };
   }
 


### PR DESCRIPTION
Closes #102.

## Summary
No external call in the app had a timeout or retry, so a hung dependency could stall a whole request under Vercel Hobby's ~30s limit. This introduces one shared helper and reuses it across every external call site.

## Shared helper — `src/lib/http.ts`
- `fetchWithTimeout(input, { timeoutMs })` — `fetch` with an AbortController deadline; rejects with a typed `TimeoutError` instead of hanging. Honors a caller-supplied `signal` alongside the timeout.
- `withRetry(op, { attempts, baseDelayMs, maxDelayMs, shouldRetry })` — bounded exponential backoff; only retries when `shouldRetry` says so; re-throws the original error once exhausted.
- `isTransientError` — classifies timeout/network/connection errors.
- Defaults: `DEFAULT_HTTP_TIMEOUT_MS = 12s`, `DEFAULT_LLM_TIMEOUT_MS = 20s` (both under the Hobby cold limit).

## Call sites updated
| Call site | Timeout | Retry |
|---|---|---|
| `src/lib/classify/openai-provider.ts` (chat.completions) | 20s via SDK `{ timeout }` | none (consensus layer already tolerates a provider failing) |
| `src/lib/classify/anthropic-provider.ts` (messages.create) | 20s via SDK `{ timeout }` | none |
| `src/lib/classify/google-provider.ts` (generateContent) | 20s via SDK `config.httpOptions.timeout` | none |
| `src/lib/classify/observe.ts` (chat.completions) | 20s via SDK `{ timeout }` | none |
| `src/app/api/reports/form-link/route.ts` — OpenAI Responses (web_search) | 20s via SDK `{ timeout }` | none |
| `src/app/api/reports/form-link/route.ts` — Nominatim reverse + forward geocode | 12s (`fetchWithTimeout`) | none; on failure returns the existing empty-location fallback |
| `src/app/api/location/suggest/route.ts` — Google autocomplete + details, Nominatim | 12s (`fetchWithTimeout`) | none; on failure returns `[]` (existing degrade path) |
| `src/lib/reverse-geocode.ts` — Nominatim reverse | 12s (`fetchWithTimeout`) | none; existing coordinate fallback on failure |
| `src/lib/submission/open311.ts` — `fetchOpen311Status` (GET) | 12s (`fetchWithTimeout`) | up to 3 attempts, backoff, on transient/network + 5xx |
| `src/lib/submission/open311.ts` — `submitToOpen311` (POST) | 12s (`fetchWithTimeout`) | see idempotency note |

The `submit/route.ts` caller already rolls a failed submission back from SUBMITTING to CONFIRMED, so a timeout now surfaces as a typed error and never leaves a report stuck in SUBMITTING.

## Open311-submit idempotency
A POST to Open311 is **not** idempotent: a request the endpoint already accepted but whose response we lost (timeout / dropped mid-reply) would file a **duplicate ticket** if blindly retried. So `submitToOpen311` retries **only** on pre-request connection errors (`ECONNREFUSED` / `ENOTFOUND` / `EAI_AGAIN` / `UND_ERR_CONNECT_TIMEOUT`) that prove the request never reached the server — and **never** after a timeout or after any HTTP response. Polling (`fetchOpen311Status`) is a GET and therefore safe to retry on any transient error or 5xx. The discriminated-result style (never throwing across the open311 boundary) is preserved throughout.

## Tests
New `src/lib/http.test.ts` covers `fetchWithTimeout` (success, timeout, caller-abort passthrough), `isTransientError`, and `withRetry` (no-retry success, retry-then-succeed, non-retryable, exhaustion, capped backoff). `npx tsc --noEmit`, `npm run lint`, `npm run format:check`, and `npm test` (220 passing) are green. `npm run build` compiles + typechecks clean; page-data collection fails only on a missing `DATABASE_URL` env var, unrelated to this change.

## Notes
The issue cited `src/app/api/cron/poll-status/route.ts` and a `fetchOpen311Status` caller; those don't exist on `main` yet (they're on a separate in-flight branch), so the library functions are hardened here and pick up the resilience automatically once wired.