### PR TITLE
fix(api): consistent error handling — cron field, suggest failures, JSON parse [#126]

### DIFF
--- a/nexa/src/app/api/auth/claim/route.test.ts
+++ b/nexa/src/app/api/auth/claim/route.test.ts
@@ -6,8 +6,9 @@ import { prismaMock } from "@/test/prisma-mock";
 import { POST } from "./route";
 
 // Integration test (node project) for the account-claim route with Prisma
-// deep-mocked. Covers the original passwordless-account upgrade AND the
-// anonymous-reporting addition where `reportIds` attach guest reports.
+// deep-mocked. Covers the original passwordless-account upgrade, the
+// anonymous-reporting addition where `reportIds` attach guest reports, and the
+// shared malformed-JSON 400 envelope.
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost/api/auth/claim", {
@@ -85,5 +86,19 @@ describe("POST /api/auth/claim", () => {
     // Assert — no report mutation happens on the rejected path.
     expect(response.status).toBe(409);
     expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns a 400 envelope error for a malformed JSON body", async () => {
+    const request = new NextRequest("http://localhost/api/auth/claim", {
+      method: "POST",
+      body: "{ not valid json",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Request body must be valid JSON.");
   });
 });

--- a/nexa/src/app/api/auth/claim/route.ts
+++ b/nexa/src/app/api/auth/claim/route.ts
@@ -2,6 +2,12 @@ import { NextRequest } from "next/server";
 import bcrypt from "bcryptjs";
 import { createToken, SESSION_COOKIE, cookieOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { ClaimSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
 
 // One-shot path to set a password on accounts that never had one. This exists
@@ -12,7 +18,10 @@ import { successResponse, errorResponse } from "@/lib/api/response";
 // password is set, this endpoint becomes a no-op for that user.
 export async function POST(request: NextRequest) {
   try {
-    const { email, password, name, reportIds } = await request.json();
+    const { email, password, name, reportIds } = await parseJsonRequest(
+      request,
+      ClaimSchema,
+    );
 
     if (!email || !password) {
       return errorResponse("Email and password are required", 400);
@@ -51,11 +60,7 @@ export async function POST(request: NextRequest) {
     // a guest to the account they just claimed. Only orphan reports (userId=null)
     // matching the supplied ids are re-associated, so this can never steal a
     // report that already belongs to someone else.
-    if (
-      Array.isArray(reportIds) &&
-      reportIds.length > 0 &&
-      reportIds.every((id): id is string => typeof id === "string")
-    ) {
+    if (Array.isArray(reportIds) && reportIds.length > 0) {
       await prisma.report.updateMany({
         where: { id: { in: reportIds }, userId: null },
         data: { userId: user.id },
@@ -67,6 +72,9 @@ export async function POST(request: NextRequest) {
     response.cookies.set(SESSION_COOKIE, token, cookieOptions);
     return response;
   } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
     console.error("Account claim error:", error);
     return errorResponse("Failed to set password. Please try again.", 500);
   }

--- a/nexa/src/app/api/cron/poll-status/route.test.ts
+++ b/nexa/src/app/api/cron/poll-status/route.test.ts
@@ -92,7 +92,7 @@ describe("GET /api/cron/poll-status", () => {
     expect(body).toMatchObject({
       checked: 1,
       updated: 1,
-      errors: 0,
+      errorCount: 0,
       ok: true,
       failures: [],
     });
@@ -162,7 +162,7 @@ describe("GET /api/cron/poll-status", () => {
 
     // Assert
     expect(response.status).toBe(200);
-    expect(body).toMatchObject({ checked: 3, errors: 1, ok: true });
+    expect(body).toMatchObject({ checked: 3, errorCount: 1, ok: true });
   });
 
   it("returns 500 with the alert prefix when the DB query throws", async () => {

--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -120,17 +120,21 @@ export async function GET(request: NextRequest) {
       updated++;
     }
 
-    const errors = failures.length;
+    const errorCount = failures.length;
     // Treat the run as unhealthy when too large a share of attempts failed, so
     // Vercel Cron sees a non-2xx and the failure is observable. The summary is
     // always returned so callers can act on it regardless of status code.
-    const errorRate = checked === 0 ? 0 : errors / checked;
+    //
+    // `errorCount` (a number) is deliberately distinct from the shared envelope's
+    // `error` (a message string): a generic consumer must not mistake this count
+    // for a failure message. The per-report detail lives in `failures`.
+    const errorRate = checked === 0 ? 0 : errorCount / checked;
     const ok = errorRate < ERROR_RATE_THRESHOLD;
-    const summary = { checked, updated, errors, failures, ok };
+    const summary = { checked, updated, errorCount, failures, ok };
 
     if (!ok) {
       console.error(
-        `${ALERT_PREFIX} run unhealthy: ${errors}/${checked} reports failed`,
+        `${ALERT_PREFIX} run unhealthy: ${errorCount}/${checked} reports failed`,
       );
       return NextResponse.json(summary, { status: 503 });
     }

--- a/nexa/src/app/api/location/suggest/route.test.ts
+++ b/nexa/src/app/api/location/suggest/route.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Drive the Nominatim path (no Google key) and control its fetch so we can
+// distinguish a genuinely-empty result from an upstream failure without any
+// real network. `vi.hoisted` lets the hoisted `vi.mock` factories reference the
+// spies without a TDZ error.
+const { getGoogleMapsApiKey, fetchWithTimeout } = vi.hoisted(() => ({
+  getGoogleMapsApiKey: vi.fn(),
+  fetchWithTimeout: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return { ...actual, getGoogleMapsApiKey };
+});
+
+vi.mock("@/lib/http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/http")>();
+  return { ...actual, fetchWithTimeout };
+});
+
+import { GET } from "./route";
+
+function request(query: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/location/suggest?q=${encodeURIComponent(query)}`,
+  );
+}
+
+describe("GET /api/location/suggest", () => {
+  beforeEach(() => {
+    // No Google key so the route falls through to the Nominatim branch.
+    getGoogleMapsApiKey.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty success for a too-short query", async () => {
+    const response = await GET(request("ab"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { suggestions: [] } });
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty success when the geocoder legitimately has no matches", async () => {
+    fetchWithTimeout.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    const response = await GET(request("nowhere at all"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { suggestions: [] } });
+  });
+
+  it("surfaces an upstream failure as a 500 envelope error, not an empty success", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A non-array body makes `.map` throw inside the route, exercising the catch.
+    fetchWithTimeout.mockResolvedValue(
+      new Response(JSON.stringify({ boom: true }), { status: 200 }),
+    );
+
+    const response = await GET(request("123 Main Street"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Failed to look up location suggestions.");
+    expect(body).not.toHaveProperty("data");
+
+    errorSpy.mockRestore();
+  });
+});

--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { getGoogleMapsApiKey } from "@/lib/config";
 import { fetchWithTimeout } from "@/lib/http";
-import { successResponse } from "@/lib/api/response";
+import { successResponse, errorResponse } from "@/lib/api/response";
 
 type NominatimSearchResult = {
   display_name?: string;
@@ -179,7 +179,12 @@ export async function GET(request: NextRequest) {
 
     return successResponse({ suggestions });
   } catch (error) {
+    // Surface upstream geocoding failures as an envelope error (500) instead of
+    // an empty success: a swallowed `{ suggestions: [] }` is indistinguishable
+    // from a legitimately-empty result and hides outages. The client treats a
+    // non-2xx the same as an empty list, so the graceful UX for real empties is
+    // preserved while genuine failures stay observable.
     console.error("Location suggestion error:", error);
-    return successResponse({ suggestions: [] });
+    return errorResponse("Failed to look up location suggestions.", 500);
   }
 }

--- a/nexa/src/lib/api/schemas.ts
+++ b/nexa/src/lib/api/schemas.ts
@@ -58,6 +58,16 @@ export const LoginSchema = z.object({
 });
 export type LoginInput = z.infer<typeof LoginSchema>;
 
+/** `POST /api/auth/claim` — set a password on a passwordless account. */
+export const ClaimSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().optional(),
+  password: z.string().optional(),
+  // Anonymous reports filed as a guest, to attach to the claimed account (#17).
+  reportIds: z.array(z.string()).optional(),
+});
+export type ClaimInput = z.infer<typeof ClaimSchema>;
+
 /** `POST /api/reports/[id]/resolution` — mark a report resolved/unresolved. */
 export const ResolutionSchema = z.object({
   resolved: z.boolean({


### PR DESCRIPTION
Closes #126.

Brings three remaining error-handling inconsistencies into line with the shared response envelope (#125). Each fix below reuses the existing `successResponse`/`errorResponse` builders and the `parseJsonRequest` helper — no new error shapes were invented.

## 1. Cron `errors` field collision
**Inconsistency:** `cron/poll-status` returned `{ checked, updated, errors }` on success where `errors` is a *count*, while the envelope's failure shape uses `error` as a *message string*. A generic consumer branching on `error` could mistake the count for a failure message.
**Fix:** renamed the success count to `errorCount` (kept inside the success `data`/summary). Per-report detail still lives in `failures`. Updated the poll-status test.

## 2. Swallowed `location/suggest` failures
**Inconsistency:** the catch block returned `{ suggestions: [] }` with an implicit 200, indistinguishable from a legitimately-empty geocoder result — upstream outages were invisible.
**Fix:** on catch, return a 500 envelope error (`errorResponse(...)`) so failures are distinguishable and observable. The client hook `use-address-lookup` already maps any non-2xx response to an empty suggestion list (and `payload.success === false` to empty), so the graceful-empty UX for real empty results is preserved — no client change was required. Added a test covering all three cases (too-short query, genuine empty, upstream failure → 500).

## 3. Divergent JSON-parse handling
**Inconsistency:** five of the six cited POST routes already parsed via `parseJsonRequest` after #125, but `auth/claim` still called raw `request.json()`, so a malformed body fell through to a generic 500 instead of the standard 400.
**Fix:** added `ClaimSchema` and routed `auth/claim` through `parseJsonRequest` + `RequestParseError`/`parseErrorResponse`, so malformed JSON now returns the same `400 { success: false, error: "Request body must be valid JSON." }` as every other POST route. Added a test for the 400 path.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in untouched files)
- `npm run format:check` — clean
- `npm test` — 33 files / 334 tests passing