### PR TITLE
feat(notifications): web push for report status changes (env-gated) [#38]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -60,5 +60,20 @@ CRON_SECRET=
 RATE_LIMIT_MAX=20
 RATE_LIMIT_WINDOW_MS=60000
 
+# --- Web Push notifications (issue #38) ---
+# Optional. When unset, web push is a NO-OP: the app runs unchanged and the
+# poll-status cron simply skips push sends (ready-to-activate). Set all of the
+# below to turn it on. Generate the key pair with:
+#   npx web-push generate-vapid-keys
+# Then paste the public key into BOTH VAPID_PUBLIC_KEY and the NEXT_PUBLIC_*
+# copy (the client needs it to subscribe; the NEXT_PUBLIC_ prefix exposes it to
+# the browser — only ever the PUBLIC key, never the private one).
+VAPID_PUBLIC_KEY=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Contact URL required by the Web Push spec (mailto: or https:). Defaults to
+# mailto:noreply@nexa.app when unset.
+VAPID_SUBJECT=mailto:noreply@nexa.app
+
 # --- App ---
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -33,6 +33,7 @@
         "sharp": "^0.34.5",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "web-push": "^3.6.7",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -46,6 +47,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
         "eslint": "^9",
@@ -4561,6 +4563,16 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
@@ -5621,6 +5633,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5798,6 +5822,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -8602,6 +8632,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -10234,6 +10273,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -13877,6 +13922,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -56,6 +56,7 @@
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "web-push": "^3.6.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -69,6 +70,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "eslint": "^9",

--- a/nexa/prisma/migrations/20260609120000_add_push_subscription/migration.sql
+++ b/nexa/prisma/migrations/20260609120000_add_push_subscription/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+
+-- AddForeignKey
+ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/nexa/prisma/schema.prisma
+++ b/nexa/prisma/schema.prisma
@@ -13,14 +13,34 @@ datasource db {
 }
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  name         String?
+  id                String             @id @default(cuid())
+  email             String             @unique
+  name              String?
   // bcrypt hash of the user's password — never store plain-text passwords
-  passwordHash String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  reports      Report[]
+  passwordHash      String?
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+  reports           Report[]
+  pushSubscriptions PushSubscription[]
+}
+
+// A browser Web Push subscription (issue #38). One row per browser/device that
+// opted in to push notifications. `userId` is nullable so a guest can still
+// subscribe; when they later claim an account we can attach it. The `endpoint`
+// is the unique push-service URL — we upsert on it so re-subscribing the same
+// browser refreshes its keys instead of creating duplicates.
+model PushSubscription {
+  id        String   @id @default(cuid())
+  endpoint  String   @unique
+  // The keys the push service needs to encrypt payloads for this subscription.
+  p256dh    String
+  auth      String
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model Report {

--- a/nexa/public/sw.js
+++ b/nexa/public/sw.js
@@ -1,4 +1,5 @@
-// Nexa service worker — offline app shell + static asset caching.
+// Nexa service worker — offline app shell + static asset caching, plus Web
+// Push handling (issue #38).
 // Part of the PWA work (issue #41). Pairs with the web app manifest and the
 // offline report queue (src/lib/offline-queue.ts), which replays queued POSTs
 // from the page on reconnect rather than here.
@@ -84,5 +85,55 @@ self.addEventListener("fetch", (event) => {
         .catch(() => cached);
       return cached || network;
     }),
+  );
+});
+
+// --- Web Push (issue #38) -------------------------------------------------
+// Payloads are JSON produced by sendPush() in src/lib/push: { title, body,
+// url?, tag? }. We tolerate a missing/garbled payload so a push never throws.
+
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = { title: "Nexa", body: event.data ? event.data.text() : "" };
+  }
+
+  const title = data.title || "Nexa";
+  const options = {
+    body: data.body || "",
+    icon: "/icon.svg",
+    badge: "/icon.svg",
+    tag: data.tag || undefined,
+    data: { url: data.url || "/dashboard" },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target =
+    (event.notification.data && event.notification.data.url) || "/dashboard";
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        // Focus an existing tab on the same origin if one is open.
+        for (const client of clientList) {
+          const url = new URL(client.url);
+          if (url.origin === self.location.origin && "focus" in client) {
+            client.navigate(target);
+            return client.focus();
+          }
+        }
+        // Otherwise open a new tab.
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(target);
+        }
+        return undefined;
+      }),
   );
 });

--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -6,6 +6,7 @@ import {
   parseOpen311Config,
   STATUS_RANK,
 } from "@/lib/submission/open311";
+import { sendPush } from "@/lib/push";
 
 // GET /api/cron/poll-status
 //
@@ -118,6 +119,24 @@ export async function GET(request: NextRequest) {
         data: { status: result.reportStatus },
       });
       updated++;
+
+      // The status genuinely advanced — notify the reporter via Web Push (#38).
+      // Complementary to the email path; never blocks the poll. `sendPush` is a
+      // NO-OP when VAPID keys are unset, so this is safe with no config.
+      await sendPush(report.userId, {
+        title: "Report status updated",
+        body: `Your report${
+          report.address ? ` at ${report.address}` : ""
+        } is now ${result.reportStatus.replace(/_/g, " ").toLowerCase()}.`,
+        url: `/dashboard/reports/${report.id}`,
+        tag: `report-${report.id}`,
+      }).catch((error) => {
+        // A push failure must never fail the poll or mask the status update.
+        console.error(`${ALERT_PREFIX} push notify failed`, {
+          reportId: report.id,
+          error,
+        });
+      });
     }
 
     const errorCount = failures.length;

--- a/nexa/src/app/api/push/subscribe/route.test.ts
+++ b/nexa/src/app/api/push/subscribe/route.test.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+// Mock the session helper so we can drive the userId attached to a subscription.
+const getSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => getSession(),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/push/subscribe", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  endpoint: "https://push.example.com/sub/abc",
+  keys: { p256dh: "pub-key", auth: "auth-secret" },
+};
+
+describe("POST /api/push/subscribe", () => {
+  beforeEach(() => {
+    getSession.mockReset();
+  });
+
+  it("upserts the subscription with the session userId", async () => {
+    getSession.mockResolvedValue({ userId: "user_1", email: "a@b.com" });
+    prismaMock.pushSubscription.upsert.mockResolvedValue({} as never);
+
+    const response = await POST(makeRequest(VALID_BODY));
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.pushSubscription.upsert).toHaveBeenCalledWith({
+      where: { endpoint: VALID_BODY.endpoint },
+      create: {
+        endpoint: VALID_BODY.endpoint,
+        p256dh: "pub-key",
+        auth: "auth-secret",
+        userId: "user_1",
+      },
+      update: {
+        p256dh: "pub-key",
+        auth: "auth-secret",
+        userId: "user_1",
+      },
+    });
+  });
+
+  it("stores a null userId for an anonymous (guest) subscriber", async () => {
+    getSession.mockResolvedValue(null);
+    prismaMock.pushSubscription.upsert.mockResolvedValue({} as never);
+
+    const response = await POST(makeRequest(VALID_BODY));
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.pushSubscription.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ userId: null }),
+      }),
+    );
+  });
+
+  it("rejects a body missing the push keys with a 400", async () => {
+    getSession.mockResolvedValue(null);
+
+    const response = await POST(
+      makeRequest({ endpoint: "https://push.example.com/sub/abc" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(prismaMock.pushSubscription.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/nexa/src/app/api/push/subscribe/route.ts
+++ b/nexa/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { PushSubscribeSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
+
+// POST /api/push/subscribe — store a browser Web Push subscription (issue #38).
+//
+// The browser creates the subscription via PushManager.subscribe() and POSTs
+// its JSON here. We upsert on the unique `endpoint` so re-subscribing the same
+// browser refreshes its keys (and re-attaches the current user) instead of
+// piling up duplicate rows.
+//
+// `userId` is taken from the session when present and stored nullable, so a
+// guest can still subscribe; a later account claim can attach the row. This is
+// complementary to the email path — it never replaces it.
+export async function POST(request: NextRequest) {
+  try {
+    const { endpoint, keys } = await parseJsonRequest(
+      request,
+      PushSubscribeSchema,
+    );
+
+    const session = await getSession();
+    const userId = session?.userId ?? null;
+
+    await prisma.pushSubscription.upsert({
+      where: { endpoint },
+      create: {
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userId,
+      },
+      update: {
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userId,
+      },
+    });
+
+    return successResponse({ subscribed: true }, 201);
+  } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
+    console.error("Push subscribe error:", error);
+    return errorResponse("Failed to save push subscription.", 500);
+  }
+}

--- a/nexa/src/app/api/push/unsubscribe/route.ts
+++ b/nexa/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { PushUnsubscribeSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
+
+// POST /api/push/unsubscribe — drop a stored Web Push subscription (issue #38).
+//
+// Called when the user opts out (or the browser revokes the subscription).
+// Keyed on the unique `endpoint`; idempotent — deleting an unknown endpoint
+// still returns success so the client can fire-and-forget.
+export async function POST(request: NextRequest) {
+  try {
+    const { endpoint } = await parseJsonRequest(request, PushUnsubscribeSchema);
+
+    await prisma.pushSubscription.deleteMany({ where: { endpoint } });
+
+    return successResponse({ unsubscribed: true });
+  } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
+    console.error("Push unsubscribe error:", error);
+    return errorResponse("Failed to remove push subscription.", 500);
+  }
+}

--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   type ReportMapPoint,
 } from "@/components/dashboard/reports-map";
 import { T } from "@/components/i18n-text";
+import { PushOptIn } from "@/components/push-opt-in";
 
 export default async function DashboardPage() {
   const session = await getSession();
@@ -86,10 +87,13 @@ export default async function DashboardPage() {
             />
           </p>
         </div>
-        <Link href="/report" className="btn-cta btn-cta-purple">
-          <T k="nav.reportIssue" />
-          <ArrowRight className="size-4" />
-        </Link>
+        <div className="flex flex-col items-end gap-2">
+          <Link href="/report" className="btn-cta btn-cta-purple">
+            <T k="nav.reportIssue" />
+            <ArrowRight className="size-4" />
+          </Link>
+          <PushOptIn />
+        </div>
       </div>
 
       <div className="mt-8 grid gap-4 sm:grid-cols-3">

--- a/nexa/src/components/push-opt-in.tsx
+++ b/nexa/src/components/push-opt-in.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Bell, BellOff, Loader2 } from "lucide-react";
+import {
+  isPushSupported,
+  getExistingSubscription,
+  getPushPermission,
+  subscribeToPush,
+  unsubscribeFromPush,
+} from "@/lib/push/client";
+
+// Opt-in control for Web Push notifications (issue #38). Rendered on the
+// dashboard. It self-hides whenever push is unavailable — no VAPID public key
+// configured, an unsupported browser, or permission already denied — so the
+// app looks unchanged until keys are set (ready-to-activate).
+export function PushOptIn() {
+  // Resolve availability after mount so SSR and the first client render match
+  // (avoids a hydration mismatch); null = undecided.
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [subscribed, setSubscribed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const usable = isPushSupported() && getPushPermission() !== "denied";
+
+    // Resolve in a microtask so setState runs from a callback rather than
+    // synchronously in the effect body (no cascading-render lint warning).
+    Promise.resolve()
+      .then(() => (usable ? getExistingSubscription() : null))
+      .then((sub) => {
+        if (!active) return;
+        setAvailable(usable);
+        setSubscribed(Boolean(sub));
+      })
+      .catch(() => {
+        if (active) setAvailable(usable);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!available) return null;
+
+  const onToggle = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      if (subscribed) {
+        await unsubscribeFromPush();
+        setSubscribed(false);
+      } else {
+        await subscribeToPush();
+        setSubscribed(true);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Could not update notification settings.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={busy}
+        className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-60"
+        aria-pressed={subscribed}
+      >
+        {busy ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : subscribed ? (
+          <BellOff className="size-3.5" />
+        ) : (
+          <Bell className="size-3.5" />
+        )}
+        {subscribed ? "Turn off notifications" : "Notify me of status updates"}
+      </button>
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/nexa/src/lib/api/schemas.ts
+++ b/nexa/src/lib/api/schemas.ts
@@ -75,3 +75,22 @@ export const ResolutionSchema = z.object({
   }),
 });
 export type ResolutionInput = z.infer<typeof ResolutionSchema>;
+
+/**
+ * `POST /api/push/subscribe` — store a browser Web Push subscription (#38).
+ * Shape mirrors the JSON produced by `PushSubscription.toJSON()` in the browser.
+ */
+export const PushSubscribeSchema = z.object({
+  endpoint: z.string().min(1, "endpoint is required"),
+  keys: z.object({
+    p256dh: z.string().min(1, "keys.p256dh is required"),
+    auth: z.string().min(1, "keys.auth is required"),
+  }),
+});
+export type PushSubscribeInput = z.infer<typeof PushSubscribeSchema>;
+
+/** `POST /api/push/unsubscribe` — drop a stored subscription by endpoint. */
+export const PushUnsubscribeSchema = z.object({
+  endpoint: z.string().min(1, "endpoint is required"),
+});
+export type PushUnsubscribeInput = z.infer<typeof PushUnsubscribeSchema>;

--- a/nexa/src/lib/push/client.ts
+++ b/nexa/src/lib/push/client.ts
@@ -1,0 +1,115 @@
+// Browser-side Web Push helpers (issue #38). Used by the opt-in hook/UI to
+// register a push subscription with the active service worker and sync it to
+// the server. Everything here is gated on the NEXT_PUBLIC_VAPID_PUBLIC_KEY env
+// var — when it's unset push is unavailable and the UI hides itself.
+
+import type { ApiResponse } from "@/lib/api/response";
+
+export const VAPID_PUBLIC_KEY =
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? undefined;
+
+/** True when the browser supports Web Push and a VAPID key is configured. */
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window &&
+    Boolean(VAPID_PUBLIC_KEY)
+  );
+}
+
+// The PushManager wants the application server key as a Uint8Array; VAPID keys
+// are distributed as URL-safe base64. Convert here.
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const buffer = new ArrayBuffer(raw.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+async function getRegistration(): Promise<ServiceWorkerRegistration> {
+  // PwaSetup registers /sw.js on load; `ready` resolves once it's active.
+  return navigator.serviceWorker.ready;
+}
+
+/** Current permission state, or "unsupported" when push can't be used here. */
+export function getPushPermission(): NotificationPermission | "unsupported" {
+  if (!isPushSupported()) return "unsupported";
+  return Notification.permission;
+}
+
+/** Whether this browser already has an active push subscription. */
+export async function getExistingSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null;
+  const registration = await getRegistration();
+  return registration.pushManager.getSubscription();
+}
+
+/**
+ * Request permission (if needed), create a push subscription, and persist it on
+ * the server. Returns true once the subscription is stored. Throws if the user
+ * denies permission or the browser can't subscribe.
+ */
+export async function subscribeToPush(): Promise<boolean> {
+  if (!isPushSupported() || !VAPID_PUBLIC_KEY) {
+    throw new Error("Push notifications are not available in this browser.");
+  }
+
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    throw new Error("Notification permission was not granted.");
+  }
+
+  const registration = await getRegistration();
+  const existing = await registration.pushManager.getSubscription();
+  const subscription =
+    existing ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+    }));
+
+  const res = await fetch("/api/push/subscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(subscription.toJSON()),
+  });
+
+  if (!res.ok) {
+    const payload = (await res
+      .json()
+      .catch(() => null)) as ApiResponse<unknown> | null;
+    throw new Error(
+      payload && !payload.success
+        ? payload.error
+        : "Failed to save push subscription.",
+    );
+  }
+  return true;
+}
+
+/**
+ * Remove the active push subscription from the browser and the server.
+ * Idempotent — safe to call when not subscribed.
+ */
+export async function unsubscribeFromPush(): Promise<void> {
+  if (!isPushSupported()) return;
+  const registration = await getRegistration();
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) return;
+
+  const { endpoint } = subscription;
+  await subscription.unsubscribe().catch(() => {});
+
+  await fetch("/api/push/unsubscribe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ endpoint }),
+  }).catch(() => {});
+}

--- a/nexa/src/lib/push/index.test.ts
+++ b/nexa/src/lib/push/index.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+// Env-gating note: src/lib/push reads VAPID_* into module-level consts at import
+// time, so each scenario sets the env and `vi.resetModules()` + dynamic import
+// to pick up the value. The default test env has no VAPID keys, exercising the
+// NO-OP path the way production does when keys are unset.
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+describe("sendPush (env-gated)", () => {
+  it("is a NO-OP returning 0 when VAPID keys are unset", async () => {
+    delete process.env.VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { sendPush, isPushConfigured } = await import("./index");
+
+    expect(isPushConfigured()).toBe(false);
+
+    const sent = await sendPush("user_1", {
+      title: "Report status updated",
+      body: "Your report is now in progress.",
+    });
+
+    // No keys -> no send, no DB lookup, just a log line.
+    expect(sent).toBe(0);
+    expect(prismaMock.pushSubscription.findMany).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("reports configured when both VAPID keys are set", async () => {
+    process.env.VAPID_PUBLIC_KEY = "test-public";
+    process.env.VAPID_PRIVATE_KEY = "test-private";
+
+    const { isPushConfigured } = await import("./index");
+
+    expect(isPushConfigured()).toBe(true);
+  });
+
+  it("short-circuits to 0 for a null userId even when configured", async () => {
+    process.env.VAPID_PUBLIC_KEY = "test-public";
+    process.env.VAPID_PRIVATE_KEY = "test-private";
+
+    const { sendPush } = await import("./index");
+
+    const sent = await sendPush(null, { title: "x", body: "y" });
+
+    expect(sent).toBe(0);
+    expect(prismaMock.pushSubscription.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/nexa/src/lib/push/index.ts
+++ b/nexa/src/lib/push/index.ts
@@ -1,0 +1,131 @@
+import webpush from "web-push";
+import { prisma } from "@/lib/prisma";
+
+// Web Push notifications (issue #38). Complementary to the email path in
+// `@/lib/email` — never a replacement. The whole feature is ENV-GATED on a
+// VAPID key pair so the app runs unchanged when keys are absent:
+//
+//   VAPID_PUBLIC_KEY   — the public application server key (also exposed to the
+//                        client as NEXT_PUBLIC_VAPID_PUBLIC_KEY for subscribe())
+//   VAPID_PRIVATE_KEY  — the private application server key (server only)
+//   VAPID_SUBJECT      — a mailto: or https: contact URL (optional; defaults
+//                        below). Required by the Web Push spec for the JWT.
+//
+// Generate a pair with: `npx web-push generate-vapid-keys`
+//
+// When the keys are unset, `sendPush` is a NO-OP: it logs once and returns, so
+// nothing throws and no push traffic is attempted (ready-to-activate).
+
+const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT ?? "mailto:noreply@nexa.app";
+
+/** True only when a usable VAPID key pair is configured. */
+export function isPushConfigured(): boolean {
+  return Boolean(VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY);
+}
+
+// Configure web-push lazily so importing this module never throws on a missing
+// key. `details` is only set once, the first time we actually need to send.
+let vapidConfigured = false;
+function ensureVapid(): boolean {
+  if (!isPushConfigured()) return false;
+  if (!vapidConfigured) {
+    webpush.setVapidDetails(
+      VAPID_SUBJECT,
+      VAPID_PUBLIC_KEY as string,
+      VAPID_PRIVATE_KEY as string,
+    );
+    vapidConfigured = true;
+  }
+  return true;
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  // Where to send the user when they click the notification.
+  url?: string;
+  tag?: string;
+}
+
+export interface PushTarget {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+/**
+ * Send a single push notification to one subscription.
+ *
+ * NO-OP when VAPID keys are unset: logs once and returns `false` without
+ * touching the network. Returns `true` on a successful send. On a `410 Gone`
+ * (or `404`) the subscription is dead, so we prune it from the database and
+ * return `false`.
+ */
+export async function sendPushToSubscription(
+  target: PushTarget,
+  payload: PushPayload,
+): Promise<boolean> {
+  if (!ensureVapid()) {
+    console.warn("[push] VAPID keys not set — skipping push send");
+    return false;
+  }
+
+  try {
+    await webpush.sendNotification(
+      {
+        endpoint: target.endpoint,
+        keys: { p256dh: target.p256dh, auth: target.auth },
+      },
+      JSON.stringify(payload),
+    );
+    return true;
+  } catch (error) {
+    const statusCode =
+      error && typeof error === "object" && "statusCode" in error
+        ? (error as { statusCode?: number }).statusCode
+        : undefined;
+
+    // 404/410 mean the push service has dropped this subscription for good.
+    // Remove it so we stop trying and the table doesn't fill with dead rows.
+    if (statusCode === 404 || statusCode === 410) {
+      await prisma.pushSubscription
+        .deleteMany({ where: { endpoint: target.endpoint } })
+        .catch(() => {});
+      return false;
+    }
+
+    console.error("[push] send failed", { endpoint: target.endpoint, error });
+    return false;
+  }
+}
+
+/**
+ * Send a push notification to every subscription a user has (one per device).
+ *
+ * NO-OP when VAPID keys are unset (logs once, returns 0) or when `userId` is
+ * null/empty. Returns the number of subscriptions successfully delivered to.
+ */
+export async function sendPush(
+  userId: string | null | undefined,
+  payload: PushPayload,
+): Promise<number> {
+  if (!isPushConfigured()) {
+    console.warn("[push] VAPID keys not set — skipping push send");
+    return 0;
+  }
+  if (!userId) return 0;
+
+  const subscriptions = await prisma.pushSubscription.findMany({
+    where: { userId },
+    select: { endpoint: true, p256dh: true, auth: true },
+  });
+
+  if (subscriptions.length === 0) return 0;
+
+  const results = await Promise.all(
+    subscriptions.map((sub) => sendPushToSubscription(sub, payload)),
+  );
+  return results.filter(Boolean).length;
+}


### PR DESCRIPTION
## Summary

Implements issue #38 — **Web Push notifications** when a report's status changes. This is **complementary** to the existing email path (`src/lib/email`), not a replacement.

The entire feature is **ENV-GATED on a VAPID key pair** and **ready-to-activate**: with `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` unset, `sendPush` is a **no-op** (logs and returns) and the opt-in UI hides itself, so the app runs unchanged. Set the keys to turn it on.

## Flow

1. User opens the dashboard and clicks **"Notify me of status updates"** (the `PushOptIn` button, which self-hides when push is unavailable).
2. The browser requests Notification permission, creates a `PushManager` subscription with the VAPID public key, and POSTs it to **`/api/push/subscribe`**, which upserts a `PushSubscription` row on the unique `endpoint` (nullable `userId` from the session — guests can subscribe).
3. The **`/api/cron/poll-status`** cron detects a real status advance for a report and calls **`sendPush(report.userId, …)`**, which looks up that user's subscriptions and sends via `web-push`. A push failure never blocks or fails the poll; dead subscriptions (404/410) are pruned.
4. The **service worker** (`public/sw.js`) receives the `push` event and shows a notification; `notificationclick` focuses/opens the report.
5. **`/api/push/unsubscribe`** removes a subscription on opt-out.

## No-op without VAPID keys

`sendPush` / `sendPushToSubscription` check `isPushConfigured()` (both VAPID keys present). When unset they log `[push] VAPID keys not set — skipping push send` and return `0`/`false` without any network or DB activity. The client `PushOptIn` component renders nothing when `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is absent or the browser/permission can't support push.

## What was added

- `prisma/schema.prisma` — `PushSubscription` model + back-relation on `User`.
- `prisma/migrations/20260609120000_add_push_subscription/migration.sql`.
- `src/app/api/push/subscribe/route.ts` + `unsubscribe/route.ts`.
- `public/sw.js` — `push` + `notificationclick` handlers (appended to the existing PWA SW).
- `src/lib/push/index.ts` — `sendPush` / `sendPushToSubscription` / `isPushConfigured` (the env-gated `web-push` helper).
- `src/lib/push/client.ts` — browser subscribe/unsubscribe helpers.
- `src/components/push-opt-in.tsx` — dashboard opt-in button (wired into `src/app/dashboard/page.tsx`).
- `src/app/api/cron/poll-status/route.ts` — fires `sendPush` on a real status advance.
- `.env.example` — documents the VAPID vars and `npx web-push generate-vapid-keys`.

## Env vars (all optional; unset = no-op)

| Var | Purpose |
| --- | --- |
| `VAPID_PUBLIC_KEY` | Application server public key (server) |
| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | Same public key, exposed to the browser to subscribe |
| `VAPID_PRIVATE_KEY` | Application server private key (server only) |
| `VAPID_SUBJECT` | `mailto:`/`https:` contact URL (optional; defaults to `mailto:noreply@nexa.app`) |

Generate with: `npx web-push generate-vapid-keys`.

## Tests

- `src/lib/push/index.test.ts` — env-gated no-op (no keys → returns 0, no DB lookup), configured detection, null-userId short-circuit.
- `src/app/api/push/subscribe/route.test.ts` — upsert with session userId, null userId for guests, 400 on missing keys.

## Verification (GREEN)

- `npx tsc --noEmit` — passes
- `npm run lint` — no new errors (only 2 pre-existing `<img>` warnings in untouched files)
- `npm run format:check` — passes
- `npm test` — 344 passed (incl. 6 new)
- `npm run build` — succeeds with `DATABASE_URL` set; both push routes appear in the route manifest. (Build's page-data collection requires `DATABASE_URL`, a pre-existing env requirement satisfied on Vercel.)
