### PR TITLE
refactor: centralize duplicated API request/response types [#127]

### DIFF
--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -11,30 +11,17 @@ import {
   parseErrorResponse,
 } from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
-
-type Confidence = "low" | "medium" | "high";
-
-type FormLinkResult =
-  | {
-      status: "found";
-      cityName: string;
-      formUrl: string;
-      reason: string;
-      confidence: Confidence;
-    }
-  | {
-      status: "not_found";
-      cityName: string | null;
-      message: string;
-      reason?: string;
-    };
+import type {
+  FormLookupConfidence,
+  OfficialFormLookupResult,
+} from "@/lib/api/types";
 
 type LookupResult =
   | {
       status: "found";
       formUrl: string;
       reason: string;
-      confidence: Confidence;
+      confidence: FormLookupConfidence;
     }
   | {
       status: "not_found";
@@ -405,7 +392,7 @@ Do not say "not_found" just because there is no "${issueLabel}"-specific form â€
     status?: string;
     formUrl?: string | null;
     reason?: string;
-    confidence?: Confidence;
+    confidence?: FormLookupConfidence;
   };
 
   try {
@@ -464,7 +451,7 @@ export async function POST(request: NextRequest) {
         issueType,
       );
       if (match?.portal) {
-        const result: FormLinkResult = {
+        const result: OfficialFormLookupResult = {
           status: "found",
           cityName: match.jurisdiction.displayName,
           formUrl: match.portal.url,
@@ -482,7 +469,7 @@ export async function POST(request: NextRequest) {
 
     // 2. LLM fallback for anywhere we don't have polygon coverage.
     if (!location.cityName) {
-      const result: FormLinkResult = {
+      const result: OfficialFormLookupResult = {
         status: "not_found",
         cityName: null,
         message: "No official city form found.",
@@ -499,7 +486,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (lookup.status === "found") {
-      const result: FormLinkResult = {
+      const result: OfficialFormLookupResult = {
         status: "found",
         cityName: location.cityName,
         formUrl: lookup.formUrl,
@@ -509,7 +496,7 @@ export async function POST(request: NextRequest) {
       return successResponse(result);
     }
 
-    const result: FormLinkResult = {
+    const result: OfficialFormLookupResult = {
       status: "not_found",
       cityName: location.cityName,
       message: "No official city form found.",

--- a/nexa/src/components/report/review-step.test.tsx
+++ b/nexa/src/components/report/review-step.test.tsx
@@ -9,9 +9,10 @@ type OfficialForm = Parameters<typeof ReviewStep>[0]["officialForm"];
 function baseProps() {
   return {
     classification: {
-      issueType: "ROAD_DAMAGE",
+      issueType: "ROAD_DAMAGE" as const,
       aiDescription: "A deep pothole in the road.",
       severity: "high" as "low" | "medium" | "high",
+      confidence: 0.92,
     },
     imagePreview: null as string | null,
     description: "Big pothole",

--- a/nexa/src/components/report/review-step.tsx
+++ b/nexa/src/components/report/review-step.tsx
@@ -12,27 +12,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { ErrorBanner } from "@/components/error-banner";
 import { useI18n } from "@/i18n/provider";
-
-interface ClassificationResult {
-  issueType: string;
-  aiDescription: string;
-  severity: "low" | "medium" | "high";
-}
-
-type OfficialFormLookupResult =
-  | {
-      status: "found";
-      cityName: string;
-      formUrl: string;
-      reason: string;
-      confidence: "low" | "medium" | "high";
-    }
-  | {
-      status: "not_found";
-      cityName: string | null;
-      message: string;
-      reason?: string;
-    };
+import type { ClassificationResult } from "@/lib/classify/types";
+import type { OfficialFormLookupResult } from "@/lib/api/types";
 
 interface ReviewStepProps {
   classification: ClassificationResult;

--- a/nexa/src/hooks/use-form-lookup.ts
+++ b/nexa/src/hooks/use-form-lookup.ts
@@ -3,21 +3,9 @@
 import { useCallback, useState } from "react";
 import { useI18n } from "@/i18n/provider";
 import type { ApiResponse } from "@/lib/api/response";
+import type { OfficialFormLookupResult } from "@/lib/api/types";
 
-export type OfficialFormLookupResult =
-  | {
-      status: "found";
-      cityName: string;
-      formUrl: string;
-      reason: string;
-      confidence: "low" | "medium" | "high";
-    }
-  | {
-      status: "not_found";
-      cityName: string | null;
-      message: string;
-      reason?: string;
-    };
+export type { OfficialFormLookupResult };
 
 export interface FormLookupLocation {
   address: string;

--- a/nexa/src/hooks/use-report-submission.ts
+++ b/nexa/src/hooks/use-report-submission.ts
@@ -3,25 +3,19 @@
 import { useCallback, useState } from "react";
 import { queueReport } from "@/lib/offline-queue";
 import type { ApiResponse } from "@/lib/api/response";
+import type {
+  ClassificationResult,
+  ComparisonResult,
+} from "@/lib/classify/types";
 
-export interface ClassificationResult {
-  issueType: string;
-  aiDescription: string;
-  severity: "low" | "medium" | "high";
-  confidence?: number;
-}
-
-export interface ProviderResult extends ClassificationResult {
-  provider: string;
-  latencyMs: number;
-}
-
-export interface ComparisonResponse {
-  winner: ClassificationResult;
-  allResults: ProviderResult[];
-  consensus: boolean;
-  method: string;
-}
+// The classify route returns the canonical `ComparisonResult` (extended on the
+// server with diagnostic fields this hook does not read). Re-export under the
+// existing names so consumers of this hook keep their import paths.
+export type {
+  ClassificationResult,
+  ProviderResult,
+} from "@/lib/classify/types";
+export type ComparisonResponse = ComparisonResult;
 
 export interface CreatedReport {
   id: string;

--- a/nexa/src/lib/api/types.ts
+++ b/nexa/src/lib/api/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared API request/response contract types.
+ *
+ * These describe the over-the-wire shapes that route handlers produce and
+ * client consumers (hooks/components) read back. Centralizing them here keeps
+ * the two sides from drifting: a contract change is made once and both the
+ * server and the client pick it up. Types are named `RouteNameResponse` /
+ * `RouteNameRequest` after the endpoint they describe.
+ *
+ * Note: classification contract types (`ClassificationResult`,
+ * `ProviderResult`, `ComparisonResult`) live in `@/lib/classify/types` — the
+ * runtime-validated source of truth the classify route already returns. Import
+ * them from there; do not re-declare them.
+ */
+
+/** Confidence band shared by the official-form lookup contract. */
+export type FormLookupConfidence = "low" | "medium" | "high";
+
+/**
+ * `POST /api/reports/form-link` response payload (the `data` of the success
+ * envelope). Either an official city form was located, or none was found (with
+ * a human-readable reason). This is the single definition consumed by the route
+ * handler that produces it and the hook/component that render it.
+ */
+export type OfficialFormLookupResult =
+  | {
+      status: "found";
+      cityName: string;
+      formUrl: string;
+      reason: string;
+      confidence: FormLookupConfidence;
+    }
+  | {
+      status: "not_found";
+      cityName: string | null;
+      message: string;
+      reason?: string;
+    };


### PR DESCRIPTION
Closes #127.

## What & why
The same logical API contract types were redefined locally across hooks, components, and a route handler with inconsistent strictness (`confidence` optional/missing, `issueType` `string` vs enum). A contract change had to be hand-propagated to several files, risking divergence. This centralizes them so each contract has one definition that both the server (producer) and the client (consumer) import.

## Types centralized

**Official-form-lookup contract — genuinely identical, consolidated**
The route handler's `FormLinkResult` (+ its `Confidence` alias) and the `OfficialFormLookupResult` declared independently in both `use-form-lookup.ts` and `review-step.tsx` were byte-for-byte the same union. Consolidated into a single `OfficialFormLookupResult` (+ `FormLookupConfidence`) exported from the new `src/lib/api/types.ts`. Now imported by:
- `src/app/api/reports/form-link/route.ts` (the producer)
- `src/hooks/use-form-lookup.ts` (re-exports the canonical type to preserve its public surface)
- `src/components/report/review-step.tsx`

**Classification contract — reconciled to the server's actual shape**
The classify route returns the canonical `ClassificationResult` / `ProviderResult` / `ComparisonResult` from `src/lib/classify/types.ts` (`issueType: IssueType`, required `confidence`, `method` as a union). The client had drifted to looser copies:
- `use-report-submission.ts` declared `ClassificationResult` with `issueType: string` + optional `confidence`, plus a `ComparisonResponse` with `method: string`.
- `review-step.tsx` declared `ClassificationResult` with `issueType: string` and no `confidence` at all.

These local copies were deleted and both files now import the canonical types from `src/lib/classify/types.ts`. The hook keeps the public names its consumers use (`ClassificationResult`, `ProviderResult`, and `ComparisonResponse` as an alias of the canonical `ComparisonResult`) by re-exporting, so no import paths elsewhere change. The classify route is actually typed `ExtendedComparisonResult extends ComparisonResult`; the hook only reads `winner` / `allResults` / `consensus` / `method`, all present on `ComparisonResult`, so narrowing to it is the correct client-side contract.

## Bug reconciled (client/server divergence)
This was a real structural mismatch, not just a duplication: the client's `ClassificationResult` was looser than what the server returns (and stored in component state / passed back to `/api/reports`). Tightening the client to the server's actual shape (required `confidence`, `issueType: IssueType`) removes the divergence the issue flagged (`confidence` required vs optional vs missing; `issueType` enum vs string). No runtime code path changed — only the static types. The two `IssueType` unions in play (`@/generated/prisma/enums` and `@/lib/classify/types`) have identical string members, so values flowing into the `/api/reports` POST and i18n lookups remain valid.

## No behavior change
Pure type-level refactor: no runtime logic, response shapes, or request bodies were modified. The form-link route still constructs and returns the same objects; the hooks still fetch/parse identically. One test fixture (`review-step.test.tsx`) gained the now-required `confidence` field so its mock conforms to the canonical `ClassificationResult` the component always receives at runtime.

## Verification
- `npx tsc --noEmit` — green
- `npm run lint` — green (0 errors; 2 pre-existing `<img>` warnings, untouched)
- `npm run format:check` — green
- `npm test` — 330 passed (31 files)
- `npm run build` — succeeds with `DATABASE_URL` set; the bare-env failure (`MissingEnvError: DATABASE_URL`) reproduces identically on clean `main` and is unrelated to this change.