### PR TITLE
feat(telemetry): measure full capture→submit time + metrics snapshot [#94]

### DIFF
--- a/nexa/docs/metrics/time-to-submit.md
+++ b/nexa/docs/metrics/time-to-submit.md
@@ -1,0 +1,39 @@
+# Time-to-submit metric snapshot
+
+Tracks the **capture → submit** latency of the report flow against the
+O1.KR2 / K2 service-level objectives.
+
+## Definition
+
+- **Source event:** `report_submitted` (PostHog), property `time_to_submit_ms`.
+- **Interval:** from the user's first capture action (first photo, or first
+  keystroke of the description) through a successful submit. This span
+  **includes** classification latency, matching the OKR definition of
+  capture → submitted.
+- **Stage event:** `report_classified` fires when classification completes, so
+  the capture → classify and classify → submit sub-stages remain queryable.
+
+## Targets (SLO)
+
+| Statistic | Target                |
+| --------- | --------------------- |
+| Median    | <= 60 s (60 000 ms)   |
+| p90       | <= 180 s (180 000 ms) |
+
+## PostHog dashboard
+
+> Manual step (out of code scope): create a saved PostHog insight/dashboard
+> computing median and p90 of `time_to_submit_ms` from `report_submitted`, with
+> the 60s/180s SLO lines marked, then paste the link below.
+
+- Dashboard link: _TODO — paste the committed PostHog dashboard URL here._
+
+## Snapshot
+
+> Fill from real data — at least one midpoint reading from the >= 10 P0 test
+> reports. Add a new row each time the snapshot is refreshed (e.g. in the
+> weekly CI eval summary).
+
+| Date (UTC) | n      | Median (ms) | p90 (ms) | Median <= 60s? | p90 <= 180s? | Notes  |
+| ---------- | ------ | ----------- | -------- | -------------- | ------------ | ------ |
+| _TODO_     | _TODO_ | _TODO_      | _TODO_   | _TODO_         | _TODO_       | _TODO_ |

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 import { Stepper, type ReportStep } from "@/components/report/stepper";
 import { DescribeStep } from "@/components/report/describe-step";
@@ -16,13 +16,30 @@ import { useI18n } from "@/i18n/provider";
 export default function ReportPage() {
   const posthog = usePostHog();
   const { t } = useI18n();
+  // `time_to_submit_ms` measures the full capture -> submit loop (O1.KR2 / K2).
+  // The clock starts at the user's first capture action — their first photo or
+  // first keystroke of the description — NOT at page mount and NOT at the
+  // classify POST. Anchoring it before classification means the reported
+  // interval includes classification latency, matching the OKR definition of
+  // capture -> submitted. Stays 0 until the first capture so an empty page that
+  // is never used contributes nothing.
   const flowStartedAt = useRef(0);
-  useEffect(() => {
-    flowStartedAt.current = Date.now();
+  const markCaptureStart = useCallback(() => {
+    if (flowStartedAt.current === 0) {
+      flowStartedAt.current = Date.now();
+    }
   }, []);
 
   const [step, setStep] = useState<ReportStep>("describe");
   const [description, setDescription] = useState("");
+
+  const handleDescriptionChange = useCallback(
+    (value: string) => {
+      markCaptureStart();
+      setDescription(value);
+    },
+    [markCaptureStart],
+  );
 
   const image = useImageUpload();
   const geo = useGeolocation();
@@ -96,10 +113,14 @@ export default function ReportPage() {
       {
         onSuccess: (report) => {
           setStep("confirmed");
+          // Guard against an unstarted clock (0) so we never emit an
+          // epoch-sized interval; in practice a submit always follows a
+          // capture, so the fallback is defensive only.
+          const captureStart = flowStartedAt.current || Date.now();
           posthog?.capture("report_submitted", {
             report_id: report.id,
             issue_type: classification.issueType,
-            time_to_submit_ms: Date.now() - flowStartedAt.current,
+            time_to_submit_ms: Date.now() - captureStart,
             has_image: !!image.imageBase64,
             has_location: !!geo.latitude,
           });
@@ -121,8 +142,19 @@ export default function ReportPage() {
     );
   };
 
+  const handleImageDrop = (e: React.DragEvent) => {
+    markCaptureStart();
+    image.handleDrop(e);
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    markCaptureStart();
+    image.handleFileInput(e);
+  };
+
   const resetForm = () => {
-    flowStartedAt.current = Date.now();
+    // Re-arm the clock: the next capture action starts a fresh interval.
+    flowStartedAt.current = 0;
     setStep("describe");
     setDescription("");
     image.clearImage();
@@ -159,9 +191,9 @@ export default function ReportPage() {
             classifyError={submission.classifyError}
             canSubmit={!!(image.imageBase64 || description.trim())}
             onImageClick={() => document.getElementById("photo-input")?.click()}
-            onDrop={image.handleDrop}
+            onDrop={handleImageDrop}
             onClearImage={image.clearImage}
-            onDescriptionChange={setDescription}
+            onDescriptionChange={handleDescriptionChange}
             onAddressChange={handleAddressChange}
             onDetectLocation={geo.detect}
             onLocationChange={geo.movePin}
@@ -180,7 +212,7 @@ export default function ReportPage() {
               submitError={submission.submitError}
               officialForm={formLookup.officialForm}
               officialFormLoading={formLookup.loading}
-              onDescriptionChange={setDescription}
+              onDescriptionChange={handleDescriptionChange}
               onAddressChange={geo.setAddress}
               onBack={() => setStep("describe")}
               onSubmit={handleSubmit}
@@ -264,7 +296,7 @@ export default function ReportPage() {
         accept="image/*"
         capture="environment"
         className="hidden"
-        onChange={image.handleFileInput}
+        onChange={handleFileInput}
       />
     </main>
   );


### PR DESCRIPTION
Closes part of #94 (the code-able parts).

## What changed

### 1. Timer start moved to the true capture moment
`time_to_submit_ms` (emitted on the `report_submitted` PostHog event) is meant to measure the full **capture → submitted** loop for O1.KR2 / K2. The start anchor was wrong.

**Before:** `flowStartedAt` was set in a `useEffect(() => { flowStartedAt.current = Date.now() }, [])` that ran once on page mount. The audit in #94 flagged this interval as not reflecting the intended capture → submit definition.

**After:** the clock starts at the user's **first capture action** — their first photo (file input / drop) or first keystroke of the description — via a `markCaptureStart()` helper that sets `flowStartedAt` once (only while it is still `0`). Because this is anchored *before* the classify POST, the measured interval now includes classification latency, matching the OKR definition.

- `markCaptureStart()` is wired into the description change handler and the image add (file-input + drop) handlers.
- `resetForm` re-arms the clock to `0` so "report another" starts a fresh interval at the next capture.
- The submit emit guards against an unstarted clock (`flowStartedAt.current || Date.now()`) so a never-captured page can never emit an epoch-sized value — defensive only, since a submit always follows a capture.

**Event payloads are unchanged:** event names (`report_classified`, `report_submitted`, `report_queued_offline`) and all payload keys — including `time_to_submit_ms` — are identical. Only the start timestamp the duration is computed from changed.

### 2. Committed metrics snapshot
Added `nexa/docs/metrics/time-to-submit.md` — a template recording date, n, median, p90 and pass/fail vs the 60s median / 180s p90 targets, to be filled from real data.

## Out of code scope (manual follow-up)
Building the external PostHog dashboard and capturing the actual median/p90 readings from the >= 10 P0 test reports are **manual steps** (not code). The dashboard link and snapshot rows are left as TODO placeholders in `docs/metrics/time-to-submit.md` for someone to fill in.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated)
- `npm run format:check` — all files match Prettier
- `npm test` — 210 passed (18 files)