### PR TITLE
feat(auth): optional anonymous reporting with account-upgrade [#17]

### DIFF
--- a/nexa/src/app/api/auth/claim/route.test.ts
+++ b/nexa/src/app/api/auth/claim/route.test.ts
@@ -1,0 +1,89 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+import { POST } from "./route";
+
+// Integration test (node project) for the account-claim route with Prisma
+// deep-mocked. Covers the original passwordless-account upgrade AND the
+// anonymous-reporting addition where `reportIds` attach guest reports.
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/auth/claim", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/claim", () => {
+  it("creates the account and attaches anonymous reports by id", async () => {
+    // Arrange — new email (no existing user), two pending guest report ids.
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    prismaMock.user.create.mockResolvedValue({
+      id: "user_new",
+      email: "guest@example.com",
+      name: null,
+    } as Awaited<ReturnType<typeof prismaMock.user.create>>);
+    prismaMock.report.updateMany.mockResolvedValue({ count: 2 });
+
+    const request = makeRequest({
+      email: "guest@example.com",
+      password: "supersecret",
+      reportIds: ["rpt_1", "rpt_2"],
+    });
+
+    // Act
+    const response = await POST(request);
+
+    // Assert — orphan reports re-associated with the new user only.
+    expect(response.status).toBe(200);
+    expect(prismaMock.report.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["rpt_1", "rpt_2"] }, userId: null },
+      data: { userId: "user_new" },
+    });
+  });
+
+  it("does not touch reports when no reportIds are supplied", async () => {
+    // Arrange — original passwordless-account flow stays unchanged.
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    prismaMock.user.create.mockResolvedValue({
+      id: "user_new",
+      email: "legacy@example.com",
+      name: null,
+    } as Awaited<ReturnType<typeof prismaMock.user.create>>);
+
+    const request = makeRequest({
+      email: "legacy@example.com",
+      password: "supersecret",
+    });
+
+    // Act
+    const response = await POST(request);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the account already has a password", async () => {
+    // Arrange
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "user_existing",
+      passwordHash: "already-set",
+    } as Awaited<ReturnType<typeof prismaMock.user.findUnique>>);
+
+    const request = makeRequest({
+      email: "taken@example.com",
+      password: "supersecret",
+      reportIds: ["rpt_1"],
+    });
+
+    // Act
+    const response = await POST(request);
+
+    // Assert — no report mutation happens on the rejected path.
+    expect(response.status).toBe(409);
+    expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/nexa/src/app/api/auth/claim/route.ts
+++ b/nexa/src/app/api/auth/claim/route.ts
@@ -12,7 +12,7 @@ import { successResponse, errorResponse } from "@/lib/api/response";
 // password is set, this endpoint becomes a no-op for that user.
 export async function POST(request: NextRequest) {
   try {
-    const { email, password, name } = await request.json();
+    const { email, password, name, reportIds } = await request.json();
 
     if (!email || !password) {
       return errorResponse("Email and password are required", 400);
@@ -46,6 +46,17 @@ export async function POST(request: NextRequest) {
           data: { email, name: name ?? null, passwordHash },
           select: { id: true, email: true, name: true },
         });
+
+    // Upgrade path for anonymous reporting: attach any reports the user filed as
+    // a guest to the account they just claimed. Only orphan reports (userId=null)
+    // matching the supplied ids are re-associated, so this can never steal a
+    // report that already belongs to someone else.
+    if (Array.isArray(reportIds) && reportIds.length > 0) {
+      await prisma.report.updateMany({
+        where: { id: { in: reportIds }, userId: null },
+        data: { userId: user.id },
+      });
+    }
 
     const token = await createToken({ userId: user.id, email: user.email });
     const response = successResponse(user);

--- a/nexa/src/app/api/auth/claim/route.ts
+++ b/nexa/src/app/api/auth/claim/route.ts
@@ -51,7 +51,11 @@ export async function POST(request: NextRequest) {
     // a guest to the account they just claimed. Only orphan reports (userId=null)
     // matching the supplied ids are re-associated, so this can never steal a
     // report that already belongs to someone else.
-    if (Array.isArray(reportIds) && reportIds.length > 0) {
+    if (
+      Array.isArray(reportIds) &&
+      reportIds.length > 0 &&
+      reportIds.every((id): id is string => typeof id === "string")
+    ) {
       await prisma.report.updateMany({
         where: { id: { in: reportIds }, userId: null },
         data: { userId: user.id },

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
+import { addPendingReportId } from "@/lib/pending-reports";
 import { Stepper, type ReportStep } from "@/components/report/stepper";
 import { DescribeStep } from "@/components/report/describe-step";
 import { ReviewStep } from "@/components/report/review-step";
@@ -32,6 +33,22 @@ export default function ReportPage() {
 
   const [step, setStep] = useState<ReportStep>("describe");
   const [description, setDescription] = useState("");
+
+  // Anonymous reporting: a guest can complete the whole flow without an account.
+  // We check session state only to decide whether to offer the post-submit
+  // "create an account to track this report" upgrade prompt. `undefined` means
+  // we haven't resolved it yet, so the prompt stays hidden until we know.
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/auth/me")
+      .then((r) => active && setIsLoggedIn(r.ok))
+      .catch(() => active && setIsLoggedIn(false));
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleDescriptionChange = useCallback(
     (value: string) => {
@@ -113,6 +130,13 @@ export default function ReportPage() {
       {
         onSuccess: (report) => {
           setStep("confirmed");
+          // Guests have no userId on the server row; remember this report's id so
+          // the confirmed step's upgrade prompt can hand it to /api/auth/claim and
+          // associate it with the account they create. Logged-in reports already
+          // carry their userId, so there is nothing to claim later.
+          if (isLoggedIn === false) {
+            addPendingReportId(report.id);
+          }
           // Guard against an unstarted clock (0) so we never emit an
           // epoch-sized interval; in practice a submit always follows a
           // capture, so the fallback is defensive only.
@@ -285,6 +309,7 @@ export default function ReportPage() {
           <ConfirmedStep
             report={submission.createdReport}
             offline={submission.submittedOffline}
+            isLoggedIn={isLoggedIn}
             onReportAnother={resetForm}
           />
         )}

--- a/nexa/src/components/auth/claim-form.tsx
+++ b/nexa/src/components/auth/claim-form.tsx
@@ -7,6 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { ApiResponse } from "@/lib/api/response";
+import {
+  clearPendingReportIds,
+  getPendingReportIds,
+} from "@/lib/pending-reports";
 
 export function ClaimForm() {
   const router = useRouter();
@@ -23,6 +27,11 @@ export function ClaimForm() {
     setLoading(true);
 
     try {
+      // Hand over any reports filed anonymously so they're attached to this
+      // account. Empty when the user reached /claim directly (the original
+      // passwordless-account flow), which keeps that path unchanged.
+      const reportIds = getPendingReportIds();
+
       const res = await fetch("/api/auth/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -30,6 +39,7 @@ export function ClaimForm() {
           email,
           password,
           name: name || undefined,
+          ...(reportIds.length > 0 ? { reportIds } : {}),
         }),
       });
 
@@ -40,6 +50,7 @@ export function ClaimForm() {
         return;
       }
 
+      clearPendingReportIds();
       router.push("/dashboard");
       router.refresh();
     } catch {

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -14,15 +14,28 @@ interface ConfirmedReport {
 interface ConfirmedStepProps {
   report: ConfirmedReport;
   offline?: boolean;
+  /**
+   * Whether the visitor is signed in. `undefined` while the session check is
+   * still resolving — we only offer the account-upgrade prompt once we know the
+   * user is a guest (`false`), never speculatively.
+   */
+  isLoggedIn?: boolean;
   onReportAnother: () => void;
 }
 
 export function ConfirmedStep({
   report,
   offline = false,
+  isLoggedIn,
   onReportAnother,
 }: ConfirmedStepProps) {
   const { t, locale } = useI18n();
+
+  // Guests who just filed a report are invited to create an account so they can
+  // track it. Hidden for logged-in users and for offline-queued reports (which
+  // have no server id to claim yet). Routes to /claim, which both creates the
+  // account and attaches the pending report ids via /api/auth/claim.
+  const showUpgradePrompt = isLoggedIn === false && !offline;
 
   return (
     <div className="flex flex-col items-center gap-10 py-12 text-center">
@@ -91,10 +104,30 @@ export function ConfirmedStep({
 
       {!offline && <SubmissionAssistant reportId={report.id} />}
 
+      {showUpgradePrompt && (
+        <div className="ep-card w-full max-w-md p-6 text-left">
+          <h3 className="text-lg font-medium tracking-tight">
+            {t("report.trackTitle")}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("report.trackSubtitle")}
+          </p>
+          <Link
+            href="/claim"
+            className="btn-cta btn-cta-purple mt-4 inline-flex"
+          >
+            {t("report.trackCta")}
+            <ArrowRight className="size-4" />
+          </Link>
+        </div>
+      )}
+
       <div className="flex flex-wrap justify-center gap-3">
-        <Link href="/dashboard" className="btn-cta btn-cta-outline">
-          {t("report.viewDashboard")}
-        </Link>
+        {isLoggedIn !== false && (
+          <Link href="/dashboard" className="btn-cta btn-cta-outline">
+            {t("report.viewDashboard")}
+          </Link>
+        )}
         <button className="btn-cta btn-cta-purple" onClick={onReportAnother}>
           {t("report.reportAnother")}
           <ArrowRight className="size-4" />

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -159,6 +159,10 @@ const enMessages = {
   "report.aiSummary": "AI Summary",
   "report.viewDashboard": "View Dashboard",
   "report.reportAnother": "Report Another Issue",
+  "report.trackTitle": "Create an account to track this report",
+  "report.trackSubtitle":
+    "Sign up to follow this report's status and see all your past reports in one place.",
+  "report.trackCta": "Create an account",
   "report.aiComparison": "/ AI Comparison",
   "report.decisionMethod": "Decision method:",
   "report.modelsAgreed": " (models agreed)",
@@ -389,6 +393,10 @@ export const messages = {
     "report.aiSummary": "Resumen de IA",
     "report.viewDashboard": "Ver panel",
     "report.reportAnother": "Reportar otro problema",
+    "report.trackTitle": "Crea una cuenta para seguir este reporte",
+    "report.trackSubtitle":
+      "Regístrate para seguir el estado de este reporte y ver todos tus reportes anteriores en un solo lugar.",
+    "report.trackCta": "Crear una cuenta",
     "report.aiComparison": "/ Comparación de IA",
     "report.decisionMethod": "Método de decisión:",
     "report.modelsAgreed": " (los modelos coincidieron)",
@@ -605,6 +613,10 @@ export const messages = {
     "report.aiSummary": "AI 摘要",
     "report.viewDashboard": "查看仪表板",
     "report.reportAnother": "报告另一个问题",
+    "report.trackTitle": "创建账户以跟踪此报告",
+    "report.trackSubtitle":
+      "注册即可跟踪此报告的状态，并在一处查看您过去的所有报告。",
+    "report.trackCta": "创建账户",
     "report.aiComparison": "/ AI 对比",
     "report.decisionMethod": "决策方法：",
     "report.modelsAgreed": "（模型一致）",
@@ -829,6 +841,10 @@ export const messages = {
     "report.aiSummary": "Résumé IA",
     "report.viewDashboard": "Voir le tableau de bord",
     "report.reportAnother": "Signaler un autre problème",
+    "report.trackTitle": "Créez un compte pour suivre ce signalement",
+    "report.trackSubtitle":
+      "Inscrivez-vous pour suivre l'état de ce signalement et retrouver tous vos signalements passés au même endroit.",
+    "report.trackCta": "Créer un compte",
     "report.aiComparison": "/ Comparaison IA",
     "report.decisionMethod": "Méthode de décision :",
     "report.modelsAgreed": " (les modèles sont d'accord)",

--- a/nexa/src/lib/pending-reports.ts
+++ b/nexa/src/lib/pending-reports.ts
@@ -1,0 +1,45 @@
+// Tracks the server ids of reports a visitor filed while signed out, so that
+// when they later create/claim an account we can hand those ids to
+// `/api/auth/claim` and re-associate the reports with the new account. This is
+// the client half of the anonymous-reporting upgrade path; the server half is
+// the `reportIds` handling in `POST /api/auth/claim`.
+
+const STORAGE_KEY = "nexa-pending-report-ids";
+
+function read(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(ids: string[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+}
+
+/** Returns the ids of anonymous reports awaiting account association. */
+export function getPendingReportIds(): string[] {
+  return read();
+}
+
+/** Records an anonymous report id (deduped) to be claimed after sign-up. */
+export function addPendingReportId(id: string) {
+  if (!id) return;
+  const ids = read();
+  if (ids.includes(id)) return;
+  ids.push(id);
+  write(ids);
+}
+
+/** Clears the pending list once the reports have been claimed. */
+export function clearPendingReportIds() {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/nexa/src/proxy.test.ts
+++ b/nexa/src/proxy.test.ts
@@ -28,7 +28,7 @@ async function validToken(): Promise<string> {
 
 describe("proxy() middleware", () => {
   describe("protected routes", () => {
-    it.each(["/report", "/dashboard", "/dashboard/reports/abc", "/report/new"])(
+    it.each(["/dashboard", "/dashboard/reports/abc"])(
       "redirects %s with no session to /login preserving redirect=path",
       async (path) => {
         // Arrange
@@ -119,10 +119,28 @@ describe("proxy() middleware", () => {
     });
   });
 
+  describe("anonymous reporting (guest access to /report)", () => {
+    it.each(["/report", "/report/new", "/reportage"])(
+      "calls next() for %s with no session — guest reporting is allowed",
+      async (path) => {
+        // Arrange — /report is intentionally NOT protected so guests can file a
+        // report without an account; /reportage shares the prefix and is public too.
+        const request = makeRequest(path);
+
+        // Act
+        const response = await proxy(request);
+
+        // Assert
+        expect(response.headers.get("location")).toBeNull();
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+      },
+    );
+  });
+
   describe("prefix (startsWith) semantics", () => {
-    it("treats /reportage as protected because it starts with /report", async () => {
+    it("treats /dashboardx as protected because it starts with /dashboard", async () => {
       // Arrange — documents the as-implemented startsWith behavior.
-      const request = makeRequest("/reportage");
+      const request = makeRequest("/dashboardx");
 
       // Act
       const response = await proxy(request);
@@ -131,7 +149,7 @@ describe("proxy() middleware", () => {
       // Assert
       expect(response.status).toBe(307);
       expect(location.pathname).toBe("/login");
-      expect(location.searchParams.get("redirect")).toBe("/reportage");
+      expect(location.searchParams.get("redirect")).toBe("/dashboardx");
     });
 
     it("does NOT treat /registerish as an auth route redirect when logged out", async () => {

--- a/nexa/src/proxy.ts
+++ b/nexa/src/proxy.ts
@@ -5,8 +5,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken, SESSION_COOKIE } from "@/lib/auth";
 
-// Pages that require a logged-in user — any path that starts with these strings is protected
-const PROTECTED_ROUTES = ["/report", "/dashboard"];
+// Pages that require a logged-in user — any path that starts with these strings is protected.
+// `/report` is intentionally NOT here: anonymous (guest) reporting is allowed so a
+// first-time visitor can file a report without an account. `/dashboard` stays protected
+// because viewing report history still requires a signed-in user.
+const PROTECTED_ROUTES = ["/dashboard"];
 
 // Pages that logged-in users should not see (they're already authenticated)
 const AUTH_ROUTES = ["/login", "/register"];


### PR DESCRIPTION
Closes #17.

Anonymous reporting: a first-time visitor can file a report with no account, then optionally upgrade to a real account that takes ownership of the reports they filed as a guest. All existing logged-in behavior is untouched.

## Route gating (`src/proxy.ts`)
- Removed `/report` from `PROTECTED_ROUTES` (now just `["/dashboard"]`). The middleware logic is otherwise unchanged: it still reads the session cookie, redirects protected routes to `/login?redirect=…` when unauthenticated, and bounces logged-in users off `/login` and `/register`.
- `/dashboard` (and its subpaths) stays protected — viewing report history still requires an account.
- Verified against the real `startsWith` semantics; updated `src/proxy.test.ts` so `/report`, `/report/new` (and the prefix `/reportage`) now pass through for guests, while `/dashboard` prefixes stay protected.

## Anonymous create flow (`POST /api/reports`)
- No code change required: the route already does `userId: session?.userId ?? null`, and `Report.userId` is nullable in the Prisma schema. A sessionless request persists an anonymous report and returns 201. This is covered by the existing route test (no session in the test context).

## Claim / account-upgrade (reuses `POST /api/auth/claim`)
- The existing claim route (which sets a password on / creates an account and signs a session) is reused as the upgrade endpoint. It gains one optional field, `reportIds: string[]`: after the account is set up, it runs `report.updateMany({ where: { id: { in: reportIds }, userId: null }, data: { userId } })`. The `userId: null` guard means it can only attach orphan reports, never steal a report that already belongs to someone else. No parallel route was created.
- Client wiring:
  - `src/lib/pending-reports.ts` — small localStorage helper that records the server id of reports filed while signed out.
  - `src/app/report/page.tsx` — checks `/api/auth/me` to know if the visitor is a guest, and on a successful guest submission stores the new report id.
  - `src/components/report/confirmed-step.tsx` — for guests (and not offline), shows a "Create an account to track this report" prompt linking to `/claim`; hides the "View Dashboard" link they can't use.
  - `src/components/auth/claim-form.tsx` — forwards the pending report ids to `/api/auth/claim` and clears them on success. Reaching `/claim` directly (the original passwordless-account flow) sends no ids, so that path is unchanged.
- New i18n keys (`report.trackTitle/Subtitle/Cta`) added across all four locales (en/es/zh/fr).

## Existing auth unchanged
- No changes to JWT signing/verification, `getSession`, register, or login. Logged-in reports already carry their `userId`, so there is nothing to claim for them and their experience is identical.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in untouched files)
- `npm run format:check` — clean
- `npm test` — 21 files / 230 tests pass (added `src/app/api/auth/claim/route.test.ts` covering report association, the no-`reportIds` legacy path, and the already-has-password rejection)
- `npm run build` — compiles + typechecks; passes page-data collection when `DATABASE_URL` is present (the only failure is the pre-existing `MissingEnvError` from `/api/cron/poll-status` when no DB env is set in the sandbox, unrelated to this change)