### PR TITLE
feat(submission): re-land Open311 status-polling service (fail-closed) [#37][#99]

### DIFF
--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
+import {
+  fetchOpen311Status,
+  parseOpen311Config,
+  STATUS_RANK,
+} from "@/lib/submission/open311";
+
+// GET /api/cron/poll-status
+//
+// Status polling service (issue #37). Intended to run on a schedule (e.g. a
+// Vercel Cron entry in vercel.json). For every report that has been submitted
+// to an Open311 agency and isn't yet in a terminal state, it queries the
+// endpoint for the latest status and advances the report's lifecycle.
+//
+// Protected by CRON_SECRET: callers must send `Authorization: Bearer <secret>`.
+// Vercel Cron automatically attaches this header when CRON_SECRET is set.
+//
+// Fail closed: if CRON_SECRET is unset/empty we refuse the request (503) and do
+// NOT poll, so a missing secret can never expose this endpoint to unauthenticated
+// callers triggering external Open311 traffic (#99).
+
+// States we still expect updates for. RESOLVED/CLOSED are terminal, so we stop
+// polling them to keep the job cheap.
+const TRACKABLE_STATUSES: ReportStatus[] = [
+  ReportStatus.SUBMITTED,
+  ReportStatus.ACKNOWLEDGED,
+  ReportStatus.IN_PROGRESS,
+];
+
+// Cap work per invocation so a backlog can't blow the cron timeout.
+const MAX_PER_RUN = 100;
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  // Fail closed: without a configured secret there is no way to authenticate the
+  // caller, so refuse rather than run polling unauthenticated.
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Cron polling is not configured." },
+      { status: 503 },
+    );
+  }
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  try {
+    const reports = await prisma.report.findMany({
+      where: {
+        status: { in: TRACKABLE_STATUSES },
+        externalTrackingId: { not: null },
+        agency: { intakeMethod: IntakeMethod.API },
+      },
+      include: { agency: true },
+      take: MAX_PER_RUN,
+      orderBy: { updatedAt: "asc" },
+    });
+
+    let checked = 0;
+    let updated = 0;
+    let errors = 0;
+
+    for (const report of reports) {
+      if (!report.agency || !report.externalTrackingId) continue;
+      checked++;
+
+      const config = parseOpen311Config(report.agency.requiredFields);
+      const result = await fetchOpen311Status(report.externalTrackingId, {
+        config,
+        intakeUrl: report.agency.intakeUrl,
+      });
+
+      if (result.status !== "ok" || !result.reportStatus) {
+        if (result.status === "error") errors++;
+        continue;
+      }
+
+      // Never regress: only advance to a status strictly later in the lifecycle.
+      if (STATUS_RANK[result.reportStatus] <= STATUS_RANK[report.status]) {
+        continue;
+      }
+
+      await prisma.report.update({
+        where: { id: report.id },
+        data: { status: result.reportStatus },
+      });
+      updated++;
+    }
+
+    return NextResponse.json({ checked, updated, errors });
+  } catch (error) {
+    console.error("Status poll error:", error);
+    return NextResponse.json(
+      { error: "Status polling failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/nexa/vercel.json
+++ b/nexa/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/poll-status",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Re-lands the Open311 status-polling service that was merged (PR #79) then reverted (PR #84 / commit `0408a34`), in its hardened **fail-closed** form.

## What changed
- **`nexa/src/app/api/cron/poll-status/route.ts`** — `GET` cron endpoint that, for every report submitted to an Open311 (API-intake) agency and not yet in a terminal state, polls the endpoint and advances the report's lifecycle (never regressing, via `STATUS_RANK`). Caps work at 100 reports/run.
  - **Fail closed (#99):** if `CRON_SECRET` is unset/empty the route returns **503 and does no polling**, so a missing secret can never expose the endpoint to unauthenticated callers triggering external Open311 traffic. When the secret is set, the caller must send `Authorization: Bearer <secret>` (Vercel Cron attaches this automatically).
- **`nexa/vercel.json`** — restores the cron entry with a **once-daily** schedule (`0 8 * * *`), which fits the Vercel Hobby plan's one-run-per-day limit (the original hourly schedule failed at deploy time).

## Compiles against current main
The route reuses current main's APIs, not stale ones:
- `fetchOpen311Status(serviceRequestId, { config, intakeUrl })` → `StatusResult` (`ok` / `not_found` / `error`); the route reads `result.status` and `result.reportStatus` exactly as defined on main (incl. the recently-hardened retry behavior — unchanged here).
- `parseOpen311Config(agency.requiredFields)` and `STATUS_RANK` are imported from `@/lib/submission/open311`.
- `ReportStatus` / `IntakeMethod` from `@/generated/prisma/enums`; `prisma` from `@/lib/prisma`. All referenced `Report`/`Agency` fields (`externalTrackingId`, `status`, `updatedAt`, `agency.intakeMethod`, `agency.intakeUrl`, `agency.requiredFields`) exist in the current schema.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in unrelated components)
- `npm run format:check` — clean
- `npm test` — 220 passed (19 files)
- `npm run build` — compiles + typechecks successfully; only fails at page-data collection on missing `DATABASE_URL` for the unrelated `/api/reports/[id]/submit` route (expected in this env)

Closes #37
Closes #99