### PR TITLE
test: component tests for report wizard, dashboard, auth/nav [#117]

### DIFF
--- a/nexa/src/components/auth/login-form.test.tsx
+++ b/nexa/src/components/auth/login-form.test.tsx
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  http,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  server,
+} from "@/test";
+
+import { LoginForm } from "./login-form";
+
+// Stable router + controllable searchParams (for the redirect query).
+const push = vi.fn();
+const refresh = vi.fn();
+let redirectParam: string | null = null;
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh, replace: vi.fn() }),
+  usePathname: () => "/login",
+  useSearchParams: () =>
+    new URLSearchParams(redirectParam ? `redirect=${redirectParam}` : ""),
+}));
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+    redirectParam = null;
+  });
+
+  it("renders required email and password inputs", () => {
+    // Arrange / Act
+    renderWithProviders(<LoginForm />);
+
+    // Assert
+    const email = screen.getByLabelText("Email");
+    const password = screen.getByLabelText("Password");
+    expect(email).toBeRequired();
+    expect(password).toBeRequired();
+    expect(password).toHaveAttribute("type", "password");
+  });
+
+  it("POSTs credentials and redirects to the safe redirect target on success", async () => {
+    // Arrange
+    redirectParam = "/dashboard";
+    let body: unknown = null;
+    server.use(
+      http.post("*/api/auth/login", async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { user } = renderWithProviders(<LoginForm />);
+
+    // Act
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "secret123");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Assert
+    expect(body).toEqual({
+      email: "user@example.com",
+      password: "secret123",
+    });
+    expect(push).toHaveBeenCalledWith("/dashboard");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a login-failed message on a non-OK response", async () => {
+    // Arrange
+    server.use(
+      http.post("*/api/auth/login", () =>
+        HttpResponse.json({ error: "bad" }, { status: 401 }),
+      ),
+    );
+    const { user } = renderWithProviders(<LoginForm />);
+
+    // Act
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "nope");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent("Login failed");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic message when the request throws (network error)", async () => {
+    // Arrange
+    server.use(http.post("*/api/auth/login", () => HttpResponse.error()));
+    const { user } = renderWithProviders(<LoginForm />);
+
+    // Act
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "secret123");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Something went wrong",
+    );
+  });
+
+  it("shows the signing-in label while the request is pending", async () => {
+    // Arrange: a never-resolving handler keeps loading=true.
+    server.use(
+      http.post(
+        "*/api/auth/login",
+        () => new Promise<HttpResponse<null>>(() => {}),
+      ),
+    );
+    const { user } = renderWithProviders(<LoginForm />);
+
+    // Act
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "secret123");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Assert
+    const button = await screen.findByRole("button", { name: "Signing in..." });
+    expect(button).toBeDisabled();
+  });
+});

--- a/nexa/src/components/auth/register-form.test.tsx
+++ b/nexa/src/components/auth/register-form.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  http,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  server,
+} from "@/test";
+
+import { RegisterForm } from "./register-form";
+
+const push = vi.fn();
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh, replace: vi.fn() }),
+  usePathname: () => "/register",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("RegisterForm", () => {
+  beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+  });
+
+  it("requires email and password but leaves name optional", () => {
+    // Arrange / Act
+    renderWithProviders(<RegisterForm />);
+
+    // Assert
+    expect(screen.getByLabelText(/Email/)).toBeRequired();
+    expect(screen.getByLabelText("Password")).toBeRequired();
+    expect(screen.getByLabelText(/Name/)).not.toBeRequired();
+  });
+
+  it("POSTs registration data and redirects home on success", async () => {
+    // Arrange
+    let body: unknown = null;
+    server.use(
+      http.post("*/api/auth/register", async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { user } = renderWithProviders(<RegisterForm />);
+
+    // Act
+    await user.type(screen.getByLabelText(/Name/), "Ada");
+    await user.type(screen.getByLabelText(/Email/), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "longpassword");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    // Assert
+    expect(body).toEqual({
+      name: "Ada",
+      email: "ada@example.com",
+      password: "longpassword",
+    });
+    expect(push).toHaveBeenCalledWith("/");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the account-exists message on a 409", async () => {
+    // Arrange
+    server.use(
+      http.post("*/api/auth/register", () =>
+        HttpResponse.json({ error: "exists" }, { status: 409 }),
+      ),
+    );
+    const { user } = renderWithProviders(<RegisterForm />);
+
+    // Act
+    await user.type(screen.getByLabelText(/Email/), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "longpassword");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "An account with this email already exists",
+    );
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("shows the password-too-short message on a 400", async () => {
+    // Arrange
+    server.use(
+      http.post("*/api/auth/register", () =>
+        HttpResponse.json({ error: "short" }, { status: 400 }),
+      ),
+    );
+    const { user } = renderWithProviders(<RegisterForm />);
+
+    // Act
+    await user.type(screen.getByLabelText(/Email/), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "x");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Password must be at least 8 characters",
+    );
+  });
+
+  it("shows a generic message when the request throws", async () => {
+    // Arrange
+    server.use(http.post("*/api/auth/register", () => HttpResponse.error()));
+    const { user } = renderWithProviders(<RegisterForm />);
+
+    // Act
+    await user.type(screen.getByLabelText(/Email/), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "longpassword");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Something went wrong",
+    );
+  });
+
+  it("disables the button and shows creating text while pending", async () => {
+    // Arrange
+    server.use(
+      http.post(
+        "*/api/auth/register",
+        () => new Promise<HttpResponse<null>>(() => {}),
+      ),
+    );
+    const { user } = renderWithProviders(<RegisterForm />);
+
+    // Act
+    await user.type(screen.getByLabelText(/Email/), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "longpassword");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    // Assert
+    const button = await screen.findByRole("button", {
+      name: "Creating account...",
+    });
+    expect(button).toBeDisabled();
+  });
+});

--- a/nexa/src/components/dashboard/delete-report-button.test.tsx
+++ b/nexa/src/components/dashboard/delete-report-button.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  http,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  server,
+} from "@/test";
+
+import { DeleteReportButton } from "./delete-report-button";
+
+// Capture a stable router so push/refresh assertions survive across renders
+// (the global mock in vitest.setup.tsx returns a fresh router each call).
+const push = vi.fn();
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh, replace: vi.fn(), back: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("DeleteReportButton", () => {
+  beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires a confirmation click before deleting", async () => {
+    // Arrange
+    let called = false;
+    server.use(
+      http.delete("*/api/reports/:id", () => {
+        called = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+    const { user } = renderWithProviders(<DeleteReportButton reportId="r1" />);
+
+    // Act: first click only arms the confirm state.
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    // Assert: no request yet; the confirm affordance appears.
+    expect(called).toBe(false);
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+  });
+
+  it("issues a DELETE to /api/reports/{id} and refreshes on success", async () => {
+    // Arrange
+    let requestedUrl: string | null = null;
+    let method: string | null = null;
+    server.use(
+      http.delete("*/api/reports/:id", ({ request }) => {
+        requestedUrl = request.url;
+        method = request.method;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+    const { user } = renderWithProviders(<DeleteReportButton reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    // Assert
+    expect(method).toBe("DELETE");
+    expect(requestedUrl).toContain("/api/reports/r1");
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("redirects instead of refreshing when redirectTo is set", async () => {
+    // Arrange
+    server.use(
+      http.delete(
+        "*/api/reports/:id",
+        () => new HttpResponse(null, { status: 200 }),
+      ),
+    );
+    const { user } = renderWithProviders(
+      <DeleteReportButton reportId="r1" redirectTo="/dashboard" />,
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    // Assert
+    expect(push).toHaveBeenCalledWith("/dashboard");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("shows the server error message when the delete fails", async () => {
+    // Arrange
+    server.use(
+      http.delete("*/api/reports/:id", () =>
+        HttpResponse.json({ error: "Not allowed" }, { status: 403 }),
+      ),
+    );
+    const { user } = renderWithProviders(<DeleteReportButton reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    // Assert
+    expect(await screen.findByText("Not allowed")).toBeInTheDocument();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("renders the Edit link by default and hides it while confirming", async () => {
+    // Arrange
+    const { user } = renderWithProviders(<DeleteReportButton reportId="r1" />);
+
+    // Assert: edit link present before confirming.
+    expect(screen.getByRole("link", { name: /Edit/ })).toHaveAttribute(
+      "href",
+      "/dashboard/reports/r1/edit",
+    );
+
+    // Act: entering confirm mode hides edit.
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    // Assert
+    expect(
+      screen.queryByRole("link", { name: /Edit/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits the Edit link when showEdit is false", () => {
+    // Arrange / Act
+    renderWithProviders(<DeleteReportButton reportId="r1" showEdit={false} />);
+
+    // Assert
+    expect(
+      screen.queryByRole("link", { name: /Edit/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/nexa/src/components/dashboard/report-card.test.tsx
+++ b/nexa/src/components/dashboard/report-card.test.tsx
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders, screen } from "@/test";
+
+import { ReportCard, type DashboardReport } from "./report-card";
+
+// The expand/collapse control is a role="button" whose accessible name is its
+// own text content (issue label, location, status…), so query it by its stable
+// aria-controls hook instead of by name.
+function getToggle(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[aria-controls^="report-"]');
+  if (!el) throw new Error("toggle not found");
+  return el;
+}
+
+function makeDashboardReport(
+  overrides: Partial<DashboardReport> = {},
+): DashboardReport {
+  return {
+    id: "report_1",
+    issueType: "ROAD_DAMAGE",
+    status: "CONFIRMED",
+    description: "Big pothole on the corner.",
+    aiDescription: "A deep pothole posing a hazard.",
+    address:
+      "Coupa Cafe, 538, Ramona Street, Palo Alto, Santa Clara County, California, 94301, United States",
+    imageUrl: "https://example.com/photo.jpg",
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+    externalTrackingId: null,
+    userResolved: null,
+    ...overrides,
+  };
+}
+
+describe("ReportCard (collapsed)", () => {
+  it("renders the issue label, shortened location and status pill", () => {
+    // Arrange / Act
+    renderWithProviders(<ReportCard report={makeDashboardReport()} />);
+
+    // Assert: shortenAddress reduces the long address to "City, ST".
+    expect(screen.getByText("Road Damage")).toBeInTheDocument();
+    expect(screen.getByText("Palo Alto, CA")).toBeInTheDocument();
+    expect(screen.getByText("Confirmed")).toBeInTheDocument();
+  });
+
+  it("colors the status pill by status", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard report={makeDashboardReport({ status: "SUBMITTED" })} />,
+    );
+
+    // Assert
+    const pill = screen.getByText("Submitted");
+    expect(pill.className).toMatch(/bg-ep-purple-light/);
+  });
+
+  it("uses the uncategorized label when there is no issue type", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard report={makeDashboardReport({ issueType: null })} />,
+    );
+
+    // Assert
+    expect(screen.getByText("Uncategorized")).toBeInTheDocument();
+  });
+
+  it("shows a relative-time tooltip carrying the ISO datetime", () => {
+    // Arrange / Act
+    renderWithProviders(<ReportCard report={makeDashboardReport()} />);
+
+    // Assert
+    const time = screen.getByText(
+      (_, el) => el?.tagName === "TIME",
+    ) as HTMLTimeElement;
+    expect(time).toHaveAttribute("datetime", "2025-01-01T00:00:00.000Z");
+  });
+
+  it("renders a delete button without expanding the card", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard report={makeDashboardReport()} />,
+    );
+    const region = getToggle();
+
+    // Act: clicking delete must not toggle the card (stopPropagation).
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    // Assert: still collapsed.
+    expect(region).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+describe("ReportCard (expand/collapse)", () => {
+  it("expands to show the photo and description on click", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard report={makeDashboardReport()} />,
+    );
+    const toggle = getToggle();
+
+    // Act
+    await user.click(toggle);
+
+    // Assert
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Photo")).toBeInTheDocument();
+    expect(screen.getByAltText(/Road Damage/)).toHaveAttribute(
+      "src",
+      "https://example.com/photo.jpg",
+    );
+    expect(screen.getByText("Big pothole on the corner.")).toBeInTheDocument();
+  });
+
+  it("toggles via the Enter key", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard report={makeDashboardReport()} />,
+    );
+    const toggle = getToggle();
+    toggle.focus();
+
+    // Act
+    await user.keyboard("{Enter}");
+
+    // Assert
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("toggles via the Space key", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard report={makeDashboardReport()} />,
+    );
+    const toggle = getToggle();
+    toggle.focus();
+
+    // Act
+    await user.keyboard("[Space]");
+
+    // Assert
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("shows the ImageOff placeholder when there is no photo", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard report={makeDashboardReport({ imageUrl: null })} />,
+    );
+
+    // Act
+    await user.click(getToggle());
+
+    // Assert
+    expect(screen.getByText("No photo attached")).toBeInTheDocument();
+  });
+
+  it("falls back to a no-description message when both descriptions are empty", async () => {
+    // Arrange
+    const { user } = renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          description: null,
+          aiDescription: null,
+        })}
+      />,
+    );
+
+    // Act
+    await user.click(getToggle());
+
+    // Assert
+    expect(
+      screen.getByText("No description was provided for this report."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ReportCard resolution prompt visibility", () => {
+  // A report old enough (>=14d) and unresolved should surface the prompt.
+  const stale = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  it("shows the resolution prompt for a stale, unresolved, non-external report", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          status: "SUBMITTED",
+          createdAt: stale,
+          updatedAt: stale,
+        })}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("Yes, fixed")).toBeInTheDocument();
+  });
+
+  it("hides the prompt when the report has an external tracking id", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          status: "SUBMITTED",
+          createdAt: stale,
+          updatedAt: stale,
+          externalTrackingId: "EXT-123",
+        })}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("Yes, fixed")).not.toBeInTheDocument();
+  });
+
+  it("hides the prompt when the user already answered", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          status: "SUBMITTED",
+          createdAt: stale,
+          updatedAt: stale,
+          userResolved: false,
+        })}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("Yes, fixed")).not.toBeInTheDocument();
+  });
+
+  it("hides the prompt when the report is too recent", () => {
+    // Arrange / Act: default report is recent (createdAt 2025-01-01 is far past
+    // but updatedAt is also fixed; use a fresh date to be unambiguous).
+    const recent = new Date();
+    renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          status: "SUBMITTED",
+          createdAt: recent,
+          updatedAt: recent,
+        })}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("Yes, fixed")).not.toBeInTheDocument();
+  });
+
+  it("hides the prompt for a hiding status (RESOLVED) even when stale", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportCard
+        report={makeDashboardReport({
+          status: "RESOLVED",
+          createdAt: stale,
+          updatedAt: stale,
+        })}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("Yes, fixed")).not.toBeInTheDocument();
+  });
+});

--- a/nexa/src/components/dashboard/reports-map.test.tsx
+++ b/nexa/src/components/dashboard/reports-map.test.tsx
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen, waitFor } from "@/test";
+
+import { ReportsMap, type ReportMapPoint } from "./reports-map";
+
+// ---------------------------------------------------------------------------
+// Leaflet double. Captures divIcon options (for marker color), bindPopup HTML
+// (to assert escaping) and setView/fitBounds calls (single vs multi point).
+// ---------------------------------------------------------------------------
+const divIconCalls: Array<{ html: string }> = [];
+const popupHtml: string[] = [];
+
+const marker = {
+  addTo: vi.fn(() => marker),
+  bindPopup: vi.fn((html: string) => {
+    popupHtml.push(html);
+    return marker;
+  }),
+};
+
+const map = {
+  remove: vi.fn(),
+  setView: vi.fn(() => map),
+  fitBounds: vi.fn(() => map),
+};
+
+const tileLayer = { addTo: vi.fn(() => tileLayer) };
+
+const L = {
+  map: vi.fn(() => map),
+  tileLayer: vi.fn(() => tileLayer),
+  divIcon: vi.fn((opts: { html: string }) => {
+    divIconCalls.push(opts);
+    return opts;
+  }),
+  marker: vi.fn(() => marker),
+};
+
+vi.mock("leaflet", () => ({ default: L, ...L }));
+vi.mock("leaflet/dist/leaflet.css", () => ({}));
+
+function makePoint(overrides: Partial<ReportMapPoint> = {}): ReportMapPoint {
+  return {
+    id: "p1",
+    latitude: 37.4,
+    longitude: -122.1,
+    issueType: "ROAD_DAMAGE",
+    shortLocation: "Palo Alto, CA",
+    status: "CONFIRMED",
+    relativeTime: "2 days ago",
+    ...overrides,
+  };
+}
+
+describe("ReportsMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    divIconCalls.length = 0;
+    popupHtml.length = 0;
+  });
+
+  it("renders nothing when there are no points", () => {
+    // Arrange / Act
+    const { container } = renderWithProviders(<ReportsMap points={[]} />);
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+    expect(L.map).not.toHaveBeenCalled();
+  });
+
+  it("renders the map shell with a pin count for a single point", async () => {
+    // Arrange / Act
+    renderWithProviders(<ReportsMap points={[makePoint()]} />);
+
+    // Assert: header + count copy ("1 pin").
+    expect(screen.getByText("Report locations")).toBeInTheDocument();
+    expect(screen.getByText(/1\s+pin/)).toBeInTheDocument();
+    await waitFor(() => expect(L.map).toHaveBeenCalledTimes(1));
+  });
+
+  it("uses setView for a single point and fitBounds for many", async () => {
+    // Arrange / Act: single point.
+    const { rerender } = renderWithProviders(
+      <ReportsMap points={[makePoint()]} />,
+    );
+    await waitFor(() => expect(map.setView).toHaveBeenCalled());
+    expect(map.fitBounds).not.toHaveBeenCalled();
+
+    // Act: two points -> fitBounds.
+    rerender(
+      <ReportsMap
+        points={[makePoint(), makePoint({ id: "p2", latitude: 40 })]}
+      />,
+    );
+
+    // Assert
+    await waitFor(() => expect(map.fitBounds).toHaveBeenCalled());
+  });
+
+  it("colors confirmed vs pending markers differently", async () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportsMap
+        points={[
+          makePoint({ id: "c", status: "CONFIRMED" }),
+          makePoint({ id: "d", status: "DRAFT" }),
+        ]}
+      />,
+    );
+
+    // Assert: confirmed green (#22c55e), pending purple (#9b87f5).
+    await waitFor(() => expect(divIconCalls.length).toBe(2));
+    expect(divIconCalls[0].html).toContain("#22c55e");
+    expect(divIconCalls[1].html).toContain("#9b87f5");
+  });
+
+  it("escapes HTML in popup content", async () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportsMap
+        points={[
+          makePoint({ shortLocation: '<img src=x onerror="alert(1)">' }),
+        ]}
+      />,
+    );
+
+    // Assert: angle brackets/quotes are entity-escaped, not raw.
+    await waitFor(() => expect(popupHtml.length).toBe(1));
+    expect(popupHtml[0]).toContain("&lt;img");
+    expect(popupHtml[0]).not.toContain("<img src=x");
+  });
+
+  it("removes the map on unmount", async () => {
+    // Arrange
+    const { unmount } = renderWithProviders(
+      <ReportsMap points={[makePoint()]} />,
+    );
+    await waitFor(() => expect(L.map).toHaveBeenCalled());
+
+    // Act
+    unmount();
+
+    // Assert
+    expect(map.remove).toHaveBeenCalled();
+  });
+});

--- a/nexa/src/components/dashboard/resolution-prompt.test.tsx
+++ b/nexa/src/components/dashboard/resolution-prompt.test.tsx
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  http,
+  HttpResponse,
+  renderWithProviders,
+  screen,
+  server,
+} from "@/test";
+
+import { ResolutionPrompt } from "./resolution-prompt";
+
+// Stable router so refresh assertions hold across renders.
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh, push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("ResolutionPrompt", () => {
+  beforeEach(() => {
+    refresh.mockClear();
+  });
+
+  it('POSTs resolved=true to the resolution endpoint when "Yes, fixed" is clicked', async () => {
+    // Arrange
+    let body: unknown = null;
+    let url: string | null = null;
+    server.use(
+      http.post("*/api/reports/:id/resolution", async ({ request }) => {
+        url = request.url;
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { user } = renderWithProviders(<ResolutionPrompt reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Yes, fixed/ }));
+
+    // Assert
+    expect(url).toContain("/api/reports/r1/resolution");
+    expect(body).toEqual({ resolved: true });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('POSTs resolved=false when "Not yet" is clicked', async () => {
+    // Arrange
+    let body: unknown = null;
+    server.use(
+      http.post("*/api/reports/:id/resolution", async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { user } = renderWithProviders(<ResolutionPrompt reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Not yet/ }));
+
+    // Assert
+    expect(body).toEqual({ resolved: false });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the server error and does not refresh on failure", async () => {
+    // Arrange
+    server.use(
+      http.post("*/api/reports/:id/resolution", () =>
+        HttpResponse.json({ error: "Update failed" }, { status: 500 }),
+      ),
+    );
+    const { user } = renderWithProviders(<ResolutionPrompt reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Yes, fixed/ }));
+
+    // Assert
+    expect(await screen.findByRole("alert")).toHaveTextContent("Update failed");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("disables both buttons while a submission is in flight", async () => {
+    // Arrange: a handler that never resolves keeps the submitting state active.
+    server.use(
+      http.post(
+        "*/api/reports/:id/resolution",
+        () => new Promise<HttpResponse<null>>(() => {}),
+      ),
+    );
+    const { user } = renderWithProviders(<ResolutionPrompt reportId="r1" />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Yes, fixed/ }));
+
+    // Assert
+    expect(screen.getByRole("button", { name: /Yes, fixed/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Not yet/ })).toBeDisabled();
+  });
+});

--- a/nexa/src/components/navbar.test.tsx
+++ b/nexa/src/components/navbar.test.tsx
@@ -27,7 +27,7 @@ function stubMe(user: unknown, status = 200) {
     http.get("*/api/auth/me", () =>
       user === null
         ? new HttpResponse(null, { status: status === 200 ? 401 : status })
-        : HttpResponse.json(user),
+        : HttpResponse.json({ success: true, data: user }),
     ),
   );
 }

--- a/nexa/src/components/navbar.test.tsx
+++ b/nexa/src/components/navbar.test.tsx
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  http,
+  HttpResponse,
+  makeUser,
+  renderWithProviders,
+  screen,
+  server,
+  waitFor,
+} from "@/test";
+
+import { Navbar } from "./navbar";
+
+// Stable router + controllable pathname.
+const push = vi.fn();
+const refresh = vi.fn();
+let pathname = "/";
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => pathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function stubMe(user: unknown, status = 200) {
+  server.use(
+    http.get("*/api/auth/me", () =>
+      user === null
+        ? new HttpResponse(null, { status: status === 200 ? 401 : status })
+        : HttpResponse.json(user),
+    ),
+  );
+}
+
+describe("Navbar", () => {
+  beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+    pathname = "/";
+  });
+
+  it("renders the logo and primary nav links", async () => {
+    // Arrange
+    stubMe(null);
+
+    // Act
+    renderWithProviders(<Navbar />);
+
+    // Assert
+    expect(screen.getByText("Nexa")).toBeInTheDocument();
+    expect(screen.getByText("How It Works")).toBeInTheDocument();
+    // Let the me-fetch settle so there are no act() warnings.
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /Sign in/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the loading placeholder before the auth check resolves", () => {
+    // Arrange: a never-resolving me request keeps user === undefined.
+    server.use(
+      http.get(
+        "*/api/auth/me",
+        () => new Promise<HttpResponse<null>>(() => {}),
+      ),
+    );
+
+    // Act
+    renderWithProviders(<Navbar />);
+
+    // Assert: neither the signed-in CTA nor the sign-in link is shown yet.
+    expect(
+      screen.queryByRole("link", { name: /Sign in/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Open account menu" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the signed-out state (Sign in) when not authenticated", async () => {
+    // Arrange
+    stubMe(null);
+
+    // Act
+    renderWithProviders(<Navbar />);
+
+    // Assert
+    expect(
+      await screen.findByRole("link", { name: /Sign in/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Open account menu" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the signed-in state with the account menu and dashboard link", async () => {
+    // Arrange
+    stubMe(makeUser({ name: "Ada Lovelace", email: "ada@example.com" }));
+
+    // Act
+    renderWithProviders(<Navbar />);
+
+    // Assert: account menu trigger appears once authenticated.
+    expect(
+      await screen.findByRole("button", { name: "Open account menu" }),
+    ).toBeInTheDocument();
+    // The Dashboard nav link is shown for signed-in users.
+    expect(
+      screen.getAllByRole("link", { name: "Dashboard" }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("derives initials from the user's name", async () => {
+    // Arrange
+    stubMe(makeUser({ name: "Ada Lovelace", email: "ada@example.com" }));
+
+    // Act
+    renderWithProviders(<Navbar />);
+
+    // Assert: trigger shows "AL".
+    const trigger = await screen.findByRole("button", {
+      name: "Open account menu",
+    });
+    expect(trigger).toHaveTextContent("AL");
+  });
+
+  it("opens the account menu and signs out", async () => {
+    // Arrange
+    stubMe(makeUser({ name: "Ada Lovelace", email: "ada@example.com" }));
+    let logoutCalled = false;
+    server.use(
+      http.post("*/api/auth/logout", () => {
+        logoutCalled = true;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { user } = renderWithProviders(<Navbar />);
+    const trigger = await screen.findByRole("button", {
+      name: "Open account menu",
+    });
+
+    // Act: open the menu, then click Sign out.
+    await user.click(trigger);
+    const signOut = await screen.findByText("Sign out");
+    await user.click(signOut);
+
+    // Assert: logout POSTed and navigation refreshed home.
+    await waitFor(() => expect(logoutCalled).toBe(true));
+    expect(push).toHaveBeenCalledWith("/");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches the auth state when the pathname changes", async () => {
+    // Arrange: first render signed out.
+    let meCalls = 0;
+    server.use(
+      http.get("*/api/auth/me", () => {
+        meCalls += 1;
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+    const { rerender } = renderWithProviders(<Navbar />);
+    await waitFor(() => expect(meCalls).toBe(1));
+
+    // Act: change pathname and re-render (the effect depends on pathname).
+    pathname = "/dashboard";
+    rerender(<Navbar />);
+
+    // Assert
+    await waitFor(() => expect(meCalls).toBe(2));
+  });
+
+  it("marks the Dashboard link as current when on the dashboard", async () => {
+    // Arrange
+    pathname = "/dashboard";
+    stubMe(makeUser({ name: "Ada", email: "ada@example.com" }));
+    const { user } = renderWithProviders(<Navbar />);
+
+    // Act: open menu to reveal the menu's Dashboard link with aria-current.
+    const trigger = await screen.findByRole("button", {
+      name: "Open account menu",
+    });
+    await user.click(trigger);
+
+    // Assert: the menu's Dashboard item is marked as the current page.
+    const dashboardItem = await screen.findByRole("menuitem", {
+      name: /Dashboard/,
+    });
+    expect(dashboardItem).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/nexa/src/components/report/confirmed-step.test.tsx
+++ b/nexa/src/components/report/confirmed-step.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { jsonGet, renderWithProviders, screen, server, waitFor } from "@/test";
+
+import { ConfirmedStep } from "./confirmed-step";
+
+// ConfirmedStep mounts <SubmissionAssistant>, which fetches submission fields on
+// mount. Stub it (no agency -> the assistant renders nothing) so these tests
+// stay offline and focused on the confirmation panel itself.
+function stubSubmissionFields() {
+  server.use(
+    jsonGet("*/api/reports/:id/submission-fields", {
+      agency: null,
+      fields: [],
+    }),
+  );
+}
+
+function baseReport() {
+  return {
+    id: "report_abc",
+    issueType: "ROAD_DAMAGE",
+    aiDescription: "A deep pothole in the road.",
+    createdAt: "2025-01-01T00:00:00.000Z",
+  };
+}
+
+describe("ConfirmedStep", () => {
+  beforeEach(() => {
+    stubSubmissionFields();
+  });
+
+  it("renders the success heading and report id", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={vi.fn()} />,
+    );
+
+    // Assert
+    expect(screen.getByText("Report submitted!")).toBeInTheDocument();
+    expect(screen.getByText("report_abc")).toBeInTheDocument();
+  });
+
+  it("renders the translated issue label", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={vi.fn()} />,
+    );
+
+    // Assert
+    expect(screen.getByText("Road Damage")).toBeInTheDocument();
+  });
+
+  it("falls back to the unknown label when issueType is null", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep
+        report={{ ...baseReport(), issueType: null }}
+        onReportAnother={vi.fn()}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("renders a machine-readable submitted timestamp", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={vi.fn()} />,
+    );
+
+    // Assert: the <time> carries the ISO datetime regardless of relative wording.
+    const time = screen.getByText(
+      (_, el) => el?.tagName === "TIME",
+    ) as HTMLTimeElement;
+    expect(time).toHaveAttribute("datetime", "2025-01-01T00:00:00.000Z");
+  });
+
+  it("shows the AI summary only when present", () => {
+    // Arrange / Act: present.
+    const { rerender } = renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={vi.fn()} />,
+    );
+    expect(screen.getByText("A deep pothole in the road.")).toBeInTheDocument();
+
+    // Act: absent -> the summary section disappears.
+    rerender(
+      <ConfirmedStep
+        report={{ ...baseReport(), aiDescription: null }}
+        onReportAnother={vi.fn()}
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.queryByText("A deep pothole in the road."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links to the dashboard", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={vi.fn()} />,
+    );
+
+    // Assert
+    expect(
+      screen.getByRole("link", { name: "View Dashboard" }),
+    ).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("calls onReportAnother when the report-another button is clicked", async () => {
+    // Arrange
+    const onReportAnother = vi.fn();
+    const { user } = renderWithProviders(
+      <ConfirmedStep report={baseReport()} onReportAnother={onReportAnother} />,
+    );
+
+    // Act
+    await user.click(
+      screen.getByRole("button", { name: /Report Another Issue/ }),
+    );
+
+    // Assert
+    expect(onReportAnother).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the offline saved state and skips the submission assistant", async () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ConfirmedStep report={baseReport()} offline onReportAnother={vi.fn()} />,
+    );
+
+    // Assert: offline copy is shown; assistant (which would show a loader) is not.
+    expect(screen.getByText("Saved offline")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Preparing your filing details…"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/nexa/src/components/report/describe-step.test.tsx
+++ b/nexa/src/components/report/describe-step.test.tsx
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen, waitFor } from "@/test";
+
+import { DescribeStep } from "./describe-step";
+
+// The real LocationMap pulls in Leaflet (touches `window` at import). Replace it
+// with a marker we can assert on so "map renders only when lat+lon set" is
+// testable without a real map.
+vi.mock("./location-map", () => ({
+  __esModule: true,
+  default: ({
+    latitude,
+    longitude,
+  }: {
+    latitude: number;
+    longitude: number;
+  }) => (
+    <div data-testid="location-map">
+      map:{latitude},{longitude}
+    </div>
+  ),
+}));
+
+// Speech-recognition hook is mocked per-test so we control supported/listening.
+const speechMock = {
+  supported: true,
+  listening: false,
+  error: null as string | null,
+  start: vi.fn(),
+  stop: vi.fn(),
+};
+vi.mock("@/hooks/use-speech-recognition", () => ({
+  useSpeechRecognition: () => speechMock,
+}));
+
+function baseProps() {
+  return {
+    imagePreview: null,
+    description: "",
+    address: "",
+    latitude: null as number | null,
+    longitude: null as number | null,
+    accuracy: null as number | null,
+    locationLoading: false,
+    locationSuggesting: false,
+    addressSuggestions: [] as string[],
+    locationError: null as string | null,
+    classifying: false,
+    classifyError: null as string | null,
+    canSubmit: false,
+    onImageClick: vi.fn(),
+    onDrop: vi.fn(),
+    onClearImage: vi.fn(),
+    onDescriptionChange: vi.fn(),
+    onAddressChange: vi.fn(),
+    onDetectLocation: vi.fn(),
+    onLocationChange: vi.fn(),
+    onClassify: vi.fn(),
+  };
+}
+
+describe("DescribeStep", () => {
+  beforeEach(() => {
+    speechMock.supported = true;
+    speechMock.listening = false;
+    speechMock.error = null;
+    speechMock.start = vi.fn();
+    speechMock.stop = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the upload prompt when there is no image preview", () => {
+    // Arrange / Act
+    renderWithProviders(<DescribeStep {...baseProps()} />);
+
+    // Assert
+    expect(screen.getByText("Upload a photo")).toBeInTheDocument();
+    expect(screen.queryByAltText("Issue preview")).not.toBeInTheDocument();
+  });
+
+  it("shows a preview image and clear button when an image is set", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <DescribeStep {...baseProps()} imagePreview="blob:preview" />,
+    );
+
+    // Assert
+    const preview = screen.getByAltText("Issue preview");
+    expect(preview).toHaveAttribute("src", "blob:preview");
+    expect(
+      screen.getByRole("button", { name: "Remove image" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClearImage (and not onImageClick) when the clear button is clicked", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(
+      <DescribeStep {...props} imagePreview="blob:preview" />,
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Remove image" }));
+
+    // Assert: stopPropagation keeps the container click handler from firing.
+    expect(props.onClearImage).toHaveBeenCalledTimes(1);
+    expect(props.onImageClick).not.toHaveBeenCalled();
+  });
+
+  it("forwards description edits to onDescriptionChange", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+
+    // Act
+    await user.type(screen.getByLabelText("Description"), "x");
+
+    // Assert
+    expect(props.onDescriptionChange).toHaveBeenCalledWith("x");
+  });
+
+  it("starts dictation through the mic toggle when supported", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+
+    // Act
+    await user.click(
+      screen.getByRole("button", { name: "Dictate description" }),
+    );
+
+    // Assert
+    expect(speechMock.start).toHaveBeenCalledTimes(1);
+    expect(speechMock.stop).not.toHaveBeenCalled();
+  });
+
+  it("stops dictation when already listening", async () => {
+    // Arrange
+    speechMock.listening = true;
+    const props = baseProps();
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Stop dictation" }));
+
+    // Assert
+    expect(speechMock.stop).toHaveBeenCalledTimes(1);
+    expect(speechMock.start).not.toHaveBeenCalled();
+  });
+
+  it("shows a translated speech error message", () => {
+    // Arrange / Act
+    speechMock.error = "speech.denied";
+    renderWithProviders(<DescribeStep {...baseProps()} />);
+
+    // Assert: the i18n value for speech.denied is rendered, not the raw key.
+    expect(screen.queryByText("speech.denied")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/microphone access|denied|allow/i),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the mic toggle when speech recognition is unsupported", () => {
+    // Arrange / Act
+    speechMock.supported = false;
+    renderWithProviders(<DescribeStep {...baseProps()} />);
+
+    // Assert
+    expect(
+      screen.queryByRole("button", { name: /dictate|stop dictation/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens address suggestions on focus and selects one on click", async () => {
+    // Arrange
+    const props = baseProps();
+    props.addressSuggestions = ["123 Main St", "456 Oak Ave"];
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+    const input = screen.getByRole("combobox");
+
+    // Act: focus opens the listbox.
+    await user.click(input);
+
+    // Assert: options visible.
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const optionButton = screen
+      .getByRole("option", { name: /123 Main St/ })
+      .querySelector("button")!;
+
+    // Act: selection runs on mousedown (the component preventDefaults it to keep
+    // focus); fire mousedown explicitly to match real interaction.
+    await user.pointer({ keys: "[MouseLeft>]", target: optionButton });
+
+    // Assert: selection bubbles up and closes the list.
+    expect(props.onAddressChange).toHaveBeenCalledWith("123 Main St");
+    await waitFor(() =>
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("closes suggestions on an outside click", async () => {
+    // Arrange
+    const props = baseProps();
+    props.addressSuggestions = ["123 Main St"];
+    const { user } = renderWithProviders(
+      <div>
+        <DescribeStep {...props} />
+        <button type="button">outside</button>
+      </div>,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "outside" }));
+
+    // Assert
+    await waitFor(() =>
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("disables the detect button while location is loading", () => {
+    // Arrange / Act
+    renderWithProviders(<DescribeStep {...baseProps()} locationLoading />);
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: "Detect my location" }),
+    ).toBeDisabled();
+  });
+
+  it("calls onDetectLocation when the detect button is clicked", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+
+    // Act
+    await user.click(
+      screen.getByRole("button", { name: "Detect my location" }),
+    );
+
+    // Assert
+    expect(props.onDetectLocation).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [10, /bg-ep-green-light/],
+    [50, /bg-yellow-50/],
+    [250, /bg-red-50/],
+  ])(
+    "renders an accuracy badge colored by accuracy=%s meters",
+    (accuracy, classPattern) => {
+      // Arrange / Act
+      renderWithProviders(
+        <DescribeStep
+          {...baseProps()}
+          latitude={37.4}
+          longitude={-122.1}
+          accuracy={accuracy}
+        />,
+      );
+
+      // Assert
+      const badge = screen.getByText(`±${Math.round(accuracy)}m`);
+      expect(badge.className).toMatch(classPattern);
+    },
+  );
+
+  it("renders the map only when both latitude and longitude are set", () => {
+    // Arrange / Act: only latitude -> no map.
+    const { rerender } = renderWithProviders(
+      <DescribeStep {...baseProps()} latitude={37.4} longitude={null} />,
+    );
+
+    // Assert
+    expect(screen.queryByTestId("location-map")).not.toBeInTheDocument();
+
+    // Act: both set -> map renders.
+    rerender(
+      <DescribeStep {...baseProps()} latitude={37.4} longitude={-122.1} />,
+    );
+
+    // Assert
+    expect(screen.getByTestId("location-map")).toBeInTheDocument();
+  });
+
+  it("disables the classify button when canSubmit is false", () => {
+    // Arrange / Act
+    renderWithProviders(<DescribeStep {...baseProps()} canSubmit={false} />);
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: /Analyze Issue/ }),
+    ).toBeDisabled();
+  });
+
+  it("calls onClassify when the analyze button is clicked and enabled", async () => {
+    // Arrange
+    const props = baseProps();
+    props.canSubmit = true;
+    const { user } = renderWithProviders(<DescribeStep {...props} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Analyze Issue/ }));
+
+    // Assert
+    expect(props.onClassify).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the analyzing spinner state while classifying", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <DescribeStep {...baseProps()} canSubmit classifying />,
+    );
+
+    // Assert
+    expect(screen.getByText("Analyzing with AI...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Analyzing with AI...").closest("button"),
+    ).toBeDisabled();
+  });
+
+  it("renders an error banner when classifyError is set", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <DescribeStep {...baseProps()} classifyError="Classification failed" />,
+    );
+
+    // Assert
+    expect(screen.getByText("Classification failed")).toBeInTheDocument();
+  });
+});

--- a/nexa/src/components/report/location-map.test.tsx
+++ b/nexa/src/components/report/location-map.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen, waitFor } from "@/test";
+
+import LocationMap from "./location-map";
+
+// ---------------------------------------------------------------------------
+// Leaflet double. The real library touches the DOM/canvas and pulls map tiles
+// over the network. We replace it with a chainable fake whose calls we can
+// inspect, and capture the `dragend` handler so we can simulate a pin drag.
+// ---------------------------------------------------------------------------
+let dragendHandler: (() => void) | null = null;
+const markerLatLng = { lat: 1, lng: 2 };
+
+const marker = {
+  addTo: vi.fn(() => marker),
+  on: vi.fn((event: string, cb: () => void) => {
+    if (event === "dragend") dragendHandler = cb;
+    return marker;
+  }),
+  getLatLng: vi.fn(() => markerLatLng),
+  setLatLng: vi.fn(() => marker),
+};
+
+const map = {
+  remove: vi.fn(),
+  setView: vi.fn(() => map),
+  getZoom: vi.fn(() => 16),
+};
+
+const tileLayer = { addTo: vi.fn(() => tileLayer) };
+
+const L = {
+  map: vi.fn(() => map),
+  tileLayer: vi.fn(() => tileLayer),
+  icon: vi.fn(() => ({})),
+  marker: vi.fn(() => marker),
+};
+
+vi.mock("leaflet", () => ({ default: L, ...L }));
+vi.mock("leaflet/dist/leaflet.css", () => ({}));
+
+describe("LocationMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dragendHandler = null;
+  });
+
+  it("mounts a leaflet map with a draggable marker and exposes the aria label", async () => {
+    // Arrange / Act
+    renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={vi.fn()} />,
+    );
+
+    // Assert: the accessible container is present immediately.
+    expect(
+      screen.getByRole("application", {
+        name: /Map showing detected location/i,
+      }),
+    ).toBeInTheDocument();
+
+    // The async import + map setup runs after mount.
+    await waitFor(() => expect(L.map).toHaveBeenCalledTimes(1));
+    expect(L.marker).toHaveBeenCalledWith(
+      [37.4, -122.1],
+      expect.objectContaining({ draggable: true }),
+    );
+    expect(map.setView).toHaveBeenCalledWith([37.4, -122.1], 16);
+  });
+
+  it("calls onMove with the marker position on dragend", async () => {
+    // Arrange
+    const onMove = vi.fn();
+    renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={onMove} />,
+    );
+    await waitFor(() => expect(dragendHandler).not.toBeNull());
+
+    // Act: simulate the user dragging the pin.
+    dragendHandler?.();
+
+    // Assert
+    expect(onMove).toHaveBeenCalledWith(markerLatLng.lat, markerLatLng.lng);
+  });
+
+  it("repositions the marker when coordinates change", async () => {
+    // Arrange
+    const { rerender } = renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={vi.fn()} />,
+    );
+    await waitFor(() => expect(L.map).toHaveBeenCalled());
+
+    // Act
+    rerender(<LocationMap latitude={40} longitude={-74} onMove={vi.fn()} />);
+
+    // Assert
+    expect(marker.setLatLng).toHaveBeenCalledWith([40, -74]);
+  });
+
+  it("removes the map on unmount", async () => {
+    // Arrange
+    const { unmount } = renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={vi.fn()} />,
+    );
+    await waitFor(() => expect(L.map).toHaveBeenCalled());
+
+    // Act
+    unmount();
+
+    // Assert
+    expect(map.remove).toHaveBeenCalled();
+  });
+});

--- a/nexa/src/components/report/review-step.test.tsx
+++ b/nexa/src/components/report/review-step.test.tsx
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen } from "@/test";
+
+import { ReviewStep } from "./review-step";
+
+type OfficialForm = Parameters<typeof ReviewStep>[0]["officialForm"];
+
+function baseProps() {
+  return {
+    classification: {
+      issueType: "ROAD_DAMAGE",
+      aiDescription: "A deep pothole in the road.",
+      severity: "high" as "low" | "medium" | "high",
+    },
+    imagePreview: null as string | null,
+    description: "Big pothole",
+    address: "University Ave, Palo Alto",
+    submitting: false,
+    submitError: null as string | null,
+    officialForm: null as OfficialForm,
+    officialFormLoading: false,
+    onDescriptionChange: vi.fn(),
+    onAddressChange: vi.fn(),
+    onBack: vi.fn(),
+    onSubmit: vi.fn(),
+  };
+}
+
+describe("ReviewStep", () => {
+  it("renders the classified issue label and AI description", () => {
+    // Arrange / Act
+    renderWithProviders(<ReviewStep {...baseProps()} />);
+
+    // Assert: issue.ROAD_DAMAGE label + the AI description text.
+    expect(screen.getByText("Road Damage")).toBeInTheDocument();
+    expect(screen.getByText("A deep pothole in the road.")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["high", /bg-red-50/],
+    ["medium", /bg-yellow-50/],
+    ["low", /bg-ep-green-light/],
+  ] as const)("colors the %s severity badge", (severity, classPattern) => {
+    // Arrange / Act
+    const props = baseProps();
+    props.classification.severity = severity;
+    renderWithProviders(<ReviewStep {...props} />);
+
+    // Assert
+    const badge = screen.getByText(severity, { selector: "span" });
+    expect(badge.className).toMatch(classPattern);
+  });
+
+  it("shows the image preview when provided", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReviewStep {...baseProps()} imagePreview="blob:pic" />,
+    );
+
+    // Assert
+    expect(screen.getByAltText("Issue preview")).toHaveAttribute(
+      "src",
+      "blob:pic",
+    );
+  });
+
+  it("forwards edits to the description and address fields", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<ReviewStep {...props} />);
+
+    // Act
+    await user.type(screen.getByDisplayValue("Big pothole"), "!");
+    await user.type(screen.getByDisplayValue("University Ave, Palo Alto"), "!");
+
+    // Assert
+    expect(props.onDescriptionChange).toHaveBeenCalledWith("Big pothole!");
+    expect(props.onAddressChange).toHaveBeenCalledWith(
+      "University Ave, Palo Alto!",
+    );
+  });
+
+  it("shows a loading state while the official form is being looked up", () => {
+    // Arrange / Act
+    renderWithProviders(<ReviewStep {...baseProps()} officialFormLoading />);
+
+    // Assert
+    expect(
+      screen.getByText("Finding official city form..."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a found official form with link, city, confidence and reason", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        officialForm={{
+          status: "found",
+          cityName: "Palo Alto",
+          formUrl: "https://paloalto.gov/report",
+          reason: "Matched the city jurisdiction.",
+          confidence: "high",
+        }}
+      />,
+    );
+
+    // Assert
+    const link = screen.getByRole("link", {
+      name: /Open official city form/,
+    });
+    expect(link).toHaveAttribute("href", "https://paloalto.gov/report");
+    expect(
+      screen.getByText("Official city website for Palo Alto"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Confidence: high")).toBeInTheDocument();
+    expect(
+      screen.getByText("Matched the city jurisdiction."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the not-found message when no official form is available", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        officialForm={{
+          status: "not_found",
+          cityName: null,
+          message: "irrelevant",
+          reason: "Outside any known jurisdiction.",
+        }}
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.getByText("No official city form found."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Outside any known jurisdiction."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Open official city form/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onBack when the back button is clicked", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<ReviewStep {...props} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Back/ }));
+
+    // Assert
+    expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSubmit when the submit button is clicked", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(<ReviewStep {...props} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /Submit Report/ }));
+
+    // Assert
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the submit button and shows submitting text while submitting", () => {
+    // Arrange / Act
+    renderWithProviders(<ReviewStep {...baseProps()} submitting />);
+
+    // Assert
+    const submitting = screen.getByText("Submitting...");
+    expect(submitting.closest("button")).toBeDisabled();
+  });
+
+  it("renders a submit error banner", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReviewStep {...baseProps()} submitError="Submission failed" />,
+    );
+
+    // Assert
+    expect(screen.getByText("Submission failed")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Implements #117 (components-only split; hook tests were #118).

## Scope
Colocated jsdom + RTL component tests for:
- **Report wizard**: `describe-step`, `review-step`, `confirmed-step`, `location-map`
- **Dashboard**: `report-card`, `reports-map`, `delete-report-button`, `resolution-prompt`
- **Auth/nav**: `login-form`, `register-form`, `navbar`

## Approach
- Reuses the `src/test` foundation (#112): `renderWithProviders`, `makeUser`, MSW `server`/`http`/`HttpResponse`, the global `next/navigation`/`next/image`/`next/headers` mocks, and `onUnhandledRequest: "error"`.
- Leaflet is mocked with a chainable fake for both map components (no tiles, no `window` blow-ups); `dynamic` `LocationMap` is mocked inside the describe-step test.
- `useSpeechRecognition` is mocked to drive the mic toggle / no-mic fallback / error states.
- All `/api/*` calls (auth login/register/me/logout, report delete, resolution, submission-fields) are stubbed via MSW. `next/navigation` is overridden per-file where `push`/`refresh` assertions are needed (the global mock returns a fresh router each call).
- AAA, deterministic/offline, queries by role/label/text.

## Verification
- `npm test` (full suite): 30 files, 315 tests passing (95 new component tests across 11 files).
- `npx tsc --noEmit`: clean.
- `npm run format:check`: clean.