### PR TITLE
feat(security): rate-limit classify and form-link endpoints [#105]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -52,5 +52,13 @@ FOLLOW_UP_REMINDER_SECRET=
 # openssl rand -base64 32
 CRON_SECRET=
 
+# --- Rate limiting ---
+# Per-IP rate limit for the unauthenticated expensive routes (classify,
+# form-link, location/suggest). Fixed-window, in-memory, enforced PER SERVERLESS
+# INSTANCE (not a hard global cap — see src/lib/rate-limit.ts). Both optional;
+# defaults are RATE_LIMIT_MAX=20 requests per RATE_LIMIT_WINDOW_MS=60000ms.
+RATE_LIMIT_MAX=20
+RATE_LIMIT_WINDOW_MS=60000
+
 # --- App ---
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/nexa/src/app/api/location/suggest/route.ts
+++ b/nexa/src/app/api/location/suggest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { getGoogleMapsApiKey } from "@/lib/config";
 import { fetchWithTimeout } from "@/lib/http";
 import { successResponse, errorResponse } from "@/lib/api/response";
+import { enforceRateLimit } from "@/lib/rate-limit";
 
 type NominatimSearchResult = {
   display_name?: string;
@@ -161,6 +162,9 @@ async function fetchNominatimSuggestions(
 
 export async function GET(request: NextRequest) {
   try {
+    const limited = enforceRateLimit(request.headers);
+    if (limited) return limited;
+
     const query = request.nextUrl.searchParams.get("q")?.trim() ?? "";
     if (query.length < 3) {
       return successResponse({ suggestions: [] });

--- a/nexa/src/app/api/reports/classify/route.ts
+++ b/nexa/src/app/api/reports/classify/route.ts
@@ -8,9 +8,13 @@ import {
   parseErrorResponse,
 } from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
+import { enforceRateLimit } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
   try {
+    const limited = enforceRateLimit(request.headers);
+    if (limited) return limited;
+
     const {
       description,
       imageBase64,

--- a/nexa/src/app/api/reports/form-link/route.ts
+++ b/nexa/src/app/api/reports/form-link/route.ts
@@ -11,6 +11,7 @@ import {
   parseErrorResponse,
 } from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
+import { enforceRateLimit } from "@/lib/rate-limit";
 import type {
   FormLookupConfidence,
   OfficialFormLookupResult,
@@ -428,6 +429,9 @@ Do not say "not_found" just because there is no "${issueLabel}"-specific form â€
 
 export async function POST(request: NextRequest) {
   try {
+    const limited = enforceRateLimit(request.headers);
+    if (limited) return limited;
+
     const { issueType, address, latitude, longitude } = await parseJsonRequest(
       request,
       FormLinkRequestSchema,

--- a/nexa/src/lib/rate-limit.test.ts
+++ b/nexa/src/lib/rate-limit.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  __resetRateLimitStore,
+  clientIpFromHeaders,
+  enforceRateLimit,
+  rateLimit,
+} from "./rate-limit";
+
+afterEach(() => {
+  __resetRateLimitStore();
+});
+
+describe("rateLimit", () => {
+  it("allows requests up to the limit then blocks", () => {
+    const opts = { limit: 3, windowMs: 60_000, now: 1_000 };
+
+    expect(rateLimit("a", opts).allowed).toBe(true);
+    expect(rateLimit("a", opts).allowed).toBe(true);
+    const third = rateLimit("a", opts);
+    expect(third.allowed).toBe(true);
+    expect(third.remaining).toBe(0);
+
+    const blocked = rateLimit("a", opts);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("tracks each key independently", () => {
+    const opts = { limit: 1, windowMs: 60_000, now: 1_000 };
+    expect(rateLimit("a", opts).allowed).toBe(true);
+    expect(rateLimit("b", opts).allowed).toBe(true);
+    expect(rateLimit("a", opts).allowed).toBe(false);
+  });
+
+  it("resets the count once the window expires", () => {
+    expect(rateLimit("a", { limit: 1, windowMs: 1_000, now: 0 }).allowed).toBe(
+      true,
+    );
+    expect(
+      rateLimit("a", { limit: 1, windowMs: 1_000, now: 500 }).allowed,
+    ).toBe(false);
+    // Window elapsed: counter restarts.
+    expect(
+      rateLimit("a", { limit: 1, windowMs: 1_000, now: 1_000 }).allowed,
+    ).toBe(true);
+  });
+
+  it("reports retryAfter in seconds rounded up", () => {
+    rateLimit("a", { limit: 1, windowMs: 5_000, now: 0 });
+    const blocked = rateLimit("a", { limit: 1, windowMs: 5_000, now: 1_200 });
+    expect(blocked.allowed).toBe(false);
+    // ~3.8s remaining → ceil to 4.
+    expect(blocked.retryAfterSeconds).toBe(4);
+  });
+});
+
+describe("clientIpFromHeaders", () => {
+  it("takes the left-most x-forwarded-for hop", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.7, 70.41.3.18, 150.172.238.178",
+    });
+    expect(clientIpFromHeaders(headers)).toBe("203.0.113.7");
+  });
+
+  it("falls back to x-real-ip then 'unknown'", () => {
+    expect(
+      clientIpFromHeaders(new Headers({ "x-real-ip": "198.51.100.5" })),
+    ).toBe("198.51.100.5");
+    expect(clientIpFromHeaders(new Headers())).toBe("unknown");
+  });
+});
+
+describe("enforceRateLimit", () => {
+  it("returns null while under the limit", () => {
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.7" });
+    expect(
+      enforceRateLimit(headers, { limit: 2, windowMs: 60_000 }),
+    ).toBeNull();
+    expect(
+      enforceRateLimit(headers, { limit: 2, windowMs: 60_000 }),
+    ).toBeNull();
+  });
+
+  it("returns a 429 envelope with Retry-After once over the limit", async () => {
+    const headers = new Headers({ "x-forwarded-for": "203.0.113.7" });
+    enforceRateLimit(headers, { limit: 1, windowMs: 60_000 });
+    const response = enforceRateLimit(headers, { limit: 1, windowMs: 60_000 });
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(429);
+    expect(Number(response!.headers.get("Retry-After"))).toBeGreaterThan(0);
+
+    const body = (await response!.json()) as {
+      success: boolean;
+      code?: string;
+    };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("RATE_LIMITED");
+  });
+});

--- a/nexa/src/lib/rate-limit.ts
+++ b/nexa/src/lib/rate-limit.ts
@@ -1,0 +1,154 @@
+// ---------------------------------------------------------------------------
+// Lightweight in-memory rate limiter for unauthenticated, expensive endpoints.
+//
+// The classify / form-link / location-suggest routes fan out to paid LLM and
+// geocoding providers, take no auth, and so are trivially abusable to burn
+// through API quota and budget. This module provides ONE shared fixed-window
+// limiter keyed by client IP that every such route reuses.
+//
+// SERVERLESS CAVEAT: state lives in this module's process memory, so the limit
+// is enforced PER INSTANCE. On Vercel each concurrent lambda has its own copy,
+// so the effective global limit is `limit * instances`. This is a deliberate
+// cheap first line of defence against a single abusive client; a hard global
+// cap needs a shared store (Upstash/Redis), which is out of scope here.
+// ---------------------------------------------------------------------------
+
+import { errorResponse } from "@/lib/api/response";
+
+/** Parse a positive-integer env var, falling back to `fallback` when unset/invalid. */
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Max requests allowed per IP within one window. Configurable via env. */
+export function getRateLimitMax(): number {
+  return envInt("RATE_LIMIT_MAX", 20);
+}
+
+/** Length of the fixed window in milliseconds. Configurable via env. */
+export function getRateLimitWindowMs(): number {
+  return envInt("RATE_LIMIT_WINDOW_MS", 60_000);
+}
+
+export type RateLimitResult = {
+  /** Whether this request is allowed (under the limit). */
+  allowed: boolean;
+  /** Requests still permitted in the current window (0 when blocked). */
+  remaining: number;
+  /** Seconds until the window resets — use for the `Retry-After` header. */
+  retryAfterSeconds: number;
+};
+
+type WindowState = {
+  count: number;
+  /** Epoch ms at which the current window expires and the count resets. */
+  resetAt: number;
+};
+
+/** Per-key window counters. Module-level so the state survives across calls. */
+const buckets = new Map<string, WindowState>();
+
+/**
+ * Derive the client IP from `x-forwarded-for`. Vercel/most proxies prepend the
+ * real client as the first entry, so we take the left-most hop. Falls back to a
+ * shared `"unknown"` key when the header is absent (callers behind no proxy),
+ * which still bounds anonymous traffic in aggregate.
+ */
+export function clientIpFromHeaders(headers: Headers): string {
+  const forwarded = headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+/**
+ * Record one request against `key` and report whether it is within the limit.
+ *
+ * Fixed-window algorithm: the first request in a window stamps a `resetAt`
+ * `windowMs` into the future; subsequent requests increment until the window
+ * expires, after which the counter restarts. Cheap and allocation-light at the
+ * cost of allowing up to `2*limit` requests across a window boundary — an
+ * accepted trade-off for a budget guard.
+ *
+ * `now` is injectable for deterministic tests.
+ */
+export function rateLimit(
+  key: string,
+  options: { limit?: number; windowMs?: number; now?: number } = {},
+): RateLimitResult {
+  const limit = options.limit ?? getRateLimitMax();
+  const windowMs = options.windowMs ?? getRateLimitWindowMs();
+  const now = options.now ?? Date.now();
+
+  const existing = buckets.get(key);
+
+  if (!existing || now >= existing.resetAt) {
+    const resetAt = now + windowMs;
+    buckets.set(key, { count: 1, resetAt });
+    return {
+      allowed: true,
+      remaining: limit - 1,
+      retryAfterSeconds: Math.ceil(windowMs / 1000),
+    };
+  }
+
+  const retryAfterSeconds = Math.max(
+    1,
+    Math.ceil((existing.resetAt - now) / 1000),
+  );
+
+  if (existing.count >= limit) {
+    return { allowed: false, remaining: 0, retryAfterSeconds };
+  }
+
+  existing.count += 1;
+  return {
+    allowed: true,
+    remaining: limit - existing.count,
+    retryAfterSeconds,
+  };
+}
+
+/**
+ * Convenience wrapper: derive the IP from request headers and apply the shared
+ * limit in one call. Returns the same {@link RateLimitResult}.
+ */
+export function rateLimitRequest(
+  headers: Headers,
+  options: { limit?: number; windowMs?: number; now?: number } = {},
+): RateLimitResult {
+  return rateLimit(clientIpFromHeaders(headers), options);
+}
+
+/**
+ * Apply the shared per-IP limit to an incoming request. When the caller is over
+ * the limit, returns a 429 envelope (via {@link errorResponse}) carrying a
+ * `Retry-After` header so clients back off; otherwise returns `null` and the
+ * route proceeds. Centralising this keeps the three protected routes free of
+ * duplicated limiter plumbing.
+ */
+export function enforceRateLimit(
+  headers: Headers,
+  options: { limit?: number; windowMs?: number; now?: number } = {},
+) {
+  const result = rateLimitRequest(headers, options);
+  if (result.allowed) return null;
+
+  const response = errorResponse(
+    "Too many requests. Please slow down and try again shortly.",
+    429,
+    "RATE_LIMITED",
+  );
+  response.headers.set("Retry-After", String(result.retryAfterSeconds));
+  return response;
+}
+
+/** Test-only: clear all window state. */
+export function __resetRateLimitStore(): void {
+  buckets.clear();
+}


### PR DESCRIPTION
Closes #105.

## What

Adds lightweight rate limiting to the unauthenticated, expensive public endpoints that fan out to paid providers:

- `POST /api/reports/classify` — OpenAI + Anthropic + Google consensus
- `POST /api/reports/form-link` — Nominatim geocoding + LLM web search
- `GET /api/location/suggest` — Google Places / Nominatim

Without auth or limits these are trivially abusable to exhaust API quota and run up cost.

## Limiter design

One shared helper, `src/lib/rate-limit.ts`, reused by all three routes — no per-route copies:

- **Algorithm:** in-memory fixed-window counter keyed by client IP. The first request in a window stamps a `resetAt` `windowMs` in the future; subsequent requests increment until it expires, then the counter restarts.
- **Client IP:** taken from the left-most `x-forwarded-for` hop (the real client on Vercel), falling back to `x-real-ip`, then a shared `"unknown"` key.
- **Enforcement:** `enforceRateLimit(headers)` returns `null` when under the limit, or a `429` built via the existing `errorResponse` envelope (`code: "RATE_LIMITED"`) with a `Retry-After` header when over. Routes call it as a one-liner at the top of their handler, so the response contract stays uniform.
- **Config:** `RATE_LIMIT_MAX` (default 20) and `RATE_LIMIT_WINDOW_MS` (default 60000ms), documented in `.env.example`. Invalid/unset values fall back to the defaults.

## Per-instance caveat (serverless)

State lives in the module's process memory, so the limit is enforced **per serverless instance**. On Vercel each concurrent lambda holds its own copy, so the effective global ceiling is `limit * instances`. This is a deliberate, cheap first line of defence against a single abusive client — not a hard global cap. A strict global limit would need a shared store (Upstash/Redis), which is out of scope for this issue. The caveat is documented at the top of `rate-limit.ts` and in `.env.example`.

## Tests / verification

- New unit test `src/lib/rate-limit.test.ts` covers limit enforcement, per-key independence, window reset, `Retry-After` rounding, IP derivation, and the 429 envelope.
- `npx tsc --noEmit` — clean
- `npm run lint` — no new errors (only pre-existing `<img>` warnings in unrelated components)
- `npm run format:check` — clean
- `npm test` — 346 passed (34 files)