### PR TITLE
feat(api): shared success/error response envelope [#125]

### DIFF
--- a/nexa/src/app/api/auth/claim/route.ts
+++ b/nexa/src/app/api/auth/claim/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import bcrypt from "bcryptjs";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 // One-shot path to set a password on accounts that never had one. This exists
 // to clean up after a prior bug in /api/auth/login that upserted users by
@@ -14,17 +15,11 @@ export async function POST(request: NextRequest) {
     const { email, password, name } = await request.json();
 
     if (!email || !password) {
-      return NextResponse.json(
-        { error: "Email and password are required" },
-        { status: 400 },
-      );
+      return errorResponse("Email and password are required", 400);
     }
 
     if (typeof password !== "string" || password.length < 8) {
-      return NextResponse.json(
-        { error: "Password must be at least 8 characters" },
-        { status: 400 },
-      );
+      return errorResponse("Password must be at least 8 characters", 400);
     }
 
     const existing = await prisma.user.findUnique({
@@ -33,12 +28,9 @@ export async function POST(request: NextRequest) {
     });
 
     if (existing && existing.passwordHash) {
-      return NextResponse.json(
-        {
-          error:
-            "This account already has a password. Sign in instead, or reset your password.",
-        },
-        { status: 409 },
+      return errorResponse(
+        "This account already has a password. Sign in instead, or reset your password.",
+        409,
       );
     }
 
@@ -56,14 +48,11 @@ export async function POST(request: NextRequest) {
         });
 
     const token = await createToken({ userId: user.id, email: user.email });
-    const response = NextResponse.json(user, { status: 200 });
+    const response = successResponse(user);
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
   } catch (error) {
     console.error("Account claim error:", error);
-    return NextResponse.json(
-      { error: "Failed to set password. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to set password. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/auth/login/route.ts
+++ b/nexa/src/app/api/auth/login/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import bcrypt from "bcryptjs";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -8,16 +8,14 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function POST(request: NextRequest) {
   try {
     const { email, password } = await parseJsonRequest(request, LoginSchema);
 
     if (!email || !password) {
-      return NextResponse.json(
-        { error: "Email and password are required" },
-        { status: 400 },
-      );
+      return errorResponse("Email and password are required", 400);
     }
 
     const user = await prisma.user.findUnique({
@@ -28,25 +26,20 @@ export async function POST(request: NextRequest) {
     // Use the same generic message for "no user" and "wrong password" so the
     // login endpoint cannot be used to enumerate which emails have accounts.
     if (!user || !user.passwordHash) {
-      return NextResponse.json(
-        { error: "Invalid email or password" },
-        { status: 401 },
-      );
+      return errorResponse("Invalid email or password", 401);
     }
 
     const ok = await bcrypt.compare(password, user.passwordHash);
     if (!ok) {
-      return NextResponse.json(
-        { error: "Invalid email or password" },
-        { status: 401 },
-      );
+      return errorResponse("Invalid email or password", 401);
     }
 
     const token = await createToken({ userId: user.id, email: user.email });
-    const response = NextResponse.json(
-      { id: user.id, email: user.email, name: user.name },
-      { status: 200 },
-    );
+    const response = successResponse({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+    });
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
   } catch (error) {
@@ -54,9 +47,6 @@ export async function POST(request: NextRequest) {
       return parseErrorResponse(error);
     }
     console.error("Login error:", error);
-    return NextResponse.json(
-      { error: "Login failed. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Login failed. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/auth/logout/route.ts
+++ b/nexa/src/app/api/auth/logout/route.ts
@@ -1,11 +1,11 @@
 // POST /api/auth/logout
 // Ends the user's session by overwriting the cookie with an expired empty value.
 
-import { NextResponse } from "next/server";
 import { SESSION_COOKIE } from "@/lib/auth";
+import { successResponse } from "@/lib/api/response";
 
 export async function POST() {
-  const response = NextResponse.json({ success: true });
+  const response = successResponse({ loggedOut: true });
   // Setting maxAge=0 tells the browser to delete the cookie immediately
   response.cookies.set(SESSION_COOKIE, "", { maxAge: 0, path: "/" });
   return response;

--- a/nexa/src/app/api/auth/me/route.ts
+++ b/nexa/src/app/api/auth/me/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function GET() {
   const session = await getSession();
   if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    return errorResponse("Not authenticated", 401);
   }
 
-  return NextResponse.json({
+  return successResponse({
     id: session.userId,
     email: session.email,
     name: session.email.split("@")[0],

--- a/nexa/src/app/api/auth/register/route.ts
+++ b/nexa/src/app/api/auth/register/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
@@ -8,6 +8,7 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,25 +18,16 @@ export async function POST(request: NextRequest) {
     );
 
     if (!email || !password) {
-      return NextResponse.json(
-        { error: "Email and password are required" },
-        { status: 400 },
-      );
+      return errorResponse("Email and password are required", 400);
     }
 
     if (password.length < 8) {
-      return NextResponse.json(
-        { error: "Password must be at least 8 characters" },
-        { status: 400 },
-      );
+      return errorResponse("Password must be at least 8 characters", 400);
     }
 
     const existing = await prisma.user.findUnique({ where: { email } });
     if (existing) {
-      return NextResponse.json(
-        { error: "An account with this email already exists" },
-        { status: 409 },
-      );
+      return errorResponse("An account with this email already exists", 409);
     }
 
     const passwordHash = await bcrypt.hash(password, 10);
@@ -49,9 +41,9 @@ export async function POST(request: NextRequest) {
     });
 
     const token = await createToken({ userId: user.id, email: user.email });
-    const response = NextResponse.json(
+    const response = successResponse(
       { id: user.id, email: user.email, name: user.name },
-      { status: 201 },
+      201,
     );
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
@@ -60,9 +52,6 @@ export async function POST(request: NextRequest) {
       return parseErrorResponse(error);
     }
     console.error("Registration error:", error);
-    return NextResponse.json(
-      { error: "Registration failed. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Registration failed. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/health/route.test.ts
+++ b/nexa/src/app/api/health/route.test.ts
@@ -6,7 +6,8 @@ import { GET } from "./route";
 
 // Integration test (node project) for the health route with the Prisma
 // singleton deep-mocked. The route now probes the DB with `SELECT 1`, so these
-// tests stub `$queryRaw` to simulate a reachable / unreachable database.
+// tests stub `$queryRaw` to simulate a reachable / unreachable database, and
+// assert the shared API response envelope shape.
 describe("GET /api/health", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -22,8 +23,8 @@ describe("GET /api/health", () => {
     // Assert
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      status: "ok",
-      database: "ok",
+      success: true,
+      data: { status: "ok", database: "ok" },
     });
   });
 
@@ -38,8 +39,9 @@ describe("GET /api/health", () => {
     // Assert
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toEqual({
-      status: "error",
-      database: "unreachable",
+      success: false,
+      error: "Database unreachable",
+      code: "db_unreachable",
     });
   });
 });

--- a/nexa/src/app/api/health/route.ts
+++ b/nexa/src/app/api/health/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { errorResponse, successResponse } from "@/lib/api/response";
 import { prisma } from "@/lib/prisma";
 
 // GET /api/health
@@ -8,8 +8,9 @@ import { prisma } from "@/lib/prisma";
 // `SELECT 1`, so an external monitor (e.g. Vercel/UptimeRobot) can distinguish a
 // healthy app from one whose DB is unreachable.
 //
-// Returns 200 with `{ status: "ok", database: "ok" }` when the DB responds, and
-// 503 with `{ status: "error", database: "unreachable" }` when it does not.
+// Returns 200 `{ success: true, data: { status: "ok", database: "ok" } }` when
+// the DB responds, and 503 `{ success: false, error, code: "db_unreachable" }`
+// when it does not.
 
 // Bound the probe so a hung connection can't make the health check itself hang.
 const DB_PROBE_TIMEOUT_MS = 5_000;
@@ -18,13 +19,10 @@ export async function GET() {
   const dbOk = await checkDatabase();
 
   if (!dbOk) {
-    return NextResponse.json(
-      { status: "error", database: "unreachable" },
-      { status: 503 },
-    );
+    return errorResponse("Database unreachable", 503, "db_unreachable");
   }
 
-  return NextResponse.json({ status: "ok", database: "ok" });
+  return successResponse({ status: "ok", database: "ok" });
 }
 
 /**

--- a/nexa/src/app/api/issues/map/route.ts
+++ b/nexa/src/app/api/issues/map/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { getIssueMapPoints } from "@/lib/issues/map";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 /**
  * Aggregated community issue map: every IssueGroup as a single pin, regardless
@@ -10,9 +10,9 @@ import { getIssueMapPoints } from "@/lib/issues/map";
 export async function GET() {
   const session = await getSession();
   if (!session) {
-    return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+    return errorResponse("Not authenticated.", 401);
   }
 
   const points = await getIssueMapPoints(session.userId);
-  return NextResponse.json({ points });
+  return successResponse({ points });
 }

--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getGoogleMapsApiKey } from "@/lib/config";
 import { fetchWithTimeout } from "@/lib/http";
+import { successResponse } from "@/lib/api/response";
 
 type NominatimSearchResult = {
   display_name?: string;
@@ -162,7 +163,7 @@ export async function GET(request: NextRequest) {
   try {
     const query = request.nextUrl.searchParams.get("q")?.trim() ?? "";
     if (query.length < 3) {
-      return NextResponse.json({ suggestions: [] });
+      return successResponse({ suggestions: [] });
     }
 
     const googleApiKey = getGoogleMapsApiKey();
@@ -176,9 +177,9 @@ export async function GET(request: NextRequest) {
       suggestions = await fetchNominatimSuggestions(query);
     }
 
-    return NextResponse.json({ suggestions });
+    return successResponse({ suggestions });
   } catch (error) {
     console.error("Location suggestion error:", error);
-    return NextResponse.json({ suggestions: [] });
+    return successResponse({ suggestions: [] });
   }
 }

--- a/nexa/src/app/api/reports/[id]/resolution/route.ts
+++ b/nexa/src/app/api/reports/[id]/resolution/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { ResolutionSchema } from "@/lib/api/schemas";
@@ -7,6 +7,7 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function POST(
   request: NextRequest,
@@ -15,10 +16,7 @@ export async function POST(
   try {
     const session = await getSession();
     if (!session) {
-      return NextResponse.json(
-        { error: "Not authenticated." },
-        { status: 401 },
-      );
+      return errorResponse("Not authenticated.", 401);
     }
 
     const { id } = await context.params;
@@ -30,14 +28,11 @@ export async function POST(
     });
 
     if (!report) {
-      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+      return errorResponse("Report not found.", 404);
     }
 
     if (report.userId !== session.userId) {
-      return NextResponse.json(
-        { error: "You can only update your own reports." },
-        { status: 403 },
-      );
+      return errorResponse("You can only update your own reports.", 403);
     }
 
     const resolvedAt = new Date();
@@ -69,7 +64,7 @@ export async function POST(
         }),
       ]);
 
-      return NextResponse.json({
+      return successResponse({
         id: report.id,
         userResolved: true,
         status: report.status === "CLOSED" ? "CLOSED" : "RESOLVED",
@@ -89,15 +84,12 @@ export async function POST(
       select: { id: true, userResolved: true, status: true },
     });
 
-    return NextResponse.json(updated);
+    return successResponse(updated);
   } catch (error) {
     if (error instanceof RequestParseError) {
       return parseErrorResponse(error);
     }
     console.error("Report resolution update error:", error);
-    return NextResponse.json(
-      { error: "Failed to update resolution. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to update resolution. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/reports/[id]/route.ts
+++ b/nexa/src/app/api/reports/[id]/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function DELETE(
   _request: NextRequest,
@@ -9,10 +10,7 @@ export async function DELETE(
   try {
     const session = await getSession();
     if (!session) {
-      return NextResponse.json(
-        { error: "Not authenticated." },
-        { status: 401 },
-      );
+      return errorResponse("Not authenticated.", 401);
     }
 
     const { id } = await context.params;
@@ -23,14 +21,11 @@ export async function DELETE(
     });
 
     if (!report) {
-      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+      return errorResponse("Report not found.", 404);
     }
 
     if (report.userId !== session.userId) {
-      return NextResponse.json(
-        { error: "You can only delete your own reports." },
-        { status: 403 },
-      );
+      return errorResponse("You can only delete your own reports.", 403);
     }
 
     // Delete the report and keep its IssueGroup consistent: a stale reportCount
@@ -74,12 +69,9 @@ export async function DELETE(
       });
     });
 
-    return NextResponse.json({ success: true });
+    return successResponse({ deleted: true });
   } catch (error) {
     console.error("Report deletion error:", error);
-    return NextResponse.json(
-      { error: "Failed to delete report. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to delete report. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/reports/[id]/submission-fields/route.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 import { buildPrefillFields } from "@/lib/submission/prefill";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 // GET /api/reports/[id]/submission-fields
 //
@@ -24,13 +25,10 @@ export async function GET(
     });
 
     if (!report) {
-      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+      return errorResponse("Report not found.", 404);
     }
     if (report.userId && report.userId !== session?.userId) {
-      return NextResponse.json(
-        { error: "You can only view your own reports." },
-        { status: 403 },
-      );
+      return errorResponse("You can only view your own reports.", 403);
     }
 
     // Resolve the agency for display without persisting (this is a read).
@@ -47,7 +45,7 @@ export async function GET(
     }
 
     if (!agency) {
-      return NextResponse.json({ agency: null, fields: [] });
+      return successResponse({ agency: null, fields: [] });
     }
 
     const fields = buildPrefillFields(
@@ -64,7 +62,7 @@ export async function GET(
       agency.requiredFields,
     );
 
-    return NextResponse.json({
+    return successResponse({
       agency: {
         name: agency.name,
         intakeUrl: agency.intakeUrl,
@@ -75,9 +73,6 @@ export async function GET(
     });
   } catch (error) {
     console.error("Submission fields error:", error);
-    return NextResponse.json(
-      { error: "Failed to build submission fields." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to build submission fields.", 500);
   }
 }

--- a/nexa/src/app/api/reports/[id]/submit/route.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.ts
@@ -1,9 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
 import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 // POST /api/reports/[id]/submit
 //
@@ -28,24 +29,18 @@ export async function POST(
     });
 
     if (!report) {
-      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+      return errorResponse("Report not found.", 404);
     }
 
     // Only the report's owner may submit it. Anonymous (userId === null)
     // reports remain submittable by anyone holding the link, matching the
     // anonymous-reporting model elsewhere in the app.
     if (report.userId && report.userId !== session?.userId) {
-      return NextResponse.json(
-        { error: "You can only submit your own reports." },
-        { status: 403 },
-      );
+      return errorResponse("You can only submit your own reports.", 403);
     }
 
     if (report.status === ReportStatus.SUBMITTED || report.externalTrackingId) {
-      return NextResponse.json(
-        { error: "This report has already been submitted." },
-        { status: 409 },
-      );
+      return errorResponse("This report has already been submitted.", 409);
     }
 
     // Reports created before jurisdiction routing existed (or whose location
@@ -63,17 +58,12 @@ export async function POST(
       }
     }
     if (!agency) {
-      return NextResponse.json(
-        { error: "No agency is assigned to this report." },
-        { status: 400 },
-      );
+      return errorResponse("No agency is assigned to this report.", 400);
     }
     if (agency.intakeMethod !== IntakeMethod.API) {
-      return NextResponse.json(
-        {
-          error: `Agency "${agency.name}" does not accept API submissions (intake method: ${agency.intakeMethod}).`,
-        },
-        { status: 400 },
+      return errorResponse(
+        `Agency "${agency.name}" does not accept API submissions (intake method: ${agency.intakeMethod}).`,
+        400,
       );
     }
 
@@ -86,10 +76,7 @@ export async function POST(
       data: { status: ReportStatus.SUBMITTING },
     });
     if (claim.count !== 1) {
-      return NextResponse.json(
-        { error: "This report is already being submitted." },
-        { status: 409 },
-      );
+      return errorResponse("This report is already being submitted.", 409);
     }
 
     const config = parseOpen311Config(agency.requiredFields);
@@ -104,10 +91,7 @@ export async function POST(
         where: { id },
         data: { status: ReportStatus.CONFIRMED },
       });
-      return NextResponse.json(
-        { error: `Submission failed: ${result.message}` },
-        { status: 502 },
-      );
+      return errorResponse(`Submission failed: ${result.message}`, 502);
     }
 
     const updated = await prisma.report.update({
@@ -120,17 +104,13 @@ export async function POST(
       },
     });
 
-    return NextResponse.json({
-      success: true,
+    return successResponse({
       reportId: updated.id,
       status: updated.status,
       externalTrackingId: updated.externalTrackingId,
     });
   } catch (error) {
     console.error("Report submission error:", error);
-    return NextResponse.json(
-      { error: "Failed to submit report. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to submit report. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/reports/classify/route.ts
+++ b/nexa/src/app/api/reports/classify/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { classifyWithConsensus } from "@/lib/classify/consensus";
 import type { LocationContext } from "@/lib/classify/types";
 import { ClassifyRequestSchema } from "@/lib/api/schemas";
@@ -7,6 +7,7 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,10 +21,7 @@ export async function POST(request: NextRequest) {
     } = await parseJsonRequest(request, ClassifyRequestSchema);
 
     if (!description && !imageBase64) {
-      return NextResponse.json(
-        { error: "Provide a description or image." },
-        { status: 400 },
-      );
+      return errorResponse("Provide a description or image.", 400);
     }
 
     const location: LocationContext | null =
@@ -45,15 +43,12 @@ export async function POST(request: NextRequest) {
       { twoStage: true, location },
     );
 
-    return NextResponse.json(result);
+    return successResponse(result);
   } catch (error) {
     if (error instanceof RequestParseError) {
       return parseErrorResponse(error);
     }
     console.error("[classify] Unexpected error:", error);
-    return NextResponse.json(
-      { error: "Classification failed. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Classification failed. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { getOpenAI } from "@/lib/openai";
 import { fetchWithTimeout, DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { ISSUE_TYPE_LABELS, US_STATE_CODES } from "@/lib/constants";
@@ -10,6 +10,7 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 type Confidence = "low" | "medium" | "high";
 
@@ -446,10 +447,7 @@ export async function POST(request: NextRequest) {
     );
 
     if (!issueType) {
-      return NextResponse.json(
-        { error: "Valid issueType is required." },
-        { status: 400 },
-      );
+      return errorResponse("Valid issueType is required.", 400);
     }
 
     const location = await resolveLocation(address, latitude, longitude);
@@ -473,7 +471,7 @@ export async function POST(request: NextRequest) {
           reason: match.portal.reason,
           confidence: match.portal.confidence,
         };
-        return NextResponse.json(result);
+        return successResponse(result);
       }
       // Matched a polygon but the portal is unverified — fall through to
       // the LLM lookup using the jurisdiction display name as the hint.
@@ -490,7 +488,7 @@ export async function POST(request: NextRequest) {
         message: "No official city form found.",
         reason: "Could not determine a city from the provided location.",
       };
-      return NextResponse.json(result);
+      return successResponse(result);
     }
 
     const lookup = await lookupOfficialForm({
@@ -508,7 +506,7 @@ export async function POST(request: NextRequest) {
         reason: lookup.reason,
         confidence: lookup.confidence,
       };
-      return NextResponse.json(result);
+      return successResponse(result);
     }
 
     const result: FormLinkResult = {
@@ -517,15 +515,12 @@ export async function POST(request: NextRequest) {
       message: "No official city form found.",
       reason: lookup.reason,
     };
-    return NextResponse.json(result);
+    return successResponse(result);
   } catch (error) {
     if (error instanceof RequestParseError) {
       return parseErrorResponse(error);
     }
     console.error("Official form lookup error:", error);
-    return NextResponse.json(
-      { error: "Failed to look up official city form." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to look up official city form.", 500);
   }
 }

--- a/nexa/src/app/api/reports/route.test.ts
+++ b/nexa/src/app/api/reports/route.test.ts
@@ -40,7 +40,8 @@ describe("POST /api/reports", () => {
 
     // Assert
     expect(response.status).toBe(201);
-    expect(body.id).toBe("report_created");
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe("report_created");
     expect(prismaMock.report.create).toHaveBeenCalledOnce();
   });
 

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
@@ -9,6 +9,7 @@ import {
   RequestParseError,
   parseErrorResponse,
 } from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 export async function POST(request: NextRequest) {
   try {
@@ -69,15 +70,12 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    return NextResponse.json(report, { status: 201 });
+    return successResponse(report, 201);
   } catch (error) {
     if (error instanceof RequestParseError) {
       return parseErrorResponse(error);
     }
     console.error("Report creation error:", error);
-    return NextResponse.json(
-      { error: "Failed to create report. Please try again." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to create report. Please try again.", 500);
   }
 }

--- a/nexa/src/app/api/reports/send-follow-up-reminders/route.ts
+++ b/nexa/src/app/api/reports/send-follow-up-reminders/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { sendReportFollowUpReminderEmail } from "@/lib/email";
 import { FOLLOW_UP_REMINDER_STALE_DAYS } from "@/lib/reports/follow-up";
 import { findStaleUnresolvedReportsForFollowUp } from "@/lib/reports/follow-up-reminders";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 function isAuthorized(request: NextRequest): boolean {
   const secret = process.env.FOLLOW_UP_REMINDER_SECRET;
@@ -21,17 +22,14 @@ function parsePositiveInteger(value: string | null): number | null {
 
 export async function POST(request: NextRequest) {
   if (!process.env.FOLLOW_UP_REMINDER_SECRET) {
-    return NextResponse.json(
-      {
-        error:
-          "FOLLOW_UP_REMINDER_SECRET is not configured. Set it before running reminders.",
-      },
-      { status: 500 },
+    return errorResponse(
+      "FOLLOW_UP_REMINDER_SECRET is not configured. Set it before running reminders.",
+      500,
     );
   }
 
   if (!isAuthorized(request)) {
-    return NextResponse.json({ error: "Not authorized." }, { status: 401 });
+    return errorResponse("Not authorized.", 401);
   }
 
   const staleDays =
@@ -40,12 +38,9 @@ export async function POST(request: NextRequest) {
   const dryRun = request.nextUrl.searchParams.get("dryRun") !== "false";
 
   if (!dryRun && !process.env.BREVO_API_KEY) {
-    return NextResponse.json(
-      {
-        error:
-          "BREVO_API_KEY is not configured. Run with dryRun=true or configure Brevo before sending reminders.",
-      },
-      { status: 500 },
+    return errorResponse(
+      "BREVO_API_KEY is not configured. Run with dryRun=true or configure Brevo before sending reminders.",
+      500,
     );
   }
 
@@ -56,10 +51,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("Follow-up reminder lookup error:", error);
-    return NextResponse.json(
-      { error: "Failed to look up eligible reports." },
-      { status: 500 },
-    );
+    return errorResponse("Failed to look up eligible reports.", 500);
   }
 
   const result = {
@@ -74,7 +66,7 @@ export async function POST(request: NextRequest) {
 
   if (dryRun) {
     result.skipped = candidates.length;
-    return NextResponse.json(result);
+    return successResponse(result);
   }
 
   for (const report of candidates) {
@@ -94,5 +86,5 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  return NextResponse.json(result);
+  return successResponse(result);
 }

--- a/nexa/src/components/auth/claim-form.tsx
+++ b/nexa/src/components/auth/claim-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import type { ApiResponse } from "@/lib/api/response";
 
 export function ClaimForm() {
   const router = useRouter();
@@ -32,10 +33,10 @@ export function ClaimForm() {
         }),
       });
 
-      const data = await res.json();
+      const payload = (await res.json()) as ApiResponse<unknown>;
 
-      if (!res.ok) {
-        setError(data.error || "Failed to claim account");
+      if (!res.ok || !payload.success) {
+        setError(!payload.success ? payload.error : "Failed to claim account");
         return;
       }
 

--- a/nexa/src/components/dashboard/delete-report-button.tsx
+++ b/nexa/src/components/dashboard/delete-report-button.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { Loader2, Pencil, Trash2 } from "lucide-react";
 import { useI18n } from "@/i18n/provider";
 import type { MessageKey } from "@/i18n/messages";
+import type { ApiResponse } from "@/lib/api/response";
 
 interface DeleteReportButtonProps {
   reportId: string;
@@ -49,10 +50,14 @@ export function DeleteReportButton({
       });
 
       if (!response.ok) {
-        const data = (await response.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        throw new Error(data?.error ?? t("common.somethingWrong"));
+        const payload = (await response
+          .json()
+          .catch(() => null)) as ApiResponse<unknown> | null;
+        throw new Error(
+          payload && !payload.success
+            ? payload.error
+            : t("common.somethingWrong"),
+        );
       }
 
       if (redirectTo) {

--- a/nexa/src/components/dashboard/resolution-prompt.tsx
+++ b/nexa/src/components/dashboard/resolution-prompt.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { useI18n } from "@/i18n/provider";
+import type { ApiResponse } from "@/lib/api/response";
 
 interface ResolutionPromptProps {
   reportId: string;
@@ -25,10 +26,14 @@ export function ResolutionPrompt({ reportId }: ResolutionPromptProps) {
         body: JSON.stringify({ resolved }),
       });
       if (!response.ok) {
-        const data = (await response.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        throw new Error(data?.error ?? t("common.somethingWrong"));
+        const payload = (await response
+          .json()
+          .catch(() => null)) as ApiResponse<unknown> | null;
+        throw new Error(
+          payload && !payload.success
+            ? payload.error
+            : t("common.somethingWrong"),
+        );
       }
       router.refresh();
     } catch (err) {

--- a/nexa/src/components/map/community-map-panel.tsx
+++ b/nexa/src/components/map/community-map-panel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import dynamic from "next/dynamic";
 import { MapPinned } from "lucide-react";
 import type { IssueMapPoint } from "@/components/map/community-map";
+import type { ApiResponse } from "@/lib/api/response";
 
 // Leaflet touches `window`/`document`, so render the map only on the client.
 const CommunityMap = dynamic(() => import("@/components/map/community-map"), {
@@ -31,8 +32,10 @@ export default function CommunityMapPanel({
   const refetch = useCallback(async () => {
     const response = await fetch("/api/issues/map");
     if (!response.ok) return;
-    const data = (await response.json()) as { points: IssueMapPoint[] };
-    setPoints(data.points);
+    const payload = (await response.json()) as ApiResponse<{
+      points: IssueMapPoint[];
+    }>;
+    if (payload.success) setPoints(payload.data.points);
   }, []);
 
   const handleResolve = useCallback(
@@ -44,10 +47,14 @@ export default function CommunityMapPanel({
         body: JSON.stringify({ resolved: true }),
       });
       if (!response.ok) {
-        const data = (await response.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        setError(data?.error ?? "Failed to mark resolved.");
+        const payload = (await response
+          .json()
+          .catch(() => null)) as ApiResponse<unknown> | null;
+        setError(
+          payload && !payload.success
+            ? payload.error
+            : "Failed to mark resolved.",
+        );
         throw new Error("resolve-failed");
       }
       await refetch();

--- a/nexa/src/components/navbar.tsx
+++ b/nexa/src/components/navbar.tsx
@@ -8,6 +8,7 @@ import { Menu } from "@base-ui/react/menu";
 import { Logo } from "@/components/logo";
 import { LanguageSelector } from "@/components/language-selector";
 import { useI18n } from "@/i18n/provider";
+import type { ApiResponse } from "@/lib/api/response";
 
 const NAV_LINKS = [
   { href: "/#how-it-works", labelKey: "nav.howItWorks" },
@@ -39,8 +40,10 @@ export function Navbar() {
 
   useEffect(() => {
     fetch("/api/auth/me")
-      .then((r) => (r.ok ? r.json() : null))
-      .then(setUser)
+      .then((r) => (r.ok ? (r.json() as Promise<ApiResponse<AuthUser>>) : null))
+      .then((payload) =>
+        setUser(payload && payload.success ? payload.data : null),
+      )
       .catch(() => setUser(null));
   }, [pathname]);
 

--- a/nexa/src/components/report/submission-assistant.tsx
+++ b/nexa/src/components/report/submission-assistant.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Check, Copy, ExternalLink, Loader2 } from "lucide-react";
+import type { ApiResponse } from "@/lib/api/response";
 
 interface PrefillField {
   key: string;
@@ -36,10 +37,12 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
     async function load() {
       try {
         const res = await fetch(`/api/reports/${reportId}/submission-fields`);
-        const json = res.ok
-          ? ((await res.json()) as SubmissionFieldsResponse)
+        const payload = res.ok
+          ? ((await res.json()) as ApiResponse<SubmissionFieldsResponse>)
           : null;
-        if (!cancelled) setData(json);
+        if (!cancelled) {
+          setData(payload && payload.success ? payload.data : null);
+        }
       } catch {
         if (!cancelled) setData(null);
       } finally {

--- a/nexa/src/hooks/use-address-lookup.ts
+++ b/nexa/src/hooks/use-address-lookup.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { ApiResponse } from "@/lib/api/response";
 
 export interface AddressSuggestion {
   displayName: string;
@@ -52,12 +53,12 @@ export function useAddressLookup() {
         );
         if (!response.ok) throw new Error("Location suggestion lookup failed.");
 
-        const data = (await response.json()) as {
+        const payload = (await response.json()) as ApiResponse<{
           suggestions?: AddressSuggestion[];
-        };
+        }>;
         if (requestId !== requestRef.current) return;
 
-        setSuggestions(data.suggestions ?? []);
+        setSuggestions(payload.success ? (payload.data.suggestions ?? []) : []);
       } catch (e) {
         if (requestId !== requestRef.current) return;
         console.error("Address suggestion lookup failed:", e);

--- a/nexa/src/hooks/use-form-lookup.ts
+++ b/nexa/src/hooks/use-form-lookup.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { useI18n } from "@/i18n/provider";
+import type { ApiResponse } from "@/lib/api/response";
 
 export type OfficialFormLookupResult =
   | {
@@ -64,9 +65,14 @@ export function useFormLookup() {
             longitude: location.longitude ?? undefined,
           }),
         });
-        if (!res.ok) throw new Error(t("report.noOfficialForm"));
-        const result: OfficialFormLookupResult = await res.json();
-        setOfficialForm(result);
+        const payload =
+          (await res.json()) as ApiResponse<OfficialFormLookupResult>;
+        if (!res.ok || !payload.success) {
+          throw new Error(
+            !payload.success ? payload.error : t("report.noOfficialForm"),
+          );
+        }
+        setOfficialForm(payload.data);
       } catch (err) {
         console.error("Official form lookup failed:", err);
         setOfficialForm({

--- a/nexa/src/hooks/use-report-submission.ts
+++ b/nexa/src/hooks/use-report-submission.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { queueReport } from "@/lib/offline-queue";
+import type { ApiResponse } from "@/lib/api/response";
 
 export interface ClassificationResult {
   issueType: string;
@@ -108,23 +109,26 @@ export function useReportSubmission() {
         // Read the raw body once so non-JSON responses surface a useful error
         // instead of Safari's cryptic "did not match the expected pattern".
         const rawBody = await res.text();
-        let payload: unknown = null;
+        let payload: ApiResponse<ComparisonResponse> | null = null;
         try {
-          payload = rawBody ? JSON.parse(rawBody) : null;
+          payload = rawBody
+            ? (JSON.parse(rawBody) as ApiResponse<ComparisonResponse>)
+            : null;
         } catch {
           throw new Error(
             `Classification failed (HTTP ${res.status}). Server returned a non-JSON response.`,
           );
         }
 
-        if (!res.ok) {
+        if (!res.ok || !payload?.success) {
           const message =
-            (payload as { error?: string } | null)?.error ??
-            `Classification failed (HTTP ${res.status}).`;
+            payload && !payload.success
+              ? payload.error
+              : `Classification failed (HTTP ${res.status}).`;
           throw new Error(message);
         }
 
-        const data = payload as ComparisonResponse;
+        const data = payload.data;
         setComparison(data);
         setClassification(data.winner);
         callbacks.onSuccess(data);
@@ -162,12 +166,14 @@ export function useReportSubmission() {
           body: JSON.stringify(payload),
         });
 
-        if (!res.ok) {
-          const err = await res.json();
-          throw new Error(err.error || callbacks.okFallback);
+        const result = (await res.json()) as ApiResponse<CreatedReport>;
+
+        if (!res.ok || !result.success) {
+          const message = !result.success ? result.error : null;
+          throw new Error(message || callbacks.okFallback);
         }
 
-        const report: CreatedReport = await res.json();
+        const report = result.data;
         setCreatedReport(report);
         setSubmittedOffline(false);
         callbacks.onSuccess(report);

--- a/nexa/src/lib/api/request-parser.ts
+++ b/nexa/src/lib/api/request-parser.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from "next/server";
+import type { NextResponse } from "next/server";
 import type { ZodType } from "zod";
+import { errorResponse } from "@/lib/api/response";
 
 /**
  * Error thrown when a request body fails schema validation. Carries the
@@ -57,5 +58,5 @@ export async function parseJsonRequest<T>(
  * Keeps the error shape identical across every route in one place.
  */
 export function parseErrorResponse(error: RequestParseError): NextResponse {
-  return NextResponse.json({ error: error.message }, { status: 400 });
+  return errorResponse(error.message, 400);
 }

--- a/nexa/src/lib/api/response.ts
+++ b/nexa/src/lib/api/response.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+/**
+ * The single response contract every API route shares. Clients branch on the
+ * `success` discriminant instead of hand-rolling per-endpoint unmarshalling:
+ * a success carries its payload in `data`, a failure carries a human-readable
+ * `error` plus an optional machine-readable `code`.
+ */
+export type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code?: string };
+
+/**
+ * Build a success envelope wrapping `data`. Raw entities (e.g. a Prisma row)
+ * go straight into `data` so the shape stays uniform across every route.
+ */
+export function successResponse<T>(
+  data: T,
+  status = 200,
+): NextResponse<ApiResponse<T>> {
+  return NextResponse.json({ success: true, data }, { status });
+}
+
+/**
+ * Build an error envelope. `status` is required so each route states its HTTP
+ * status explicitly; `code` is an optional stable identifier for clients that
+ * want to branch on a reason rather than the localized message.
+ */
+export function errorResponse(
+  message: string,
+  status: number,
+  code?: string,
+): NextResponse<ApiResponse<never>> {
+  return NextResponse.json(
+    code
+      ? { success: false, error: message, code }
+      : { success: false, error: message },
+    { status },
+  );
+}


### PR DESCRIPTION
Closes #125.

## What

Introduces one shared API response contract — a discriminated `success`/`error` envelope with typed builders — and migrates every route handler and every client read site to it. Clients now branch on the `success` discriminant instead of hand-rolling per-endpoint unmarshalling and unsafe `as { error?: string }` casts.

## New module

- `src/lib/api/response.ts` — exports `type ApiResponse<T> = { success: true; data: T } | { success: false; error: string; code?: string }` plus `successResponse<T>(data, status?)` and `errorResponse(message, status, code?)`.
- `src/lib/api/request-parser.ts` — the shared `parseErrorResponse` 400 path (#124) now returns through `errorResponse` so parse failures use the same envelope.

## Routes updated (all 16 under `src/app/api/**`)

Success payloads wrapped in `data` (raw Prisma entities included); errors via `errorResponse` with their existing HTTP status codes preserved:

- `reports/route.ts` — POST create (201; raw `Report` → `data`)
- `reports/[id]/route.ts` — DELETE (`{ deleted: true }`)
- `reports/[id]/submit/route.ts` — POST submit (404/403/409/400/502/500 + success `{ reportId, status, externalTrackingId }`)
- `reports/[id]/resolution/route.ts` — POST (both success shapes wrapped; 401/404/403/500)
- `reports/[id]/submission-fields/route.ts` — GET (agency/fields payloads; 404/403/500)
- `reports/classify/route.ts` — POST (consensus result → `data`; 400/500)
- `reports/form-link/route.ts` — POST (all `FormLinkResult` returns → `data`; 400/500)
- `reports/send-follow-up-reminders/route.ts` — POST (result summary; 401/500)
- `auth/login/route.ts` — POST (`{ id, email, name }`; 400/401/500)
- `auth/register/route.ts` — POST (201; 400/409/500)
- `auth/logout/route.ts` — POST (`{ loggedOut: true }`)
- `auth/me/route.ts` — GET (session user; 401)
- `auth/claim/route.ts` — POST (user; 400/409/500)
- `issues/map/route.ts` — GET (`{ points }`; 401)
- `location/suggest/route.ts` — GET (`{ suggestions }`; graceful-empty branches kept as success)
- `health/route.ts` — GET (`{ status: "ok" }`)

## Client read sites updated

Each now branches on the `success` discriminant; no unsafe casts; UI behavior unchanged:

- `src/hooks/use-report-submission.ts` — classify + create (`ComparisonResponse`, `CreatedReport`)
- `src/hooks/use-form-lookup.ts` — `OfficialFormLookupResult`
- `src/hooks/use-address-lookup.ts` — `/location/suggest` suggestions
- `src/components/navbar.tsx` — `/auth/me` user unwrap
- `src/components/auth/claim-form.tsx` — claim error/success
- `src/components/dashboard/resolution-prompt.tsx` — resolution error
- `src/components/dashboard/delete-report-button.tsx` — delete error
- `src/components/report/submission-assistant.tsx` — submission-fields unwrap
- `src/components/map/community-map-panel.tsx` — map refetch + resolve error

`login-form.tsx`, `register-form.tsx`, and `lib/offline-queue.ts` read only `res.ok`/`res.status` (never the JSON body), so they required no change; status codes are preserved.

## Tests

- `src/app/api/health/route.test.ts` and `src/app/api/reports/route.test.ts` updated to assert the new envelope shape.

## Verification

- `npx tsc --noEmit` — pass
- `npm run lint` — pass (0 errors; 2 pre-existing `<img>` warnings unrelated)
- `npm run format:check` — pass
- `npm test` — 220 passed (19 files)
- `npm run build` — compiles and collects all routes (requires `DATABASE_URL`, as on main)