### PR TITLE
feat(ops): cron + health observability — DB health check, structured failure signaling [#108]

### DIFF
--- a/nexa/src/app/api/cron/poll-status/route.test.ts
+++ b/nexa/src/app/api/cron/poll-status/route.test.ts
@@ -1,0 +1,183 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeAgency } from "@/test/factories/agency";
+import { makeReport } from "@/test/factories/report";
+import { prismaMock } from "@/test/prisma-mock";
+import { ReportStatus } from "@/generated/prisma/enums";
+
+// Mock the Open311 module so we control poll results without any network. We
+// re-export the real STATUS_RANK / parseOpen311Config so the route's lifecycle
+// logic still runs; only fetchOpen311Status is stubbed. `vi.hoisted` lets the
+// hoisted `vi.mock` factory reference the spy without a TDZ error.
+const { fetchOpen311Status } = vi.hoisted(() => ({
+  fetchOpen311Status: vi.fn(),
+}));
+vi.mock("@/lib/submission/open311", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/submission/open311")>();
+  return { ...actual, fetchOpen311Status };
+});
+
+import { GET } from "./route";
+
+const SECRET = "test-cron-secret";
+
+function authedRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/cron/poll-status", {
+    headers: { authorization: `Bearer ${SECRET}` },
+  });
+}
+
+function trackedReport() {
+  return makeReport({
+    status: ReportStatus.SUBMITTED,
+    externalTrackingId: "sr-123",
+    agency: makeAgency(),
+  } as Parameters<typeof makeReport>[0]);
+}
+
+describe("GET /api/cron/poll-status", () => {
+  beforeEach(() => {
+    vi.stubEnv("CRON_SECRET", SECRET);
+    fetchOpen311Status.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 503 when CRON_SECRET is unset (fail closed)", async () => {
+    // Arrange
+    vi.stubEnv("CRON_SECRET", "");
+
+    // Act
+    const response = await GET(authedRequest());
+
+    // Assert
+    expect(response.status).toBe(503);
+    expect(prismaMock.report.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the bearer token is wrong", async () => {
+    // Act
+    const response = await GET(
+      new NextRequest("http://localhost/api/cron/poll-status", {
+        headers: { authorization: "Bearer nope" },
+      }),
+    );
+
+    // Assert
+    expect(response.status).toBe(401);
+  });
+
+  it("advances a report and returns a 200 summary on success", async () => {
+    // Arrange
+    prismaMock.report.findMany.mockResolvedValue([trackedReport()]);
+    prismaMock.report.update.mockResolvedValue(makeReport());
+    fetchOpen311Status.mockResolvedValue({
+      status: "ok",
+      open311Status: "closed",
+      reportStatus: ReportStatus.RESOLVED,
+      statusNotes: null,
+    });
+
+    // Act
+    const response = await GET(authedRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      checked: 1,
+      updated: 1,
+      errors: 0,
+      ok: true,
+      failures: [],
+    });
+  });
+
+  it("logs a structured per-report failure with the alert prefix", async () => {
+    // Arrange
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    prismaMock.report.findMany.mockResolvedValue([trackedReport()]);
+    fetchOpen311Status.mockResolvedValue({
+      status: "error",
+      httpStatus: 500,
+      message: "Open311 endpoint returned HTTP 500.",
+    });
+
+    // Act
+    const response = await GET(authedRequest());
+    const body = await response.json();
+
+    // Assert: a single failure -> 100% error rate -> 503, with a structured
+    // failure record carrying the report + service request id and reason.
+    expect(response.status).toBe(503);
+    expect(body.ok).toBe(false);
+    expect(body.failures).toHaveLength(1);
+    expect(body.failures[0]).toMatchObject({
+      serviceRequestId: "sr-123",
+      httpStatus: 500,
+      reason: "Open311 endpoint returned HTTP 500.",
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[poll-status][ALERT]"),
+      expect.objectContaining({ serviceRequestId: "sr-123" }),
+    );
+  });
+
+  it("returns 200 when the failure rate stays below the threshold", async () => {
+    // Arrange: 1 failure out of 3 (33%) < 50% threshold.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    prismaMock.report.findMany.mockResolvedValue([
+      trackedReport(),
+      trackedReport(),
+      trackedReport(),
+    ]);
+    prismaMock.report.update.mockResolvedValue(makeReport());
+    fetchOpen311Status
+      .mockResolvedValueOnce({
+        status: "ok",
+        open311Status: "closed",
+        reportStatus: ReportStatus.RESOLVED,
+        statusNotes: null,
+      })
+      .mockResolvedValueOnce({
+        status: "ok",
+        open311Status: "closed",
+        reportStatus: ReportStatus.RESOLVED,
+        statusNotes: null,
+      })
+      .mockResolvedValueOnce({
+        status: "error",
+        httpStatus: 503,
+        message: "unavailable",
+      });
+
+    // Act
+    const response = await GET(authedRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ checked: 3, errors: 1, ok: true });
+  });
+
+  it("returns 500 with the alert prefix when the DB query throws", async () => {
+    // Arrange
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    prismaMock.report.findMany.mockRejectedValue(new Error("db down"));
+
+    // Act
+    const response = await GET(authedRequest());
+
+    // Assert
+    expect(response.status).toBe(500);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[poll-status][ALERT]"),
+      expect.any(Error),
+    );
+  });
+});

--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -32,6 +32,25 @@ const TRACKABLE_STATUSES: ReportStatus[] = [
 // Cap work per invocation so a backlog can't blow the cron timeout.
 const MAX_PER_RUN = 100;
 
+// Prefix every operational failure line with this token so an external log
+// monitor (Vercel log drains, Logflare, a grep-based alert, etc.) can match on
+// it and alert. Kept deliberately greppable — see the PR for the alerting hook.
+const ALERT_PREFIX = "[poll-status][ALERT]";
+
+// When at least this share of the reports we attempted fail, the run is treated
+// as unhealthy and the route returns 503 so Vercel Cron records a failure rather
+// than a silent partial success. Below the threshold we still report the count
+// but return 200, since a few transient per-report errors are expected.
+const ERROR_RATE_THRESHOLD = 0.5;
+
+// One structured failure record per report we couldn't poll.
+type ReportFailure = {
+  reportId: string;
+  serviceRequestId: string | null;
+  httpStatus: number | null;
+  reason: string;
+};
+
 export async function GET(request: NextRequest) {
   const secret = process.env.CRON_SECRET;
   // Fail closed: without a configured secret there is no way to authenticate the
@@ -61,7 +80,7 @@ export async function GET(request: NextRequest) {
 
     let checked = 0;
     let updated = 0;
-    let errors = 0;
+    const failures: ReportFailure[] = [];
 
     for (const report of reports) {
       if (!report.agency || !report.externalTrackingId) continue;
@@ -74,7 +93,18 @@ export async function GET(request: NextRequest) {
       });
 
       if (result.status !== "ok" || !result.reportStatus) {
-        if (result.status === "error") errors++;
+        if (result.status === "error") {
+          // Structured, per-report failure log: report id + service request id
+          // + HTTP status + reason, so a failed poll is traceable from the logs.
+          const failure: ReportFailure = {
+            reportId: report.id,
+            serviceRequestId: report.externalTrackingId,
+            httpStatus: result.httpStatus,
+            reason: result.message,
+          };
+          failures.push(failure);
+          console.error(`${ALERT_PREFIX} report poll failed`, failure);
+        }
         continue;
       }
 
@@ -90,9 +120,26 @@ export async function GET(request: NextRequest) {
       updated++;
     }
 
-    return NextResponse.json({ checked, updated, errors });
+    const errors = failures.length;
+    // Treat the run as unhealthy when too large a share of attempts failed, so
+    // Vercel Cron sees a non-2xx and the failure is observable. The summary is
+    // always returned so callers can act on it regardless of status code.
+    const errorRate = checked === 0 ? 0 : errors / checked;
+    const ok = errorRate < ERROR_RATE_THRESHOLD;
+    const summary = { checked, updated, errors, failures, ok };
+
+    if (!ok) {
+      console.error(
+        `${ALERT_PREFIX} run unhealthy: ${errors}/${checked} reports failed`,
+      );
+      return NextResponse.json(summary, { status: 503 });
+    }
+
+    return NextResponse.json(summary);
   } catch (error) {
-    console.error("Status poll error:", error);
+    // Whole-run failure (e.g. DB unreachable): emit the alert prefix too so the
+    // same monitor catches a total outage, not just per-report failures.
+    console.error(`${ALERT_PREFIX} status poll crashed:`, error);
     return NextResponse.json(
       { error: "Status polling failed." },
       { status: 500 },

--- a/nexa/src/app/api/health/route.test.ts
+++ b/nexa/src/app/api/health/route.test.ts
@@ -1,35 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { http, HttpResponse } from "@/test/msw/handlers";
-import { server } from "@/test/msw/server";
+import { prismaMock } from "@/test/prisma-mock";
 
 import { GET } from "./route";
 
-// Integration test (node project) for a route handler. The health route is the
-// simplest handler; this also proves the MSW server is live (an un-stubbed
-// outbound request would fail under onUnhandledRequest: "error").
+// Integration test (node project) for the health route with the Prisma
+// singleton deep-mocked. The route now probes the DB with `SELECT 1`, so these
+// tests stub `$queryRaw` to simulate a reachable / unreachable database.
 describe("GET /api/health", () => {
-  it("responds 200 with status ok", async () => {
-    // Arrange / Act
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("responds 200 with status ok when the DB probe succeeds", async () => {
+    // Arrange: SELECT 1 resolves.
+    prismaMock.$queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+
+    // Act
     const response = await GET();
 
     // Assert
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ok" });
+    await expect(response.json()).resolves.toEqual({
+      status: "ok",
+      database: "ok",
+    });
   });
 
-  it("has a live MSW server that serves a stubbed handler", async () => {
-    // Arrange: register a per-test handler.
-    server.use(
-      http.get("https://example.test/ping", () =>
-        HttpResponse.json({ pong: true }),
-      ),
-    );
+  it("responds 503 when the DB probe throws", async () => {
+    // Arrange: silence the expected error log, make the probe reject.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    prismaMock.$queryRaw.mockRejectedValue(new Error("connection refused"));
 
     // Act
-    const res = await fetch("https://example.test/ping");
+    const response = await GET();
 
     // Assert
-    await expect(res.json()).resolves.toEqual({ pong: true });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: "error",
+      database: "unreachable",
+    });
   });
 });

--- a/nexa/src/app/api/health/route.ts
+++ b/nexa/src/app/api/health/route.ts
@@ -1,3 +1,55 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// GET /api/health
+//
+// Liveness + readiness probe (issue #108). Beyond reporting that the process is
+// up, this actually verifies the database is reachable by running a cheap
+// `SELECT 1`, so an external monitor (e.g. Vercel/UptimeRobot) can distinguish a
+// healthy app from one whose DB is unreachable.
+//
+// Returns 200 with `{ status: "ok", database: "ok" }` when the DB responds, and
+// 503 with `{ status: "error", database: "unreachable" }` when it does not.
+
+// Bound the probe so a hung connection can't make the health check itself hang.
+const DB_PROBE_TIMEOUT_MS = 5_000;
+
 export async function GET() {
-  return Response.json({ status: "ok" });
+  const dbOk = await checkDatabase();
+
+  if (!dbOk) {
+    return NextResponse.json(
+      { status: "error", database: "unreachable" },
+      { status: 503 },
+    );
+  }
+
+  return NextResponse.json({ status: "ok", database: "ok" });
+}
+
+/**
+ * Run a lightweight `SELECT 1` against the database, bounded by a timeout.
+ * Returns `true` only if the query resolves before the deadline; any error or
+ * timeout returns `false` (and logs a recognizable prefix for monitors).
+ */
+async function checkDatabase(): Promise<boolean> {
+  try {
+    await Promise.race([
+      prisma.$queryRaw`SELECT 1`,
+      new Promise((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(`DB probe timed out after ${DB_PROBE_TIMEOUT_MS}ms`),
+            ),
+          DB_PROBE_TIMEOUT_MS,
+        ),
+      ),
+    ]);
+    return true;
+  } catch (error) {
+    // Recognizable prefix so an external log monitor can alert on it.
+    console.error("[health] DB probe failed:", error);
+    return false;
+  }
 }


### PR DESCRIPTION
Closes #108.

Adds operational visibility for the poll-status cron and the health probe — no new dependencies, no paid SaaS.

## What `/api/health` now checks
Previously returned `{ status: "ok" }` unconditionally with no dependency probe. It now runs a cheap `prisma.$queryRaw\`SELECT 1\``, bounded by a 5s timeout (so a hung connection can't hang the probe itself):

- DB reachable → `200 { status: "ok", database: "ok" }`
- DB unreachable / probe times out → `503 { status: "error", database: "unreachable" }` (and logs `[health] DB probe failed: …`)

An external monitor (Vercel, UptimeRobot, etc.) can now distinguish a healthy app from one whose DB is down.

## Failure-signaling approach (poll-status)
The cron previously incremented an in-memory `errors` counter and `continue`d, returning a generic 200 — Vercel Cron could not tell a healthy run from one that silently failed N reports.

- **Structured per-report failure logging.** On a per-report poll error we now record `{ reportId, serviceRequestId, httpStatus, reason }` (reason/httpStatus come from the existing Open311 `StatusResult` error variant) and log it.
- **Failure summary in the response.** The JSON now includes `{ checked, updated, errors, failures, ok }`, so callers see exactly which service requests failed and why.
- **Non-200 on unhealthy runs.** When the per-report error rate ≥ 50% (`ERROR_RATE_THRESHOLD`), the route returns `503` so Vercel Cron records a failure instead of a silent partial success. A few transient errors below the threshold still return 200.
- **Alerting hook.** Per-report failures, unhealthy runs, and whole-run crashes all emit a greppable `[poll-status][ALERT]` prefix. An external log monitor (Vercel log drain, Logflare, a grep-based alert) can match on this token to fire an alert — no paid alerting SaaS integrated.

The existing fail-closed auth (503 when `CRON_SECRET` unset, 401 on bad bearer) and polling/lifecycle behavior are unchanged.

## Tests
- `health/route.test.ts`: 200 on DB ok, 503 when the probe throws.
- `cron/poll-status/route.test.ts` (new): fail-closed 503/401 auth, success summary, structured failure log with the alert prefix, sub-threshold errors stay 200, and whole-run crash → 500 with the alert prefix.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in unrelated component files)
- `npm run format:check` — clean
- `npm test` — 226 passed (20 files)