### PR TITLE
feat(types): runtime validation at JWT + LLM-JSON boundaries [#129]

### DIFF
--- a/nexa/src/lib/auth.test.ts
+++ b/nexa/src/lib/auth.test.ts
@@ -1,8 +1,21 @@
+import { SignJWT } from "jose";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MissingEnvError } from "@/lib/config";
 
 import { createToken, verifyToken, type SessionPayload } from "./auth";
+
+// Sign an arbitrary (possibly malformed) payload under the active test secret so
+// we can exercise verifyToken's runtime claim validation on a signature-valid
+// but wrong-shaped token.
+async function signRaw(claims: Record<string, unknown>): Promise<string> {
+  const secret = new TextEncoder().encode("unit-test-secret");
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("7d")
+    .sign(secret);
+}
 
 // auth.ts reads the JWT secret via @/lib/config's getJwtSecret (cached/memoized
 // in the real module). We mock that one getter so each test controls the secret
@@ -84,6 +97,60 @@ describe("createToken / verifyToken", () => {
 
     // Assert
     expect(decoded).toBeNull();
+  });
+
+  it("returns null for a signature-valid token whose payload is missing userId", async () => {
+    // Arrange: a properly signed token that lacks userId — previously this was
+    // cast straight through as a SessionPayload with userId === undefined.
+    const token = await signRaw({ email: "person@example.com" });
+
+    // Act
+    const decoded = await verifyToken(token);
+
+    // Assert
+    expect(decoded).toBeNull();
+  });
+
+  it("returns null for a signature-valid token whose payload is missing email", async () => {
+    // Arrange
+    const token = await signRaw({ userId: "user-123" });
+
+    // Act / Assert
+    expect(await verifyToken(token)).toBeNull();
+  });
+
+  it("returns null when userId/email are present but the wrong type", async () => {
+    // Arrange: userId is a number, email is null — not a usable session.
+    const token = await signRaw({ userId: 7, email: null });
+
+    // Act / Assert
+    expect(await verifyToken(token)).toBeNull();
+  });
+
+  it("returns null when userId/email are empty strings", async () => {
+    // Arrange: present but empty — there is no real user to identify.
+    const token = await signRaw({ userId: "", email: "" });
+
+    // Act / Assert
+    expect(await verifyToken(token)).toBeNull();
+  });
+
+  it("returns only userId/email, dropping extra claims from the token", async () => {
+    // Arrange: a valid session plus an unexpected extra claim and jose's iat/exp.
+    const token = await signRaw({
+      userId: "user-123",
+      email: "person@example.com",
+      role: "admin",
+    });
+
+    // Act
+    const decoded = await verifyToken(token);
+
+    // Assert: the returned payload is exactly the SessionPayload shape.
+    expect(decoded).toEqual({
+      userId: "user-123",
+      email: "person@example.com",
+    });
   });
 
   it("throws when the JWT secret is missing (observed through createToken)", async () => {

--- a/nexa/src/lib/auth.ts
+++ b/nexa/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
+import { z } from "zod";
 import { getJwtSecret } from "@/lib/config";
 
 // The name of the cookie that holds the session token
@@ -14,28 +15,48 @@ export interface SessionPayload {
   email: string;
 }
 
+// Runtime shape of the claims we trust out of a decoded JWT. jose validates the
+// signature/expiry, but the payload itself is attacker-influenced data, so we
+// validate the fields we read before handing them to callers. The schema is
+// non-strict so the standard JWT registered claims (iat/exp/...) jose adds pass
+// through; we then return just the SessionPayload fields callers depend on.
+const sessionPayloadSchema = z.object({
+  userId: z.string().min(1),
+  email: z.string().min(1),
+});
+
 // Encode the secret once — jose requires a Uint8Array.
 // getJwtSecret() throws a clear, named error when JWT_SECRET is unset.
 function getSecret() {
   return new TextEncoder().encode(getJwtSecret());
 }
 
-// Signs a JWT containing the user's id and email, valid for 7 days
+// Signs a JWT containing the user's id and email, valid for 7 days.
+// SignJWT accepts a JWTPayload directly — SessionPayload satisfies it, so no cast.
 export async function createToken(payload: SessionPayload): Promise<string> {
-  return new SignJWT(payload as unknown as Record<string, unknown>)
+  return new SignJWT({ ...payload })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime("7d")
     .sign(getSecret());
 }
 
-// Verifies the token's signature and expiry — returns the payload or null if invalid
+// Verifies the token's signature and expiry, then validates the decoded claims.
+// Returns the typed payload, or null if the signature/expiry is invalid OR the
+// payload is malformed (missing/empty userId or email) — never an unchecked cast.
 export async function verifyToken(
   token: string,
 ): Promise<SessionPayload | null> {
   try {
     const { payload } = await jwtVerify(token, getSecret());
-    return payload as unknown as SessionPayload;
+    const result = sessionPayloadSchema.safeParse(payload);
+    if (!result.success) {
+      // Signature was valid but the claims are not a usable session — e.g. a
+      // token minted elsewhere with a different shape. Treat as logged out.
+      return null;
+    }
+    const { userId, email } = result.data;
+    return { userId, email };
   } catch {
     // Token is expired, tampered with, or the secret changed — treat as logged out
     return null;

--- a/nexa/src/lib/classify/observe.test.ts
+++ b/nexa/src/lib/classify/observe.test.ts
@@ -79,47 +79,46 @@ describe("observeImage (parseObservation behavior)", () => {
     expect(obs.scene).toBe("s");
   });
 
-  it("coerces non-array fields to empty arrays", async () => {
-    // Arrange: objects is a string, hazards is a number.
+  it("throws on a wrong-shaped field instead of coercing it to empty", async () => {
+    // Arrange: objects is a string, hazards a number — previously these were
+    // silently coerced to [], masking an upstream model failure. They must now
+    // fail traceably at the boundary.
     createMock.mockResolvedValue(
       reply(JSON.stringify({ objects: "nope", hazards: 3, scene: "s" })),
     );
 
-    // Act
-    const obs = await observeImage("data:image/jpeg;base64,xxx");
-
-    // Assert
-    expect(obs.objects).toEqual([]);
-    expect(obs.conditions).toEqual([]);
-    expect(obs.hazards).toEqual([]);
+    // Act / Assert
+    await expect(observeImage("data:image/jpeg;base64,xxx")).rejects.toThrow(
+      /invalid observation response/i,
+    );
   });
 
-  it("coerces non-string array elements to strings", async () => {
-    // Arrange
+  it("throws on non-string array elements instead of stringifying them", async () => {
+    // Arrange: the array must contain strings — no String() coercion now.
     createMock.mockResolvedValue(
       reply(JSON.stringify({ objects: [1, true, null], scene: "s" })),
     );
 
-    // Act
-    const obs = await observeImage("data:image/jpeg;base64,xxx");
-
-    // Assert
-    expect(obs.objects).toEqual(["1", "true", "null"]);
+    // Act / Assert
+    await expect(observeImage("data:image/jpeg;base64,xxx")).rejects.toThrow(
+      /invalid observation response/i,
+    );
   });
 
-  it("defaults scene to empty string when missing or non-string", async () => {
-    // Arrange
+  it("throws when scene is present but not a string", async () => {
+    // Arrange: a non-string scene is malformed, not an empty scene.
     createMock.mockResolvedValue(reply(JSON.stringify({ scene: 99 })));
 
-    // Act
-    const obs = await observeImage("data:image/jpeg;base64,xxx");
-
-    // Assert
-    expect(obs.scene).toBe("");
+    // Act / Assert
+    await expect(observeImage("data:image/jpeg;base64,xxx")).rejects.toThrow(
+      /invalid observation response/i,
+    );
   });
 
-  it("falls back to {} when the model returns null content (empty observation)", async () => {
-    // Arrange: content null → source defaults raw to "{}".
+  it("treats missing keys as a legitimate empty observation (blurry/empty image)", async () => {
+    // Arrange: the prompt permits empty arrays / scene for an empty image, and
+    // null content defaults raw to "{}" — every key missing is valid, so the
+    // schema fills defaults rather than throwing.
     createMock.mockResolvedValue(reply(null));
 
     // Act

--- a/nexa/src/lib/classify/observe.ts
+++ b/nexa/src/lib/classify/observe.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { z } from "zod";
 import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
 import { extractJsonObject } from "./json";
 
@@ -9,6 +10,19 @@ export interface Observation {
   scene: string;
   latencyMs: number;
 }
+
+// Runtime contract for the stage-1 observation JSON. The prompt explicitly
+// permits empty arrays / an empty scene for a blurry-or-empty image, so missing
+// keys default to empty — that is a legitimate observation, not a failure. What
+// we will NOT do is silently coerce a wrong-shaped payload (e.g. objects: "nope"
+// or a non-object) into all-empty observations, which would mask an upstream
+// model failure; those mismatch the schema and throw traceably instead.
+const observationSchema = z.object({
+  objects: z.array(z.string()).default([]),
+  conditions: z.array(z.string()).default([]),
+  hazards: z.array(z.string()).default([]),
+  scene: z.string().default(""),
+});
 
 const OBSERVATION_PROMPT = `You are a visual observation assistant for a civic-issue reporting app. Your job is NOT to classify or label the issue — only to describe what is in the image as concretely as possible. A downstream classifier will use your observations.
 
@@ -29,16 +43,23 @@ function getClient() {
   return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 }
 
+/**
+ * Parse and validate a stage-1 observation response.
+ *
+ * @throws {SyntaxError} When no JSON object can be located in `raw`.
+ * @throws {Error} When the parsed object is the wrong shape (e.g. `objects` is
+ *   not a string array) — a malformed response fails traceably instead of being
+ *   silently coerced to all-empty observations that hide the real failure.
+ */
 function parseObservation(raw: string): Omit<Observation, "latencyMs"> {
-  const parsed = extractJsonObject<Record<string, unknown>>(raw, "observation");
-  return {
-    objects: Array.isArray(parsed.objects) ? parsed.objects.map(String) : [],
-    conditions: Array.isArray(parsed.conditions)
-      ? parsed.conditions.map(String)
-      : [],
-    hazards: Array.isArray(parsed.hazards) ? parsed.hazards.map(String) : [],
-    scene: typeof parsed.scene === "string" ? parsed.scene : "",
-  };
+  const parsed = extractJsonObject<unknown>(raw, "observation");
+  const result = observationSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Invalid observation response: ${z.prettifyError(result.error)}`,
+    );
+  }
+  return result.data;
 }
 
 /**

--- a/nexa/src/lib/classify/types.test.ts
+++ b/nexa/src/lib/classify/types.test.ts
@@ -74,33 +74,69 @@ describe("parseClassificationResponse", () => {
     expect(() => parseClassificationResponse("{ not: valid, json }")).toThrow();
   });
 
-  it("returns missing required fields as undefined (no schema enforcement)", () => {
-    // Arrange: the parser does not validate the schema — callers do.
+  it("throws when required fields are missing (schema enforced)", () => {
+    // Arrange: only issueType is present — the schema now rejects the rest.
     const raw = JSON.stringify({ issueType: "OTHER" });
 
-    // Act
-    const result = parseClassificationResponse(raw);
-
-    // Assert
-    expect(result.issueType).toBe("OTHER");
-    expect(result.aiDescription).toBeUndefined();
-    expect(result.severity).toBeUndefined();
-    expect(result.confidence).toBeUndefined();
+    // Act / Assert: a traceable validation error, not a half-typed object.
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
   });
 
-  it("passes through non-string string fields unchanged (no coercion)", () => {
-    // Arrange: aiDescription is a number — the parser does not coerce it.
+  it("throws when issueType is not in the IssueType enum", () => {
+    // Arrange: a value outside the allowed enum must fail rather than cast.
+    const raw = JSON.stringify({ ...valid, issueType: "NOT_A_TYPE" });
+
+    // Act / Assert
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws when issueType is a number (the documented crash case)", () => {
+    // Arrange: `{ issueType: 123 }` previously passed the cast and crashed
+    // downstream — it must now fail at the boundary.
+    const raw = JSON.stringify({ ...valid, issueType: 123 });
+
+    // Act / Assert
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws when severity is not in the Severity enum", () => {
+    // Arrange
+    const raw = JSON.stringify({ ...valid, severity: "critical" });
+
+    // Act / Assert
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws when a string field is the wrong type (no coercion)", () => {
+    // Arrange: aiDescription is a number — validation rejects rather than coerce.
     const raw = JSON.stringify({ ...valid, aiDescription: 42 });
 
-    // Act
-    const result = parseClassificationResponse(raw);
-
-    // Assert
-    expect(result.aiDescription as unknown).toBe(42);
+    // Act / Assert
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
   });
 
-  it("passes through confidence values outside 0-1 (no clamping)", () => {
+  it("throws when confidence is not a number", () => {
     // Arrange
+    const raw = JSON.stringify({ ...valid, confidence: "high" });
+
+    // Act / Assert
+    expect(() => parseClassificationResponse(raw)).toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("accepts confidence values outside 0-1 (bounds are out of scope, #106)", () => {
+    // Arrange: the schema validates the type, not the numeric range.
     const raw = JSON.stringify({ ...valid, confidence: 5 });
 
     // Act / Assert

--- a/nexa/src/lib/classify/types.ts
+++ b/nexa/src/lib/classify/types.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { extractJsonObject } from "./json";
 
 export const ISSUE_TYPES = [
@@ -8,8 +9,10 @@ export const ISSUE_TYPES = [
   "OTHER",
 ] as const;
 
+export const SEVERITIES = ["low", "medium", "high"] as const;
+
 export type IssueType = (typeof ISSUE_TYPES)[number];
-export type Severity = "low" | "medium" | "high";
+export type Severity = (typeof SEVERITIES)[number];
 
 export interface ClassificationResult {
   issueType: IssueType;
@@ -17,6 +20,17 @@ export interface ClassificationResult {
   severity: Severity;
   confidence: number;
 }
+
+// Runtime contract for a model's classification JSON. The provider is an
+// external, untrusted boundary: a model returning e.g. `{ issueType: 123 }` must
+// fail here, traceably, rather than be cast through as a ClassificationResult
+// and crash some unrelated consumer downstream.
+const classificationResultSchema = z.object({
+  issueType: z.enum(ISSUE_TYPES),
+  aiDescription: z.string(),
+  severity: z.enum(SEVERITIES),
+  confidence: z.number(),
+}) satisfies z.ZodType<ClassificationResult>;
 
 export interface ProviderResult extends ClassificationResult {
   provider: string;
@@ -99,7 +113,22 @@ export function buildClassificationPrompt(
   return sections.join("\n");
 }
 
-/** Parse model JSON even when wrapped in markdown fences or extra prose. */
+/**
+ * Parse and validate a model's classification JSON, even when wrapped in
+ * markdown fences or extra prose.
+ *
+ * @throws {SyntaxError} When no JSON object can be located in `raw`.
+ * @throws {Error} When the parsed object does not match the classification
+ *   schema (bad `issueType`/`severity` enum, missing/mistyped fields) — the
+ *   message names the offending fields so the failure is traceable.
+ */
 export function parseClassificationResponse(raw: string): ClassificationResult {
-  return extractJsonObject<ClassificationResult>(raw);
+  const parsed = extractJsonObject<unknown>(raw);
+  const result = classificationResultSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Invalid classification response: ${z.prettifyError(result.error)}`,
+    );
+  }
+  return result.data;
 }


### PR DESCRIPTION
Closes #129.

Replaces unchecked `as` / `as unknown as` casts at three trust boundaries with zod runtime validation that yields the typed value. Malformed data now fails explicitly and traceably instead of flowing in as if well-typed. Reuses the existing `zod` dependency and the shared `extractJsonObject` extractor (from #130).

## Boundaries hardened
1. **`src/lib/auth.ts` — `verifyToken`**: jose verifies signature/expiry, but the decoded payload is attacker-influenced. It is now validated against a `sessionPayloadSchema` (non-empty `userId` and `email`); a signature-valid-but-malformed token returns `null` instead of being cast through with `userId`/`email` possibly missing. `verifyToken` returns exactly the `{ userId, email }` fields. `createToken` no longer double-casts — `SignJWT` accepts the payload directly.
2. **`src/lib/classify/types.ts` — `parseClassificationResponse`**: the parsed object is validated against `classificationResultSchema` (`issueType` and `severity` as enums, `aiDescription` string, `confidence` number). A provider returning e.g. `{ issueType: 123 }` now throws a traceable `Invalid classification response: …` error (with prettified zod detail) instead of casting to `ClassificationResult` and crashing downstream. Both providers and the `consensus` `safeCall` wrapper already treat a thrown parse error as a provider failure.
3. **`src/lib/classify/observe.ts` — `parseObservation`**: the parsed value is validated against `observationSchema`. A wrong-shaped field (e.g. `objects: "nope"`, non-string array elements, non-string `scene`) now throws `Invalid observation response: …` rather than being silently coerced to all-empty observations that mask an upstream model failure. Missing keys still default to empty, since the prompt explicitly permits an empty observation for a blurry/empty image; `consensus` already catches stage-1 failures and falls back.

## Tests updated and why
The existing suites pinned the OLD cast/coercion behavior, so they were rewritten to assert the new validation behavior (no vacuous tests):

- **`src/lib/classify/types.test.ts`**: the three "no schema enforcement / no coercion" cases (missing fields → undefined, non-string passed through, out-of-range passed through) now assert throws for missing fields, bad `issueType` enum, `issueType` as a number (the documented crash case), bad `severity` enum, and wrong-typed string/number fields. Kept an explicit case documenting that numeric bounds remain out of scope (#106): `confidence: 5` still parses.
- **`src/lib/classify/observe.test.ts`**: the "coerces non-array fields", "coerces non-string elements", and "defaults scene from non-string" cases now assert throws on those malformed shapes. The null-content case is retained but reframed as the legitimate empty-observation path (missing keys default to empty).
- **`src/lib/auth.test.ts`**: added a `signRaw` helper and cases asserting `verifyToken` returns `null` for a signature-valid token missing `userId`, missing `email`, with wrong-typed or empty `userId`/`email`, and a case asserting only `userId`/`email` are returned (extra claims dropped).
- `src/lib/auth-session.test.ts` and `src/proxy.test.ts` needed no changes — they only exercise valid tokens and invalid/unverifiable tokens, both of which behave identically.

## Verification (all green)
- `npx tsc --noEmit`
- `npm run lint` (0 errors; 2 pre-existing `<img>` warnings unrelated to this change)
- `npm run format:check`
- `npm test` — 229 passed
- `npm run build` — succeeds with env vars set (the bare run fails only on missing `DATABASE_URL` during page-data collection, an environment/setup issue unrelated to this change; the compile + TypeScript steps pass)