### PR TITLE
ci: gate routing-engine eval accuracy on every push [#92]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,28 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+  eval:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nexa
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: nexa/package-lock.json
+
+      - run: npm ci
+
+      # Offline, deterministic routing eval (pure polygon lookups — no network,
+      # no LLM, no DB). Gates the build on O2.KR1 routing accuracy: the runner
+      # exits non-zero when accuracy is below target, failing this job.
+      # The classification LLM eval is intentionally NOT run here — it needs paid
+      # API keys / network and would break PRs from forks.
+      - name: Routing eval (accuracy gate)
+        run: npm run eval:routing

--- a/nexa/eval/routing.ts
+++ b/nexa/eval/routing.ts
@@ -237,6 +237,11 @@ async function main() {
   console.log(
     `\n${pass ? "PASS" : "BELOW TARGET"}: routing accuracy ${(metrics.accuracy * 100).toFixed(1)}% vs target ${(TARGET_ACCURACY * 100).toFixed(0)}% (O2.KR1).`,
   );
+
+  // Exit non-zero below target so CI gates the build on routing accuracy.
+  if (!pass) {
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## What

Closes #92. Wires the **offline routing eval** into CI as an accuracy gate that runs on every push to `main` and on PRs.

## Changes

- **`.github/workflows/ci.yml`** — adds a new, distinct `eval` job (`working-directory: nexa`) that runs `npm run eval:routing`. Kept separate from the existing `lint-and-typecheck` and `test` jobs, which are untouched.
- **`nexa/eval/routing.ts`** — the runner previously printed `PASS` / `BELOW TARGET` but always exited 0, so it could not gate CI. It now sets `process.exitCode = 1` when routing accuracy is below the O2.KR1 target (`TARGET_ACCURACY = 0.85`), so the CI job fails on regressions.

## Why only the routing eval

The routing eval is fully deterministic and offline (pure polygon lookups over bundled boundaries — no network, no LLM, no DB), so it is safe to run on every push including PRs from forks. The classification LLM eval is intentionally **not** wired into CI: it requires paid API keys / network and would break fork PRs.

## How failure is signaled

`npm run eval:routing` computes `accuracy >= TARGET_ACCURACY`. On pass it exits 0; below target it sets a non-zero exit code, which fails the `eval` job and the overall build. The pass rate is printed to the CI logs (`PASS: routing accuracy X% vs target 85%`) for weekly tracking.

## Verification

- `npm run eval:routing` → exits **0** at 100% accuracy (current dataset).
- Temporarily raising the target above the measured accuracy → runner prints `BELOW TARGET` and exits **1**, confirming the gate.
- Verified the eval runs offline without `prisma generate` (the only Prisma reference is a type-only import, erased at runtime), so no DB/codegen step is needed in the job.