### PR TITLE
feat(submission): orchestrate end-to-end submit by intake method [#34]

### DIFF
--- a/nexa/src/app/api/reports/[id]/submit/route.test.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.test.ts
@@ -1,0 +1,153 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { IntakeMethod } from "@/generated/prisma/enums";
+
+// The route is a thin translator over the orchestrator; mock the orchestrator
+// to assert the HTTP mapping per result kind (the orchestrator has its own
+// tests). Mock the session so we can exercise owner authorization wiring.
+const orchestrateSubmission = vi.fn();
+vi.mock("@/lib/submission/orchestrate", () => ({
+  orchestrateSubmission: (...args: unknown[]) => orchestrateSubmission(...args),
+}));
+
+const getSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => getSession(),
+}));
+
+import { POST } from "./route";
+
+function call(id = "report_1") {
+  const request = new NextRequest(`http://localhost/api/reports/${id}/submit`, {
+    method: "POST",
+  });
+  return POST(request, { params: Promise.resolve({ id }) });
+}
+
+beforeEach(() => {
+  orchestrateSubmission.mockReset();
+  getSession.mockReset();
+  getSession.mockResolvedValue({ userId: "user_1", email: "u@x.com" });
+});
+
+describe("POST /api/reports/[id]/submit", () => {
+  it("passes the session user id to the orchestrator", async () => {
+    // Arrange
+    orchestrateSubmission.mockResolvedValue({
+      status: "submitted",
+      reportId: "report_1",
+      externalTrackingId: "SR-1",
+    });
+
+    // Act
+    await call("report_1");
+
+    // Assert
+    expect(orchestrateSubmission).toHaveBeenCalledWith("report_1", {
+      userId: "user_1",
+    });
+  });
+
+  it("returns 200 with the tracking id for an automated submission", async () => {
+    // Arrange
+    orchestrateSubmission.mockResolvedValue({
+      status: "submitted",
+      reportId: "report_1",
+      externalTrackingId: "SR-1",
+    });
+
+    // Act
+    const res = await call();
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      data: {
+        submitted: true,
+        status: "SUBMITTED",
+        externalTrackingId: "SR-1",
+      },
+    });
+  });
+
+  it("returns 200 (not 400) with manualAssist for non-API intake", async () => {
+    // Arrange
+    orchestrateSubmission.mockResolvedValue({
+      status: "manual_assist",
+      reportId: "report_1",
+      intakeMethod: IntakeMethod.WEB_FORM,
+      agencyName: "Palo Alto 311",
+      intakeUrl: "https://paloalto.gov/311",
+      intakeEmail: null,
+    });
+
+    // Act
+    const res = await call();
+    const body = await res.json();
+
+    // Assert: graceful degradation, never a 4xx.
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.submitted).toBe(false);
+    expect(body.data.manualAssist).toMatchObject({
+      intakeMethod: IntakeMethod.WEB_FORM,
+      agencyName: "Palo Alto 311",
+      intakeUrl: "https://paloalto.gov/311",
+    });
+  });
+
+  it.each([
+    ["not_found", 404],
+    ["forbidden", 403],
+    ["already_submitted", 409],
+    ["in_progress", 409],
+    ["no_agency", 400],
+    ["submit_failed", 502],
+  ] as const)("maps the %s error code to HTTP %i", async (code, httpStatus) => {
+    // Arrange
+    orchestrateSubmission.mockResolvedValue({
+      status: "error",
+      code,
+      message: "boom",
+    });
+
+    // Act
+    const res = await call();
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(httpStatus);
+    expect(body.success).toBe(false);
+    expect(body.code).toBe(code);
+  });
+
+  it("prefixes the agent reason for submit_failed", async () => {
+    // Arrange
+    orchestrateSubmission.mockResolvedValue({
+      status: "error",
+      code: "submit_failed",
+      message: "Open311 endpoint timed out.",
+    });
+
+    // Act
+    const res = await call();
+    const body = await res.json();
+
+    // Assert
+    expect(body.error).toBe("Submission failed: Open311 endpoint timed out.");
+  });
+
+  it("returns 500 when the orchestrator throws unexpectedly", async () => {
+    // Arrange
+    orchestrateSubmission.mockRejectedValue(new Error("kaboom"));
+
+    // Act
+    const res = await call();
+
+    // Assert
+    expect(res.status).toBe(500);
+  });
+});

--- a/nexa/src/app/api/reports/[id]/submit/route.ts
+++ b/nexa/src/app/api/reports/[id]/submit/route.ts
@@ -1,20 +1,25 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
-import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
-import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
-import { resolveAgencyId } from "@/lib/jurisdictions/agency";
+import { orchestrateSubmission } from "@/lib/submission/orchestrate";
 import { successResponse, errorResponse } from "@/lib/api/response";
 
 // POST /api/reports/[id]/submit
 //
-// Submits a single confirmed report to its assigned agency via the Open311
-// GeoReport v2 API. This is the API submission agent from issue #32; web-form,
-// email, and phone intake methods are handled by their own agents (#31, #33)
-// and are out of scope here.
+// Submits a single confirmed report to its assigned agency, dispatching to the
+// right submission agent by the agency's `intakeMethod` (issue #34):
 //
-// On success the report's externalTrackingId is stored and its status advances
-// to SUBMITTED so the status poller (#37) can later track it.
+//   - API:              the report is filed automatically via the Open311
+//                       GeoReport agent (#32). On success its
+//                       externalTrackingId is stored and its status advances to
+//                       SUBMITTED so the status poller (#37) can track it.
+//   - WEB_FORM / EMAIL: there is no automated agent yet (#31/#33), so we degrade
+//                       gracefully — the response reports `manualAssist` with
+//                       the official intake link so the UI can guide the user
+//                       through filing it themselves. The report stays CONFIRMED.
+//
+// The orchestration itself (auth, agency resolution, status transitions, agent
+// dispatch) lives in `@/lib/submission/orchestrate`; this route is a thin
+// translation of its discriminated result onto HTTP.
 export async function POST(
   _request: NextRequest,
   context: { params: Promise<{ id: string }> },
@@ -23,94 +28,61 @@ export async function POST(
     const session = await getSession();
     const { id } = await context.params;
 
-    const report = await prisma.report.findUnique({
-      where: { id },
-      include: { agency: true },
-    });
+    const result = await orchestrateSubmission(id, { userId: session?.userId });
 
-    if (!report) {
-      return errorResponse("Report not found.", 404);
-    }
+    switch (result.status) {
+      case "submitted":
+        return successResponse({
+          reportId: result.reportId,
+          status: "SUBMITTED",
+          submitted: true,
+          externalTrackingId: result.externalTrackingId,
+        });
 
-    // Only the report's owner may submit it. Anonymous (userId === null)
-    // reports remain submittable by anyone holding the link, matching the
-    // anonymous-reporting model elsewhere in the app.
-    if (report.userId && report.userId !== session?.userId) {
-      return errorResponse("You can only submit your own reports.", 403);
-    }
+      case "manual_assist":
+        // Not an error: the agency simply has no automated agent, so the user
+        // files it via the official channel. 200 with the details the UI needs
+        // to render the manual-assist guidance.
+        return successResponse({
+          reportId: result.reportId,
+          status: "CONFIRMED",
+          submitted: false,
+          manualAssist: {
+            intakeMethod: result.intakeMethod,
+            agencyName: result.agencyName,
+            intakeUrl: result.intakeUrl,
+            intakeEmail: result.intakeEmail,
+          },
+        });
 
-    if (report.status === ReportStatus.SUBMITTED || report.externalTrackingId) {
-      return errorResponse("This report has already been submitted.", 409);
-    }
-
-    // Reports created before jurisdiction routing existed (or whose location
-    // was added later) may not have an agency yet — resolve it on demand.
-    let agency = report.agency;
-    if (!agency) {
-      const { agencyId } = await resolveAgencyId({
-        latitude: report.latitude,
-        longitude: report.longitude,
-        issueType: report.issueType,
-      });
-      if (agencyId) {
-        await prisma.report.update({ where: { id }, data: { agencyId } });
-        agency = await prisma.agency.findUnique({ where: { id: agencyId } });
+      case "error": {
+        // The Open311 agent's failure reason is worth surfacing to the user.
+        const message =
+          result.code === "submit_failed"
+            ? `Submission failed: ${result.message}`
+            : result.message;
+        return errorResponse(message, ERROR_STATUS[result.code], result.code);
       }
     }
-    if (!agency) {
-      return errorResponse("No agency is assigned to this report.", 400);
-    }
-    if (agency.intakeMethod !== IntakeMethod.API) {
-      return errorResponse(
-        `Agency "${agency.name}" does not accept API submissions (intake method: ${agency.intakeMethod}).`,
-        400,
-      );
-    }
-
-    // Atomically claim the report for submission. A single conditional update
-    // (CONFIRMED -> SUBMITTING) is the DB-level guard against concurrent
-    // submits: only one of two simultaneous POSTs can flip the row, so only
-    // one ever reaches submitToOpen311 below. The loser sees count === 0.
-    const claim = await prisma.report.updateMany({
-      where: { id, status: ReportStatus.CONFIRMED },
-      data: { status: ReportStatus.SUBMITTING },
-    });
-    if (claim.count !== 1) {
-      return errorResponse("This report is already being submitted.", 409);
-    }
-
-    const config = parseOpen311Config(agency.requiredFields);
-    const result = await submitToOpen311(report, {
-      config,
-      intakeUrl: agency.intakeUrl,
-    });
-
-    if (result.status === "error") {
-      // Roll back to CONFIRMED so the user can retry.
-      await prisma.report.update({
-        where: { id },
-        data: { status: ReportStatus.CONFIRMED },
-      });
-      return errorResponse(`Submission failed: ${result.message}`, 502);
-    }
-
-    const updated = await prisma.report.update({
-      where: { id },
-      data: {
-        status: ReportStatus.SUBMITTED,
-        // Prefer the immediate id; fall back to the async token until a later
-        // poll resolves it to a real service_request_id.
-        externalTrackingId: result.serviceRequestId ?? result.token,
-      },
-    });
-
-    return successResponse({
-      reportId: updated.id,
-      status: updated.status,
-      externalTrackingId: updated.externalTrackingId,
-    });
   } catch (error) {
     console.error("Report submission error:", error);
     return errorResponse("Failed to submit report. Please try again.", 500);
   }
 }
+
+// HTTP status for each orchestration error code. Keeping this here (rather than
+// in the orchestrator) lets the service stay transport-agnostic.
+const ERROR_STATUS: Record<
+  Extract<
+    Awaited<ReturnType<typeof orchestrateSubmission>>,
+    { status: "error" }
+  >["code"],
+  number
+> = {
+  not_found: 404,
+  forbidden: 403,
+  already_submitted: 409,
+  in_progress: 409,
+  no_agency: 400,
+  submit_failed: 502,
+};

--- a/nexa/src/components/report/submission-assistant.tsx
+++ b/nexa/src/components/report/submission-assistant.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Copy, ExternalLink, Loader2 } from "lucide-react";
+import {
+  Check,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Loader2,
+  Send,
+} from "lucide-react";
 import type { ApiResponse } from "@/lib/api/response";
 
 interface PrefillField {
@@ -23,16 +30,96 @@ interface SubmissionFieldsResponse {
   fields: PrefillField[];
 }
 
+// Shape returned by POST /api/reports/[id]/submit (see the orchestrator).
+interface SubmitResponse {
+  reportId: string;
+  status: string;
+  submitted: boolean;
+  externalTrackingId?: string;
+  manualAssist?: {
+    intakeMethod: string;
+    agencyName: string;
+    intakeUrl: string | null;
+    intakeEmail: string | null;
+  };
+}
+
 interface SubmissionAssistantProps {
   reportId: string;
 }
 
+// What the orchestrator told us to do with this report.
+type Outcome =
+  | { kind: "loading" }
+  // Automated (API) submission succeeded — nothing left for the user to do.
+  | { kind: "submitted"; trackingId?: string }
+  // No automated agent; show the copy-over guide for the official form/email.
+  | { kind: "manual" }
+  // Submission attempt failed (network/agency error) — let the user retry.
+  | { kind: "error"; message: string };
+
+/**
+ * After a report is confirmed, this drives its submission. It first asks the
+ * orchestrator (POST /submit) to file the report with the right agent:
+ *
+ *   - API agencies are submitted automatically — we show a success state with
+ *     the tracking id, completing the flow in-app (issue #34 acceptance: a
+ *     confirmed in-coverage report submitted end-to-end without leaving the app).
+ *   - WEB_FORM / EMAIL agencies have no automated agent yet, so the orchestrator
+ *     returns a `manualAssist` result and we fall back to the copy-over guide:
+ *     the official form/address plus each field pre-filled.
+ */
 export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
-  const [data, setData] = useState<SubmissionFieldsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [outcome, setOutcome] = useState<Outcome>({ kind: "loading" });
+  const [fields, setFields] = useState<SubmissionFieldsResponse | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
+  // Attempt submission once on mount. The orchestrator decides — automated for
+  // API intake, manual-assist otherwise — so we don't need to know the agency's
+  // method up front.
   useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      let next: Outcome;
+      try {
+        const res = await fetch(`/api/reports/${reportId}/submit`, {
+          method: "POST",
+        });
+        const payload = (await res.json()) as ApiResponse<SubmitResponse>;
+
+        if (payload.success && payload.data.submitted) {
+          next = {
+            kind: "submitted",
+            trackingId: payload.data.externalTrackingId,
+          };
+        } else if (payload.success) {
+          // manualAssist (or anything non-submitted) -> show the copy-over guide.
+          next = { kind: "manual" };
+        } else if (payload.code === "already_submitted") {
+          // Re-render of an already-filed report (e.g. remount) is a success.
+          next = { kind: "submitted" };
+        } else {
+          next = { kind: "error", message: payload.error };
+        }
+      } catch {
+        next = {
+          kind: "error",
+          message: "Could not reach the submission service.",
+        };
+      }
+      if (!cancelled) setOutcome(next);
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [reportId]);
+
+  // Lazily load the copy-over fields only when we're in the manual-assist path.
+  useEffect(() => {
+    if (outcome.kind !== "manual" || fields !== null) return;
     let cancelled = false;
     async function load() {
       try {
@@ -41,19 +128,17 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
           ? ((await res.json()) as ApiResponse<SubmissionFieldsResponse>)
           : null;
         if (!cancelled) {
-          setData(payload && payload.success ? payload.data : null);
+          setFields(payload && payload.success ? payload.data : null);
         }
       } catch {
-        if (!cancelled) setData(null);
-      } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setFields(null);
       }
     }
     void load();
     return () => {
       cancelled = true;
     };
-  }, [reportId]);
+  }, [outcome.kind, reportId, fields]);
 
   const handleCopy = async (key: string, value: string) => {
     await navigator.clipboard.writeText(value);
@@ -61,7 +146,67 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
     setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 2000);
   };
 
-  if (loading) {
+  const handleRetry = () => setOutcome({ kind: "loading" });
+
+  if (outcome.kind === "loading") {
+    return (
+      <div className="ep-card flex w-full max-w-md items-center gap-2 p-6 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        Filing your report…
+      </div>
+    );
+  }
+
+  if (outcome.kind === "submitted") {
+    return (
+      <div className="ep-card w-full max-w-md p-6 text-left">
+        <div className="flex items-center gap-2">
+          <CheckCircle2 className="size-5 text-ep-green" />
+          <span className="text-sm font-medium text-foreground">
+            Filed with the agency
+          </span>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Nexa submitted this report for you. You can track its status from your
+          dashboard.
+        </p>
+        {outcome.trackingId && (
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+              Tracking ID
+            </span>
+            <span className="font-mono text-sm">{outcome.trackingId}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (outcome.kind === "error") {
+    return (
+      <div className="ep-card w-full max-w-md p-6 text-left">
+        <span className="text-sm font-medium text-foreground">
+          We couldn&apos;t file this report automatically
+        </span>
+        {outcome.message && (
+          <p className="mt-2 text-sm text-muted-foreground">
+            {outcome.message}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={handleRetry}
+          className="btn-cta btn-cta-purple mt-4 inline-flex"
+        >
+          <Send className="size-4" />
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  // outcome.kind === "manual": show the copy-over guide once fields load.
+  if (fields === null) {
     return (
       <div className="ep-card flex w-full max-w-md items-center gap-2 p-6 text-sm text-muted-foreground">
         <Loader2 className="size-4 animate-spin" />
@@ -70,34 +215,34 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
     );
   }
 
-  if (!data?.agency || data.fields.length === 0) {
+  if (!fields.agency || fields.fields.length === 0) {
     return null;
   }
 
   return (
     <div className="ep-card w-full max-w-md p-6 text-left">
       <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-        File with {data.agency.name}
+        File with {fields.agency.name}
       </span>
       <p className="mt-2 text-sm text-muted-foreground">
         Nexa doesn&apos;t submit for you. Open the official form and copy each
         value below into the matching field.
       </p>
 
-      {data.formUrl && (
+      {fields.formUrl && (
         <a
-          href={data.formUrl}
+          href={fields.formUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="mt-3 inline-flex items-center gap-1.5 text-sm text-ep-purple underline-offset-4 hover:underline"
         >
-          Open {data.agency.name} form
+          Open {fields.agency.name} form
           <ExternalLink className="size-3.5" />
         </a>
       )}
 
       <div className="mt-5 flex flex-col gap-4">
-        {data.fields.map((field) => (
+        {fields.fields.map((field) => (
           <div key={field.key}>
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-foreground">

--- a/nexa/src/lib/submission/orchestrate.test.ts
+++ b/nexa/src/lib/submission/orchestrate.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
+import { makeReport } from "@/test/factories/report";
+import { makeAgency } from "@/test/factories/agency";
+import { prismaMock } from "@/test/prisma-mock";
+
+// The orchestrator delegates the actual API call to submitToOpen311; we stub it
+// so these tests exercise dispatch + status transitions, not the HTTP client
+// (which has its own tests in open311.test.ts).
+const submitToOpen311 = vi.fn();
+vi.mock("@/lib/submission/open311", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/submission/open311")
+  >("@/lib/submission/open311");
+  return {
+    ...actual,
+    submitToOpen311: (...args: unknown[]) => submitToOpen311(...args),
+  };
+});
+
+// resolveAgencyId hits prisma; stub it so on-demand resolution is deterministic.
+const resolveAgencyId = vi.fn();
+vi.mock("@/lib/jurisdictions/agency", () => ({
+  resolveAgencyId: (...args: unknown[]) => resolveAgencyId(...args),
+}));
+
+import { orchestrateSubmission } from "./orchestrate";
+
+beforeEach(() => {
+  submitToOpen311.mockReset();
+  resolveAgencyId.mockReset();
+});
+
+// A confirmed report whose API agency is already attached. The `as never` casts
+// satisfy the deep-mock's overloaded signatures without re-stating their types.
+function stubReportWithAgency(
+  reportOverrides = {},
+  agencyOverrides = {},
+): { reportId: string } {
+  const agency = makeAgency({
+    intakeMethod: IntakeMethod.API,
+    ...agencyOverrides,
+  });
+  const report = makeReport({
+    status: ReportStatus.CONFIRMED,
+    agencyId: agency.id,
+    externalTrackingId: null,
+    ...reportOverrides,
+  });
+  prismaMock.report.findUnique.mockResolvedValue({
+    ...report,
+    agency,
+  } as never);
+  return { reportId: report.id };
+}
+
+describe("orchestrateSubmission — API intake (automated)", () => {
+  it("files via Open311 and advances to SUBMITTED with the tracking id", async () => {
+    // Arrange
+    const { reportId } = stubReportWithAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitToOpen311.mockResolvedValue({
+      status: "submitted",
+      serviceRequestId: "SR-123",
+      token: null,
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({
+        id: reportId,
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "SR-123",
+      }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toEqual({
+      status: "submitted",
+      reportId,
+      externalTrackingId: "SR-123",
+    });
+    // Claimed CONFIRMED -> SUBMITTING atomically before submitting.
+    expect(prismaMock.report.updateMany).toHaveBeenCalledWith({
+      where: { id: reportId, status: ReportStatus.CONFIRMED },
+      data: { status: ReportStatus.SUBMITTING },
+    });
+  });
+
+  it("falls back to the async token when no service_request_id is returned", async () => {
+    // Arrange
+    const { reportId } = stubReportWithAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitToOpen311.mockResolvedValue({
+      status: "submitted",
+      serviceRequestId: null,
+      token: "tok-abc",
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({
+        id: reportId,
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "tok-abc",
+      }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "submitted",
+      externalTrackingId: "tok-abc",
+    });
+  });
+
+  it("rolls back to CONFIRMED and reports submit_failed when the agent errors", async () => {
+    // Arrange
+    const { reportId } = stubReportWithAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitToOpen311.mockResolvedValue({
+      status: "error",
+      httpStatus: 502,
+      message: "Open311 endpoint timed out.",
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({ id: reportId, status: ReportStatus.CONFIRMED }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toEqual({
+      status: "error",
+      code: "submit_failed",
+      message: "Open311 endpoint timed out.",
+    });
+    // Status rolled back so the user can retry.
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: reportId },
+      data: { status: ReportStatus.CONFIRMED },
+    });
+  });
+
+  it("reports in_progress when the atomic claim loses the race", async () => {
+    // Arrange
+    const { reportId } = stubReportWithAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", code: "in_progress" });
+    expect(submitToOpen311).not.toHaveBeenCalled();
+  });
+});
+
+describe("orchestrateSubmission — non-API intake (graceful fallback)", () => {
+  it.each([IntakeMethod.WEB_FORM, IntakeMethod.EMAIL, IntakeMethod.PHONE])(
+    "returns manual_assist (not an error) for %s intake",
+    async (intakeMethod) => {
+      // Arrange
+      const { reportId } = stubReportWithAgency(
+        { userId: null },
+        {
+          intakeMethod,
+          name: "Palo Alto 311",
+          intakeUrl: "https://paloalto.gov/311",
+          intakeEmail: "311@paloalto.gov",
+        },
+      );
+
+      // Act
+      const result = await orchestrateSubmission(reportId, {});
+
+      // Assert: degrade gracefully, never 400, report stays CONFIRMED.
+      expect(result).toEqual({
+        status: "manual_assist",
+        reportId,
+        intakeMethod,
+        agencyName: "Palo Alto 311",
+        intakeUrl: "https://paloalto.gov/311",
+        intakeEmail: "311@paloalto.gov",
+      });
+      expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
+      expect(submitToOpen311).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("orchestrateSubmission — preconditions", () => {
+  it("returns not_found for a missing report", async () => {
+    // Arrange
+    prismaMock.report.findUnique.mockResolvedValue(null as never);
+
+    // Act
+    const result = await orchestrateSubmission("missing", {});
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", code: "not_found" });
+  });
+
+  it("returns forbidden when a different user submits an owned report", async () => {
+    // Arrange
+    stubReportWithAgency({ id: "r1", userId: "owner" });
+
+    // Act
+    const result = await orchestrateSubmission("r1", { userId: "intruder" });
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", code: "forbidden" });
+  });
+
+  it("returns already_submitted when a tracking id is already present", async () => {
+    // Arrange
+    stubReportWithAgency({
+      id: "r2",
+      userId: null,
+      externalTrackingId: "SR-9",
+    });
+
+    // Act
+    const result = await orchestrateSubmission("r2", {});
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "error",
+      code: "already_submitted",
+    });
+  });
+
+  it("resolves and persists an agency on demand when one isn't set", async () => {
+    // Arrange: a report with no agency that resolves to an API agency.
+    const report = makeReport({
+      id: "r3",
+      userId: null,
+      agencyId: null,
+      status: ReportStatus.CONFIRMED,
+      externalTrackingId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...report,
+      agency: null,
+    } as never);
+    resolveAgencyId.mockResolvedValue({
+      agencyId: "agency_x",
+      candidates: ["agency_x"],
+    });
+    prismaMock.report.update.mockResolvedValue(report as never);
+    prismaMock.agency.findUnique.mockResolvedValue(
+      makeAgency({ id: "agency_x", intakeMethod: IntakeMethod.API }) as never,
+    );
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitToOpen311.mockResolvedValue({
+      status: "submitted",
+      serviceRequestId: "SR-onresolve",
+      token: null,
+    });
+    prismaMock.report.update.mockResolvedValueOnce(report as never);
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({
+        id: "r3",
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "SR-onresolve",
+      }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission("r3", {});
+
+    // Assert
+    expect(resolveAgencyId).toHaveBeenCalledOnce();
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: "r3" },
+      data: { agencyId: "agency_x" },
+    });
+    expect(result).toMatchObject({ status: "submitted" });
+  });
+
+  it("returns no_agency when none can be resolved", async () => {
+    // Arrange
+    const report = makeReport({
+      id: "r4",
+      userId: null,
+      agencyId: null,
+      externalTrackingId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...report,
+      agency: null,
+    } as never);
+    resolveAgencyId.mockResolvedValue({ agencyId: null, candidates: [] });
+
+    // Act
+    const result = await orchestrateSubmission("r4", {});
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", code: "no_agency" });
+  });
+});

--- a/nexa/src/lib/submission/orchestrate.ts
+++ b/nexa/src/lib/submission/orchestrate.ts
@@ -1,0 +1,216 @@
+import { prisma } from "@/lib/prisma";
+import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
+import { resolveAgencyId } from "@/lib/jurisdictions/agency";
+import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
+
+// ---------------------------------------------------------------------------
+// Submission orchestrator (issue #34)
+//
+// One entry point ties a CONFIRMED report to the right submission agent based
+// on its assigned agency's `intakeMethod`, executes that agent, stores the
+// resulting tracking id, and advances the report's status — or rolls it back
+// on failure so the user can retry.
+//
+//   API                -> the Open311 GeoReport agent (`open311.ts`). Fully
+//                         automated: we file the request and store the returned
+//                         service_request_id / token. (issue #32)
+//   WEB_FORM / EMAIL    -> a graceful manual-assist fallback. The per-modality
+//                         email (#31) and web-form (#33) agents are separate;
+//                         until they land, we degrade gracefully by pointing the
+//                         user at the official form / address with their fields
+//                         pre-filled (the `submission-fields` route + assistant)
+//                         rather than failing the request. The report stays
+//                         CONFIRMED so it can be submitted manually.
+//   PHONE              -> same manual-assist fallback (no automated path).
+//
+// Like `open311.ts`, this never throws to its caller: every outcome is a typed
+// discriminated result the route maps onto an HTTP response.
+// ---------------------------------------------------------------------------
+
+/** Outcome of orchestrating a single report's submission. */
+export type OrchestrationResult =
+  | {
+      // The report was filed with an automated agent (API intake). Status is
+      // now SUBMITTED and `externalTrackingId` is set.
+      status: "submitted";
+      reportId: string;
+      externalTrackingId: string;
+    }
+  | {
+      // No automated agent covers this agency's intake method. The report stays
+      // CONFIRMED; the caller should surface the manual-assist path (official
+      // form/email link + pre-filled fields) so the user can file it.
+      status: "manual_assist";
+      reportId: string;
+      intakeMethod: IntakeMethod;
+      agencyName: string;
+      // Where the user should file: the agency's form URL or intake email.
+      intakeUrl: string | null;
+      intakeEmail: string | null;
+    }
+  | {
+      // A precondition failed (report missing, not owned, already submitted, no
+      // agency). `code` lets the route choose an HTTP status without parsing
+      // the message.
+      status: "error";
+      code:
+        | "not_found"
+        | "forbidden"
+        | "already_submitted"
+        | "in_progress"
+        | "no_agency"
+        | "submit_failed";
+      message: string;
+    };
+
+/** Caller identity used to authorize the submission. */
+export type OrchestrationActor = {
+  // The signed-in user's id, or null/undefined for an anonymous caller.
+  userId?: string | null;
+};
+
+/**
+ * Orchestrates submission of a single confirmed report end-to-end.
+ *
+ * Responsibilities (mirroring the prior inline logic of the submit route, now
+ * generalized beyond API-only intake):
+ *  1. Load the report and authorize the actor (owner-only; anonymous reports
+ *     stay submittable by any link-holder).
+ *  2. Ensure an agency is assigned, resolving + persisting one on demand.
+ *  3. Dispatch by `agency.intakeMethod`:
+ *       - API: atomically claim CONFIRMED -> SUBMITTING, run the Open311 agent,
+ *         then SUBMITTING -> SUBMITTED (storing the tracking id) on success or
+ *         roll back to CONFIRMED on failure.
+ *       - WEB_FORM / EMAIL / PHONE: leave the report CONFIRMED and return a
+ *         `manual_assist` result instead of erroring.
+ */
+export async function orchestrateSubmission(
+  reportId: string,
+  actor: OrchestrationActor = {},
+): Promise<OrchestrationResult> {
+  const report = await prisma.report.findUnique({
+    where: { id: reportId },
+    include: { agency: true },
+  });
+
+  if (!report) {
+    return {
+      status: "error",
+      code: "not_found",
+      message: "Report not found.",
+    };
+  }
+
+  // Only the report's owner may submit it. Anonymous (userId === null) reports
+  // remain submittable by anyone holding the link, matching the
+  // anonymous-reporting model elsewhere in the app.
+  if (report.userId && report.userId !== actor.userId) {
+    return {
+      status: "error",
+      code: "forbidden",
+      message: "You can only submit your own reports.",
+    };
+  }
+
+  if (report.status === ReportStatus.SUBMITTED || report.externalTrackingId) {
+    return {
+      status: "error",
+      code: "already_submitted",
+      message: "This report has already been submitted.",
+    };
+  }
+
+  // Reports created before jurisdiction routing existed (or whose location was
+  // added later) may not have an agency yet — resolve it on demand.
+  let agency = report.agency;
+  if (!agency) {
+    const { agencyId } = await resolveAgencyId({
+      latitude: report.latitude,
+      longitude: report.longitude,
+      issueType: report.issueType,
+    });
+    if (agencyId) {
+      await prisma.report.update({
+        where: { id: reportId },
+        data: { agencyId },
+      });
+      agency = await prisma.agency.findUnique({ where: { id: agencyId } });
+    }
+  }
+  if (!agency) {
+    return {
+      status: "error",
+      code: "no_agency",
+      message: "No agency is assigned to this report.",
+    };
+  }
+
+  // Non-API intake has no automated agent wired yet (#31/#33). Degrade
+  // gracefully: the report stays CONFIRMED and the caller surfaces the
+  // manual-assist path rather than returning an error.
+  if (agency.intakeMethod !== IntakeMethod.API) {
+    return {
+      status: "manual_assist",
+      reportId: report.id,
+      intakeMethod: agency.intakeMethod,
+      agencyName: agency.name,
+      intakeUrl: agency.intakeUrl,
+      intakeEmail: agency.intakeEmail,
+    };
+  }
+
+  // --- API path: fully automated Open311 submission -----------------------
+
+  // Atomically claim the report for submission. A single conditional update
+  // (CONFIRMED -> SUBMITTING) is the DB-level guard against concurrent submits:
+  // only one of two simultaneous calls can flip the row, so only one ever
+  // reaches submitToOpen311 below. The loser sees count === 0.
+  const claim = await prisma.report.updateMany({
+    where: { id: reportId, status: ReportStatus.CONFIRMED },
+    data: { status: ReportStatus.SUBMITTING },
+  });
+  if (claim.count !== 1) {
+    return {
+      status: "error",
+      code: "in_progress",
+      message: "This report is already being submitted.",
+    };
+  }
+
+  const config = parseOpen311Config(agency.requiredFields);
+  const result = await submitToOpen311(report, {
+    config,
+    intakeUrl: agency.intakeUrl,
+  });
+
+  if (result.status === "error") {
+    // Roll back to CONFIRMED so the user can retry.
+    await prisma.report.update({
+      where: { id: reportId },
+      data: { status: ReportStatus.CONFIRMED },
+    });
+    return {
+      status: "error",
+      code: "submit_failed",
+      message: result.message,
+    };
+  }
+
+  const updated = await prisma.report.update({
+    where: { id: reportId },
+    data: {
+      status: ReportStatus.SUBMITTED,
+      // Prefer the immediate id; fall back to the async token until a later
+      // poll resolves it to a real service_request_id.
+      externalTrackingId: result.serviceRequestId ?? result.token,
+    },
+  });
+
+  return {
+    status: "submitted",
+    reportId: updated.id,
+    // Non-null: a "submitted" result always carries an id or token (the agent
+    // errors otherwise), and the line above writes one of the two.
+    externalTrackingId: updated.externalTrackingId as string,
+  };
+}


### PR DESCRIPTION
Closes #34.

## What this does
Ties classify -> route -> pick agent -> execute -> store tracking id -> advance status into one orchestration path, selecting the submission agent by the agency's `intakeMethod`.

## Already existed (reused, not duplicated)
- **Open311 API agent** (`src/lib/submission/open311.ts`) — request building, retry-safe POST, discriminated `SubmitResult`. Unchanged.
- **Agency resolution** (`src/lib/jurisdictions/agency.ts`, `resolveAgencyId`) — on-demand agency assignment. Unchanged.
- **Manual-assist prefill** (`src/lib/submission/prefill.ts` + `GET /api/reports/[id]/submission-fields`) — the copy-over field guide. Unchanged.
- **`SubmissionAssistant`** was already mounted in the confirmed step (read-only field guide).
- The submit route already did the atomic `CONFIRMED -> SUBMITTING` claim, the Open311 dispatch, rollback-on-failure, and tracking-id storage — but **only for `IntakeMethod.API`**, returning **400** for every other method.

## What I added
- **`src/lib/submission/orchestrate.ts`** — a single `orchestrateSubmission(reportId, actor)` service (never throws; typed discriminated result), lifting the route's inline logic and generalizing it beyond API-only. Owns auth, on-demand agency resolution, the atomic status transitions, agent dispatch, and rollback.
- **Generalized the submit route** (`src/app/api/reports/[id]/submit/route.ts`) into a thin translator over the orchestrator. It now handles **all** intake methods without 400ing.
- **Auto-submit from the UI**: `SubmissionAssistant` now POSTs `/submit` on mount and renders by outcome — a filed/tracking-id success state for the API path, a retry on error, and the existing copy-over guide for manual-assist — completing API submission **in-app**.
- Tests for the orchestrator and the route.

## Per-intake-method dispatch
| `intakeMethod` | Behavior |
|---|---|
| `API` | Open311 agent files the request; store `externalTrackingId`; `CONFIRMED -> SUBMITTING -> SUBMITTED` (rollback to `CONFIRMED` on failure). |
| `WEB_FORM` / `EMAIL` / `PHONE` | No automated agent yet (#31/#33). Returns `manual_assist` (HTTP 200) with the official link / intake email; report stays `CONFIRMED` so the user files it via the prefill guide. |

> Note: all seeded agencies are currently `WEB_FORM`, so until an API-intake agency is seeded the live end-to-end path is the manual-assist fallback. The automated path is exercised by tests.

## Verification (all green)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings in untouched files)
- `npm run format:check` — clean
- `npm test` — 361 passed (incl. 23 new)
- `npm run build` — succeeds with `DATABASE_URL` set; the `/submit` route builds fine