### PR TITLE
feat(backend): detect duplicate reports within a time/space window [#111]

### DIFF
--- a/nexa/prisma/migrations/20260609000000_report_dedup_index/migration.sql
+++ b/nexa/prisma/migrations/20260609000000_report_dedup_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Report_userId_issueType_createdAt_idx" ON "Report"("userId", "issueType", "createdAt");

--- a/nexa/prisma/schema.prisma
+++ b/nexa/prisma/schema.prisma
@@ -44,6 +44,10 @@ model Report {
   issueGroup         IssueGroup?  @relation(fields: [issueGroupId], references: [id])
   createdAt          DateTime     @default(now())
   updatedAt          DateTime     @updatedAt
+
+  // Speeds the duplicate-report lookup (src/lib/reports/dedup.ts), which filters
+  // recent same-type reports by reporter before the lat/long bounding box.
+  @@index([userId, issueType, createdAt])
 }
 
 // A shared "case" that groups duplicate reports — multiple people reporting the

--- a/nexa/src/app/api/reports/route.test.ts
+++ b/nexa/src/app/api/reports/route.test.ts
@@ -18,6 +18,8 @@ describe("POST /api/reports", () => {
     // Routing/dedupe helpers query prisma too — stub them so the route runs.
     prismaMock.agency.findMany.mockResolvedValue([]);
     prismaMock.issueGroup.findMany.mockResolvedValue([]);
+    // No prior report -> not a duplicate, so creation proceeds.
+    prismaMock.report.findMany.mockResolvedValue([]);
     // findOrCreateIssueGroup selects only { id }, so a narrowed shape is correct.
     prismaMock.issueGroup.create.mockResolvedValue({
       id: "group_1",
@@ -45,10 +47,45 @@ describe("POST /api/reports", () => {
     expect(prismaMock.report.create).toHaveBeenCalledOnce();
   });
 
+  it("returns 409 with the existing report id on a likely duplicate", async () => {
+    // Arrange: an existing same-type report at the exact same location, recent.
+    const existing = makeReport({
+      id: "report_existing",
+      issueType: "ROAD_DAMAGE",
+      latitude: 37.4419,
+      longitude: -122.143,
+      createdAt: new Date(),
+    });
+    prismaMock.report.findMany.mockResolvedValue([existing]);
+
+    const request = new NextRequest("http://localhost/api/reports", {
+      method: "POST",
+      body: JSON.stringify({
+        description: "Pothole on University Ave",
+        issueType: "ROAD_DAMAGE",
+        latitude: 37.4419,
+        longitude: -122.143,
+      }),
+    });
+
+    // Act
+    const response = await POST(request);
+    const body = await response.json();
+
+    // Assert: the second report is rejected, not persisted, and points at the
+    // original report so the client can surface it.
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("DUPLICATE_REPORT");
+    expect(body.details.duplicateOf).toBe("report_existing");
+    expect(prismaMock.report.create).not.toHaveBeenCalled();
+  });
+
   it("returns 500 when the database write throws", async () => {
     // Arrange
     prismaMock.agency.findMany.mockResolvedValue([]);
     prismaMock.issueGroup.findMany.mockResolvedValue([]);
+    prismaMock.report.findMany.mockResolvedValue([]);
     prismaMock.report.create.mockRejectedValue(new Error("db down"));
 
     const request = new NextRequest("http://localhost/api/reports", {

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 import { findOrCreateIssueGroup } from "@/lib/issues/dedupe";
+import { findDuplicateReport } from "@/lib/reports/dedup";
 import { CreateReportSchema } from "@/lib/api/schemas";
 import {
   parseJsonRequest,
@@ -25,6 +26,25 @@ export async function POST(request: NextRequest) {
     } = await parseJsonRequest(request, CreateReportSchema);
 
     const validIssueType = issueType ?? null;
+
+    // Guard against the same reporter (or, for guests, the same nearby spot)
+    // filing an identical issue twice in quick succession. On a likely match we
+    // return 409 with the existing report's id rather than persisting a second
+    // copy — distinct reports (different type/location/window) are unaffected.
+    const duplicate = await findDuplicateReport({
+      userId: session?.userId ?? null,
+      issueType: validIssueType,
+      latitude,
+      longitude,
+    });
+    if (duplicate) {
+      return errorResponse(
+        "A matching report was filed recently nearby.",
+        409,
+        "DUPLICATE_REPORT",
+        { duplicateOf: duplicate.reportId },
+      );
+    }
 
     // Route the report to the responsible agency from its location + issue
     // type so the submission pipeline has somewhere to file it. When routing is

--- a/nexa/src/lib/api/response.ts
+++ b/nexa/src/lib/api/response.ts
@@ -8,7 +8,12 @@ import { NextResponse } from "next/server";
  */
 export type ApiResponse<T> =
   | { success: true; data: T }
-  | { success: false; error: string; code?: string };
+  | {
+      success: false;
+      error: string;
+      code?: string;
+      details?: Record<string, unknown>;
+    };
 
 /**
  * Build a success envelope wrapping `data`. Raw entities (e.g. a Prisma row)
@@ -24,17 +29,23 @@ export function successResponse<T>(
 /**
  * Build an error envelope. `status` is required so each route states its HTTP
  * status explicitly; `code` is an optional stable identifier for clients that
- * want to branch on a reason rather than the localized message.
+ * want to branch on a reason rather than the localized message; `details`
+ * carries optional structured context (e.g. the `duplicateOf` report id) for
+ * clients that need to act on the failure.
  */
 export function errorResponse(
   message: string,
   status: number,
   code?: string,
+  details?: Record<string, unknown>,
 ): NextResponse<ApiResponse<never>> {
   return NextResponse.json(
-    code
-      ? { success: false, error: message, code }
-      : { success: false, error: message },
+    {
+      success: false,
+      error: message,
+      ...(code ? { code } : {}),
+      ...(details ? { details } : {}),
+    },
     { status },
   );
 }

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -38,6 +38,19 @@ function optionalEnv(name: string): string | undefined {
 }
 
 /**
+ * Read an optional numeric env var, falling back to `fallback` when the var is
+ * unset, empty, non-numeric, or non-positive. Keeps tuning knobs configurable
+ * without letting a typo silently disable a feature (a `0`/`NaN` radius would).
+ */
+function optionalPositiveNumberEnv(name: string, fallback: number): number {
+  const raw = optionalEnv(name);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+/**
  * Wrap a getter so its result is computed once and cached. The first call
  * resolves the value (and may throw for required vars); later calls return the
  * memoized result.
@@ -88,4 +101,35 @@ export const getGoogleApiKey = cached(() => optionalEnv("GOOGLE_API_KEY"));
  */
 export const getGoogleMapsApiKey = cached(() =>
   optionalEnv("GOOGLE_MAPS_API_KEY"),
+);
+
+// --- Duplicate-report detection (see src/lib/reports/dedup.ts) ---
+
+/** Default radius (metres) within which a same-type report counts as a dup. */
+export const DEFAULT_DUPLICATE_RADIUS_METERS = 50;
+/** Default look-back window (hours) for the duplicate search. */
+export const DEFAULT_DUPLICATE_WINDOW_HOURS = 24;
+
+/**
+ * Radius (metres) within which a new report with the same reporter + issue type
+ * is treated as a likely duplicate. Configurable via `DUPLICATE_RADIUS_METERS`;
+ * defaults to {@link DEFAULT_DUPLICATE_RADIUS_METERS}.
+ */
+export const getDuplicateRadiusMeters = cached(() =>
+  optionalPositiveNumberEnv(
+    "DUPLICATE_RADIUS_METERS",
+    DEFAULT_DUPLICATE_RADIUS_METERS,
+  ),
+);
+
+/**
+ * Look-back window (hours) for the duplicate search — only reports created
+ * within this window are considered. Configurable via `DUPLICATE_WINDOW_HOURS`;
+ * defaults to {@link DEFAULT_DUPLICATE_WINDOW_HOURS}.
+ */
+export const getDuplicateWindowHours = cached(() =>
+  optionalPositiveNumberEnv(
+    "DUPLICATE_WINDOW_HOURS",
+    DEFAULT_DUPLICATE_WINDOW_HOURS,
+  ),
 );

--- a/nexa/src/lib/reports/dedup.test.ts
+++ b/nexa/src/lib/reports/dedup.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { makeReport } from "@/test/factories/report";
+import { prismaMock } from "@/test/prisma-mock";
+
+import { findDuplicateReport } from "./dedup";
+
+// Default radius is 50m and the default look-back window is 24h (env unset in
+// the test runner). A point ~12m east of the Stanford default coordinates.
+const LAT = 37.4419;
+const LON = -122.143;
+const NEAR_LON = -122.1428; // ~17m east at this latitude — inside 50m.
+const FAR_LON = -122.142; // ~88m east — outside 50m.
+
+describe("findDuplicateReport", () => {
+  it("returns null when the report has no issue type", async () => {
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: null,
+      latitude: LAT,
+      longitude: LON,
+    });
+    expect(match).toBeNull();
+    expect(prismaMock.report.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the report has no location", async () => {
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: null,
+      longitude: null,
+    });
+    expect(match).toBeNull();
+    expect(prismaMock.report.findMany).not.toHaveBeenCalled();
+  });
+
+  it("flags an existing same-user, same-type report within the radius", async () => {
+    const existing = makeReport({
+      id: "report_existing",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+    });
+    prismaMock.report.findMany.mockResolvedValue([existing]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match).not.toBeNull();
+    expect(match?.reportId).toBe("report_existing");
+    expect(match?.distanceMeters).toBeLessThanOrEqual(50);
+  });
+
+  it("scopes the query to the reporter when signed in", async () => {
+    prismaMock.report.findMany.mockResolvedValue([]);
+
+    await findDuplicateReport({
+      userId: "user_42",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    const where = prismaMock.report.findMany.mock.calls[0][0]?.where;
+    expect(where).toMatchObject({
+      userId: "user_42",
+      issueType: "ROAD_DAMAGE",
+    });
+  });
+
+  it("omits the user filter for anonymous reports", async () => {
+    prismaMock.report.findMany.mockResolvedValue([]);
+
+    await findDuplicateReport({
+      userId: null,
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    const where = prismaMock.report.findMany.mock.calls[0][0]?.where;
+    expect(where).not.toHaveProperty("userId");
+  });
+
+  it("ignores candidates outside the radius (distinct nearby reports)", async () => {
+    const far = makeReport({
+      id: "report_far",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: FAR_LON,
+    });
+    // The bounding box is generous enough that a just-outside report can be
+    // returned by the prefilter; the haversine refinement must still reject it.
+    prismaMock.report.findMany.mockResolvedValue([far]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match).toBeNull();
+  });
+
+  it("returns the closest candidate when several match", async () => {
+    const nearer = makeReport({
+      id: "report_nearer",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+    const farther = makeReport({
+      id: "report_farther",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+    });
+    prismaMock.report.findMany.mockResolvedValue([farther, nearer]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match?.reportId).toBe("report_nearer");
+  });
+});

--- a/nexa/src/lib/reports/dedup.ts
+++ b/nexa/src/lib/reports/dedup.ts
@@ -1,0 +1,113 @@
+import { prisma } from "@/lib/prisma";
+import { haversineMeters } from "@/lib/issues/dedupe";
+import {
+  getDuplicateRadiusMeters,
+  getDuplicateWindowHours,
+} from "@/lib/config";
+import type { IssueType } from "@/generated/prisma/enums";
+
+// Approximate metres per degree of latitude (constant); longitude is scaled by
+// the cosine of the latitude in the bounding-box prefilter. Mirrors the
+// constant used by the IssueGroup dedupe so both lookups behave consistently.
+const METERS_PER_DEGREE_LAT = 111_320;
+
+interface FindDuplicateArgs {
+  /** The reporter, or null for an anonymous (guest) submission. */
+  userId?: string | null;
+  issueType?: IssueType | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export interface DuplicateMatch {
+  /** Id of the existing report this submission duplicates. */
+  reportId: string;
+  /** Distance (metres) between the two reports. */
+  distanceMeters: number;
+}
+
+/**
+ * Looks for an existing report that the incoming submission likely duplicates:
+ * the same issue type, a near-identical location (within the configured
+ * radius), filed within the recent time window. For a signed-in reporter the
+ * match is additionally scoped to their own reports (a user re-filing the same
+ * issue); anonymous submissions (`userId == null`) fall back to a pure
+ * location + type heuristic across all reporters, since we have no stable guest
+ * identity to key on.
+ *
+ * This deliberately reuses {@link haversineMeters} from the IssueGroup dedupe
+ * rather than rolling a second distance metric. The two features are distinct:
+ * IssueGroup *merges* distinct people's reports of one real-world problem into a
+ * shared case; this guards against one reporter filing the *same* report twice.
+ *
+ * Returns the closest match within the radius, or null when none is found (and
+ * therefore when the report has no location or issue type to compare on).
+ */
+export async function findDuplicateReport(
+  args: FindDuplicateArgs,
+): Promise<DuplicateMatch | null> {
+  const { userId, issueType, latitude, longitude } = args;
+
+  if (
+    !issueType ||
+    typeof latitude !== "number" ||
+    !Number.isFinite(latitude) ||
+    typeof longitude !== "number" ||
+    !Number.isFinite(longitude)
+  ) {
+    return null;
+  }
+
+  const radiusMeters = getDuplicateRadiusMeters();
+  const windowHours = getDuplicateWindowHours();
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+
+  // Bounding-box prefilter keeps the candidate set tiny before the exact
+  // haversine refinement; identical approach to the IssueGroup lookup.
+  const latDelta = radiusMeters / METERS_PER_DEGREE_LAT;
+  const cosLat = Math.cos((latitude * Math.PI) / 180);
+  const lonDelta =
+    radiusMeters / (METERS_PER_DEGREE_LAT * Math.max(Math.abs(cosLat), 1e-6));
+
+  const candidates = await prisma.report.findMany({
+    where: {
+      issueType,
+      // Scope to the reporter when signed in; anonymous reports rely on the
+      // location + type heuristic alone.
+      ...(userId ? { userId } : {}),
+      createdAt: { gte: since },
+      latitude: { gte: latitude - latDelta, lte: latitude + latDelta },
+      longitude: { gte: longitude - lonDelta, lte: longitude + lonDelta },
+    },
+    select: {
+      id: true,
+      latitude: true,
+      longitude: true,
+    },
+  });
+
+  let best: DuplicateMatch | null = null;
+
+  for (const candidate of candidates) {
+    if (
+      typeof candidate.latitude !== "number" ||
+      typeof candidate.longitude !== "number"
+    ) {
+      continue;
+    }
+    const distance = haversineMeters(
+      latitude,
+      longitude,
+      candidate.latitude,
+      candidate.longitude,
+    );
+    if (
+      distance <= radiusMeters &&
+      (best === null || distance < best.distanceMeters)
+    ) {
+      best = { reportId: candidate.id, distanceMeters: distance };
+    }
+  }
+
+  return best;
+}


### PR DESCRIPTION
Closes #111.

## What
`POST /api/reports` previously created a report immediately with no check for an existing near-identical report, so a reporter could file the same issue repeatedly. This adds a pre-create duplicate check.

## Dedup rule
A new submission is treated as a likely duplicate of an existing report when **all** hold:
- **same `issueType`**
- **near-identical location** — within a configurable radius (default **50 m**), measured by true haversine distance after a lat/long bounding-box prefilter
- **recent** — created within a configurable look-back window (default **24 h**)
- **same reporter** when signed in (scoped to `userId`); **anonymous** submissions (`userId == null`) drop the user filter and rely on the location + type heuristic alone, since there is no stable guest identity to key on

On a match the route returns **409** with the existing report's id in `details.duplicateOf` instead of persisting a second copy. Reports that differ in type, location, or fall outside the window are unaffected — behavior is backward-compatible for non-duplicates.

## How it reuses existing logic
- Reuses `haversineMeters` and the same bounding-box prefilter pattern from the existing IssueGroup dedupe (`src/lib/issues/dedupe.ts`) rather than rolling a second distance metric. The two features stay distinct: IssueGroup **merges** different people's reports of one real-world problem into a shared case; this new helper guards against **one reporter** filing the **same** report twice.
- The new `findDuplicateReport` (`src/lib/reports/dedup.ts`) is a standalone read-only lookup that runs before `findOrCreateIssueGroup`, so the grouping flow is untouched.

## Configurability
- `DUPLICATE_RADIUS_METERS` (default 50)
- `DUPLICATE_WINDOW_HOURS` (default 24)

Both read through a new `optionalPositiveNumberEnv` getter in `src/lib/config.ts` that falls back to the default on unset/non-numeric/non-positive values, so a typo can't silently disable the guard.

## Schema
Adds an index `Report(userId, issueType, createdAt)` (+ migration) to speed the lookup. `errorResponse` gains an optional `details` field to carry the structured `duplicateOf` reference.

## Verification
- `npx tsc --noEmit` clean
- `npm run lint` (0 errors; 2 pre-existing `<img>` warnings)
- `npm run format:check` clean
- `npm test` — 346 passed (new dedup unit tests + a 409 route test)