### PR TITLE
fix(classify): two-stage analysis + conservative consensus/observation tuning [#96]

### DIFF
--- a/nexa/eval/metrics.ts
+++ b/nexa/eval/metrics.ts
@@ -148,3 +148,112 @@ export function diffReport(
   );
   return lines.join("\n");
 }
+
+/** A single case whose correctness flipped between two eval modes. */
+export interface FlipCase {
+  caseId: string;
+  expected: IssueType;
+  baselinePredicted: IssueType;
+  candidatePredicted: IssueType;
+}
+
+export interface FlipReport {
+  /** baseline wrong → candidate right (the candidate's wins) */
+  gained: FlipCase[];
+  /** baseline right → candidate wrong (the candidate's regressions) */
+  regressed: FlipCase[];
+  /** per-expected-class net accuracy delta the candidate introduced */
+  perClassDelta: Record<
+    string,
+    { support: number; gained: number; regressed: number; netCases: number }
+  >;
+}
+
+/**
+ * Diff two modes' per-case predictions to surface the exact cases that flipped
+ * and the per-category contribution of those flips. This is what makes the
+ * two-stage regression in issue #96 measurable and inspectable: the headline
+ * accuracy delta alone hides which categories the observation stage helped vs
+ * hurt. Acceptance criterion: an ablation/diff documenting the observation's
+ * per-category accuracy delta.
+ *
+ * Both prediction arrays must come from the same dataset; cases present in only
+ * one are ignored (a mode may SKIP a case on a transient API error).
+ */
+export function flipReport(
+  baseline: CasePrediction[],
+  candidate: CasePrediction[],
+): FlipReport {
+  const candById = new Map(candidate.map((p) => [p.caseId, p]));
+  const gained: FlipCase[] = [];
+  const regressed: FlipCase[] = [];
+  const perClassDelta: FlipReport["perClassDelta"] = {};
+
+  for (const b of baseline) {
+    const c = candById.get(b.caseId);
+    if (!c) continue;
+    const cls = (perClassDelta[b.expected] ??= {
+      support: 0,
+      gained: 0,
+      regressed: 0,
+      netCases: 0,
+    });
+    cls.support++;
+    if (!b.ok && c.ok) {
+      gained.push({
+        caseId: b.caseId,
+        expected: b.expected,
+        baselinePredicted: b.predicted,
+        candidatePredicted: c.predicted,
+      });
+      cls.gained++;
+      cls.netCases++;
+    } else if (b.ok && !c.ok) {
+      regressed.push({
+        caseId: b.caseId,
+        expected: b.expected,
+        baselinePredicted: b.predicted,
+        candidatePredicted: c.predicted,
+      });
+      cls.regressed++;
+      cls.netCases--;
+    }
+  }
+
+  return { gained, regressed, perClassDelta };
+}
+
+export function renderFlipReport(
+  candidateLabel: string,
+  report: FlipReport,
+): string {
+  const lines: string[] = [];
+  lines.push(`\n=== ${candidateLabel}: per-case flips vs baseline ===`);
+  lines.push(
+    `Gained (baseline wrong → ${candidateLabel} right): ${report.gained.length}`,
+  );
+  for (const f of report.gained) {
+    lines.push(
+      `  + ${f.caseId.slice(0, 50).padEnd(50)} ${f.baselinePredicted} → ${f.candidatePredicted}  (expected ${f.expected})`,
+    );
+  }
+  lines.push(
+    `Regressed (baseline right → ${candidateLabel} wrong): ${report.regressed.length}`,
+  );
+  for (const f of report.regressed) {
+    lines.push(
+      `  - ${f.caseId.slice(0, 50).padEnd(50)} ${f.baselinePredicted} → ${f.candidatePredicted}  (expected ${f.expected})`,
+    );
+  }
+
+  lines.push("\nPer-class net contribution of the candidate stage:");
+  const classes = Object.keys(report.perClassDelta).sort();
+  for (const cls of classes) {
+    const d = report.perClassDelta[cls];
+    const sign = d.netCases > 0 ? "+" : "";
+    lines.push(
+      `  ${cls.padEnd(22)} support=${String(d.support).padStart(3)}  +${d.gained} −${d.regressed}  net=${sign}${d.netCases} case(s)`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/nexa/eval/results/SUMMARY.md
+++ b/nexa/eval/results/SUMMARY.md
@@ -88,3 +88,99 @@ npm run eval
 
 Raw per-case predictions land in `eval/results/{baseline,two-stage}.json`
 (gitignored).
+
+---
+
+## Investigation: two-stage regression (issue #96)
+
+The headline above shows two-stage regressing −2.6 pp, driven entirely by three
+`X → OTHER` flips after the stage-1 observation pass:
+
+| Case                                            | Baseline           | Two-stage |
+| ----------------------------------------------- | ------------------ | --------- |
+| `Flood_damage_in_American_Fork_Canyon_..._2023` | ROAD_DAMAGE        | OTHER     |
+| `Vddj-1.jpg`                                    | ROAD_DAMAGE        | OTHER     |
+| `M_Infraestrutura.jpg`                          | STREETLIGHT_OUTAGE | OTHER     |
+
+### Static analysis of plausible causes
+
+1. **Low-signal observation poisoning the prompt (most likely).** All three
+   regressions flip _to_ OTHER, and OTHER is the "doesn't clearly fit"
+   bucket. `renderObservation` previously emitted a `Stage-1 visual
+observations:` header even when the observation carried no concrete
+   objects/conditions/hazards. An empty-but-present block adds no grounding yet
+   primes the classifier to expect that "the structured observation didn't find
+   anything definitive" — a nudge toward hedging. The stage-1 model
+   (`gpt-4o-mini`, `detail: "low"`, 250 max tokens) is exactly the case most
+   likely to return a thin observation on a hard image (flood-damaged road,
+   distant streetlight).
+
+2. **No quality gate on stage 1.** `observeImage` has no confidence/quality
+   threshold — any successfully-parsed observation, however thin, is fed
+   forward. A blurry/empty image legitimately yields empty arrays (the prompt
+   says so), and that empty result was still rendered into the prompt.
+
+3. **Consensus tie-break was order-dependent.** `pickWinner`'s
+   highest-confidence and majority paths used `reduce(... a.confidence >= b.confidence ...)`,
+   which on an exact confidence tie keeps whichever provider responded first in
+   the `Promise.all` array (openai, anthropic, google). That is an undocumented
+   tiebreaker that could move with provider ordering. (Note: the tiebreaker
+   fired 5× in baseline and 0× in two-stage, so it is _not_ the direct cause of
+   these three flips — but it is a latent determinism bug worth fixing while
+   here.)
+
+4. **Preprocessing** (downscale + EXIF) is unlikely to cause classification
+   flips on its own — it mainly fixed the Anthropic 5 MB rejections and added
+   EXIF GPS. Ruled out as a regression cause.
+
+### Conservative changes shipped in this PR
+
+These are behavior-safe and justifiable _without_ new eval data — none can move
+two-stage _away_ from baseline:
+
+- **Observation quality gate** (`observe.ts`): `renderObservation` now drops an
+  observation carrying fewer than `MIN_OBSERVATION_SIGNALS` (= 1) concrete
+  signals — i.e. a zero-signal observation collapses the stage-2 prompt back to
+  the exact baseline single-stage prompt. `scene` is deliberately excluded from
+  the signal count (the prompt fills it even for empty images).
+  `MIN_OBSERVATION_SIGNALS` is exposed as a tunable constant; raising it trades
+  grounding for safety and MUST be validated empirically before changing.
+- **Deterministic consensus tie-break** (`consensus.ts`): `pickWinner` now
+  breaks exact confidence ties by lexicographic provider name and picks the
+  majority block deterministically (votes → peak confidence → issue type),
+  removing the dependency on provider call order. Behavior-preserving whenever
+  there is a clear confidence max.
+- **Measurable eval reporting** (`eval/run.ts`, `eval/metrics.ts`): a new
+  per-case flip diff (`flipReport` / `renderFlipReport`) prints, and writes
+  `eval/results/flips.json`, the exact gained/regressed cases plus the
+  per-category net contribution of the observation stage — so the regression is
+  inspectable, not just a single accuracy number.
+
+### REQUIRED empirical validation (human / CI step)
+
+This environment has **no live LLM API keys**, so the numbers above were NOT
+re-measured and the gate's effect on the three flips is a hypothesis, not a
+result. Before relying on these changes:
+
+```bash
+cd nexa
+cp .env.example .env.local   # fill in OPENAI / ANTHROPIC / GOOGLE keys
+npm run eval:fetch:download
+npm run eval                 # --mode=both: emits the flip diff + flips.json
+# or run the two modes separately for a clean A/B:
+npm run eval:baseline
+npm run eval:two-stage
+```
+
+Then confirm against the issue-#96 acceptance criteria:
+
+- [ ] The three known regressions (`Flood_damage…`, `Vddj-1`, `M_Infraestrutura`)
+      no longer flip to OTHER, OR the trade-off is recorded here.
+- [ ] Overall two-stage accuracy ≥ baseline (and ≥ 80% per O1.KR1).
+- [ ] ROAD_DAMAGE per-class accuracy not regressed vs the 100% baseline.
+- [ ] `eval/results/flips.json` shows the per-category observation delta.
+
+If the gate alone does not recover all three, the next lever to evaluate
+(empirically) is raising `MIN_OBSERVATION_SIGNALS`, or adding a stage-1
+confidence signal to the observation schema — do **not** ship either without
+eval data.

--- a/nexa/eval/run.ts
+++ b/nexa/eval/run.ts
@@ -27,6 +27,8 @@ import type { DatasetCase } from "./dataset/fetch";
 import {
   aggregate,
   diffReport,
+  flipReport,
+  renderFlipReport,
   renderReport,
   type CasePrediction,
 } from "./metrics";
@@ -172,10 +174,13 @@ async function main() {
 
   let baselineMetrics = null;
   let twoStageMetrics = null;
+  let baselinePreds: CasePrediction[] | null = null;
+  let twoStagePreds: CasePrediction[] | null = null;
 
   if (args.mode === "baseline" || args.mode === "both") {
     console.log(`\n>>> Baseline (single-stage), n=${cases.length}`);
     const preds = await runMode(cases, false, args.download);
+    baselinePreds = preds;
     baselineMetrics = aggregate(preds);
     await writeFile(
       path.join(RESULTS_DIR, "baseline.json"),
@@ -199,6 +204,7 @@ async function main() {
       `\n>>> Two-stage (preprocess + observe + classify), n=${cases.length}`,
     );
     const preds = await runMode(cases, true, args.download);
+    twoStagePreds = preds;
     twoStageMetrics = aggregate(preds);
     await writeFile(
       path.join(RESULTS_DIR, "two-stage.json"),
@@ -220,6 +226,20 @@ async function main() {
   if (baselineMetrics && twoStageMetrics) {
     console.log(
       diffReport("Baseline", baselineMetrics, "Two-stage", twoStageMetrics),
+    );
+  }
+
+  // Per-case flip diff: which exact cases the observation stage helped vs hurt,
+  // and the per-category net contribution. This is the inspectable artifact the
+  // regression investigation (issue #96) needs — run with --mode=both so both
+  // prediction sets exist in one process.
+  if (baselinePreds && twoStagePreds) {
+    const flips = flipReport(baselinePreds, twoStagePreds);
+    console.log(renderFlipReport("Two-stage", flips));
+    await writeFile(
+      path.join(RESULTS_DIR, "flips.json"),
+      JSON.stringify({ ranAt: new Date().toISOString(), ...flips }, null, 2) +
+        "\n",
     );
   }
 }

--- a/nexa/src/lib/classify/consensus.test.ts
+++ b/nexa/src/lib/classify/consensus.test.ts
@@ -143,6 +143,73 @@ describe("classifyWithConsensus — voting (pickWinner)", () => {
     },
   );
 
+  it("breaks an exact confidence tie deterministically by provider name, not call order", async () => {
+    // Arrange: a three-way disagreement where every provider reports the SAME
+    // confidence. The old reduce kept the first array element (openai, by
+    // Promise.all order) — an undocumented, order-dependent tiebreaker. The new
+    // rule prefers the lexicographically smallest provider name on a tie:
+    // anthropic < google < openai, so anthropic must win regardless of order.
+    openaiMock.mockResolvedValue(
+      makeProvider({
+        provider: "openai",
+        issueType: "ROAD_DAMAGE",
+        confidence: 0.8,
+      }),
+    );
+    anthropicMock.mockResolvedValue(
+      makeProvider({
+        provider: "anthropic",
+        issueType: "OTHER",
+        confidence: 0.8,
+      }),
+    );
+    googleMock.mockResolvedValue(
+      makeProvider({
+        provider: "google",
+        issueType: "ILLEGAL_DUMPING",
+        confidence: 0.8,
+      }),
+    );
+
+    // Act
+    const result = await classifyWithConsensus("desc", null);
+
+    // Assert: anthropic (smallest provider name) wins the tie, not openai.
+    expect(result.method).toBe("highest-confidence");
+    expect(result.winner.issueType).toBe("OTHER");
+  });
+
+  it("majority block's peak confidence wins, not the array-order first vote", async () => {
+    // Arrange: ROAD_DAMAGE has the 2-vote plurality. Verify the winner is the
+    // ROAD_DAMAGE result with the higher confidence (peak), selected
+    // deterministically rather than by call order within the group.
+    openaiMock.mockResolvedValue(
+      makeProvider({ provider: "openai", issueType: "OTHER", confidence: 0.6 }),
+    );
+    anthropicMock.mockResolvedValue(
+      makeProvider({
+        provider: "anthropic",
+        issueType: "ROAD_DAMAGE",
+        confidence: 0.7,
+      }),
+    );
+    googleMock.mockResolvedValue(
+      makeProvider({
+        provider: "google",
+        issueType: "ROAD_DAMAGE",
+        confidence: 0.55,
+      }),
+    );
+
+    // Act
+    const result = await classifyWithConsensus("desc", null);
+
+    // Assert: ROAD_DAMAGE has the 2-vote majority; its peak (0.7) wins.
+    expect(result.method).toBe("majority");
+    expect(result.winner.issueType).toBe("ROAD_DAMAGE");
+    expect(result.winner.confidence).toBe(0.7);
+  });
+
   it("strips provider/latencyMs from the winner (toClassification)", async () => {
     // Arrange
     const winning = makeProvider({ confidence: 0.99 });

--- a/nexa/src/lib/classify/consensus.ts
+++ b/nexa/src/lib/classify/consensus.ts
@@ -53,6 +53,35 @@ function toClassification(r: ProviderResult): ClassificationResult {
   };
 }
 
+/**
+ * Pick the highest-confidence result, breaking exact confidence ties
+ * deterministically.
+ *
+ * The previous `reduce((a, b) => a.confidence >= b.confidence ? a : b)` had two
+ * subtle problems (issue #96):
+ *   1. On an exact confidence tie it kept whichever element appeared first in
+ *      `results`, so the outcome depended on the provider call order — a hidden,
+ *      undocumented tiebreaker.
+ *   2. That order is the array order from `Promise.all` (openai, anthropic,
+ *      google), which is stable today but is an implementation detail, not an
+ *      intended policy.
+ *
+ * We make the tiebreaker explicit and stable: on equal confidence, prefer the
+ * lexicographically smaller `provider` name. This is a deterministic,
+ * documented rule that does not depend on call ordering, so identical inputs
+ * always yield the identical winner regardless of which provider responded
+ * first. It is behavior-preserving for the common case (a clear confidence
+ * max) and only changes the previously-arbitrary tie case.
+ */
+function bestByConfidence(results: ProviderResult[]): ProviderResult {
+  return results.reduce((best, r) => {
+    if (r.confidence > best.confidence) return r;
+    if (r.confidence === best.confidence && r.provider < best.provider)
+      return r;
+    return best;
+  });
+}
+
 function pickWinner(valid: ProviderResult[]): {
   winner: ClassificationResult;
   method: ComparisonResult["method"];
@@ -60,8 +89,10 @@ function pickWinner(valid: ProviderResult[]): {
   const issueTypes = valid.map((r) => r.issueType);
   const allSame = issueTypes.every((t) => t === issueTypes[0]);
   if (allSame) {
-    const best = valid.reduce((a, b) => (a.confidence >= b.confidence ? a : b));
-    return { winner: toClassification(best), method: "unanimous" };
+    return {
+      winner: toClassification(bestByConfidence(valid)),
+      method: "unanimous",
+    };
   }
   const counts = new Map<string, ProviderResult[]>();
   for (const r of valid) {
@@ -69,16 +100,35 @@ function pickWinner(valid: ProviderResult[]): {
     arr.push(r);
     counts.set(r.issueType, arr);
   }
-  for (const [, group] of counts) {
-    if (group.length >= 2) {
-      const best = group.reduce((a, b) =>
-        a.confidence >= b.confidence ? a : b,
-      );
-      return { winner: toClassification(best), method: "majority" };
+  // Pick the strongest majority block deterministically: among issue types with
+  // >= 2 votes, prefer more votes, then higher peak confidence, then
+  // lexicographic issue type. Previously the first >=2 group encountered in
+  // Map-iteration (i.e. provider-call) order won, which was order-dependent
+  // whenever two distinct types each drew two votes.
+  let bestMajority: { group: ProviderResult[]; peak: ProviderResult } | null =
+    null;
+  for (const group of counts.values()) {
+    if (group.length < 2) continue;
+    const peak = bestByConfidence(group);
+    if (
+      bestMajority === null ||
+      group.length > bestMajority.group.length ||
+      (group.length === bestMajority.group.length &&
+        peak.confidence > bestMajority.peak.confidence) ||
+      (group.length === bestMajority.group.length &&
+        peak.confidence === bestMajority.peak.confidence &&
+        peak.issueType < bestMajority.peak.issueType)
+    ) {
+      bestMajority = { group, peak };
     }
   }
-  const best = valid.reduce((a, b) => (a.confidence >= b.confidence ? a : b));
-  return { winner: toClassification(best), method: "highest-confidence" };
+  if (bestMajority) {
+    return { winner: toClassification(bestMajority.peak), method: "majority" };
+  }
+  return {
+    winner: toClassification(bestByConfidence(valid)),
+    method: "highest-confidence",
+  };
 }
 
 function mergeLocation(

--- a/nexa/src/lib/classify/observe.test.ts
+++ b/nexa/src/lib/classify/observe.test.ts
@@ -199,8 +199,8 @@ describe("renderObservation", () => {
     expect(out).toContain("  Hazards: trip hazard");
   });
 
-  it("excludes empty arrays and empty scene", () => {
-    // Arrange
+  it("drops a fully-empty observation entirely (no header) so stage 2 falls back to baseline", () => {
+    // Arrange: no objects/conditions/hazards and no scene — zero signal.
     const sparse: Observation = {
       objects: [],
       conditions: [],
@@ -212,9 +212,43 @@ describe("renderObservation", () => {
     // Act
     const out = renderObservation(sparse);
 
-    // Assert: only the header line remains.
-    expect(out).toBe("\nStage-1 visual observations:");
-    expect(out).not.toContain("Scene:");
-    expect(out).not.toContain("Objects:");
+    // Assert (issue #96 quality gate): a zero-signal observation is dropped to
+    // "" rather than emitting a content-free "Stage-1 visual observations:"
+    // header that could bias the classifier toward OTHER.
+    expect(out).toBe("");
+  });
+
+  it("drops a scene-only observation (scene is not a usable signal)", () => {
+    // Arrange: a vague scene with no concrete objects/conditions/hazards. The
+    // stage-1 prompt fills `scene` even for blurry/empty images, so scene alone
+    // is not evidence of usable grounding.
+    const sceneOnly: Observation = {
+      objects: [],
+      conditions: [],
+      hazards: [],
+      scene: "A blurry outdoor photo.",
+      latencyMs: 5,
+    };
+
+    // Act / Assert
+    expect(renderObservation(sceneOnly)).toBe("");
+  });
+
+  it("keeps an observation with at least one concrete signal", () => {
+    // Arrange: one object is enough to clear MIN_OBSERVATION_SIGNALS.
+    const oneSignal: Observation = {
+      objects: ["pothole"],
+      conditions: [],
+      hazards: [],
+      scene: "",
+      latencyMs: 5,
+    };
+
+    // Act
+    const out = renderObservation(oneSignal);
+
+    // Assert
+    expect(out).toContain("\nStage-1 visual observations:");
+    expect(out).toContain("  Objects: pothole");
   });
 });

--- a/nexa/src/lib/classify/observe.ts
+++ b/nexa/src/lib/classify/observe.ts
@@ -11,6 +11,39 @@ export interface Observation {
   latencyMs: number;
 }
 
+/**
+ * Minimum number of concrete signal items (objects + conditions + hazards) an
+ * observation must carry before its block is allowed into the stage-2 prompt.
+ *
+ * Rationale (see issue #96): a near-empty observation — e.g. only a vague
+ * `scene` line and no objects/conditions/hazards — adds no grounding but still
+ * occupies prompt space under a "Stage-1 visual observations:" header. That
+ * header alone can nudge a classifier toward hedging (OTHER) on an image it
+ * would otherwise have classified confidently. Gating it out lets stage 2 fall
+ * back to its own vision, identical to the baseline single-stage prompt.
+ *
+ * This threshold is intentionally conservative: 1 means "drop only the
+ * genuinely empty observation." Raising it trades grounding for safety and
+ * MUST be validated empirically against the eval set before changing (see the
+ * empirical-validation note in the PR / SUMMARY.md). Do not raise it blindly.
+ */
+export const MIN_OBSERVATION_SIGNALS = 1;
+
+/**
+ * Count the concrete, classifier-useful signals in an observation. The `scene`
+ * sentence is deliberately excluded: it is free-form prose that the stage-1
+ * prompt asks the model to fill in even for a blurry/empty image ("say so in
+ * scene and return empty arrays"), so a non-empty scene is NOT evidence that
+ * the observation carries usable grounding.
+ */
+export function observationSignalCount(observation: Observation): number {
+  return (
+    observation.objects.length +
+    observation.conditions.length +
+    observation.hazards.length
+  );
+}
+
 // Runtime contract for the stage-1 observation JSON. The prompt explicitly
 // permits empty arrays / an empty scene for a blurry-or-empty image, so missing
 // keys default to empty — that is a legitimate observation, not a failure. What
@@ -109,9 +142,17 @@ export async function observeImage(
  * Render an observation into a compact text block that can be appended to the
  * stage-2 classification prompt. Centralised so all three providers see the
  * same grounding text.
+ *
+ * Returns "" — i.e. the prompt collapses to the baseline single-stage prompt —
+ * when the observation is null OR carries fewer than `MIN_OBSERVATION_SIGNALS`
+ * concrete signals. A low-signal observation is dropped rather than allowed to
+ * poison stage 2 with a content-free "Stage-1 visual observations:" header
+ * (issue #96). This is a behavior-safe guard: dropping a low-signal block can
+ * only move two-stage closer to baseline, never further from it.
  */
 export function renderObservation(observation: Observation | null): string {
   if (!observation) return "";
+  if (observationSignalCount(observation) < MIN_OBSERVATION_SIGNALS) return "";
   const lines: string[] = ["\nStage-1 visual observations:"];
   if (observation.scene) lines.push(`  Scene: ${observation.scene}`);
   if (observation.objects.length > 0)


### PR DESCRIPTION
Closes #96.

## Constraint
This environment has **no live LLM API keys**, so the classification eval was **not** re-run and no new accuracy numbers were measured. This PR is a careful static analysis plus conservative, behavior-safe changes, with the empirical validation step documented as a human/CI activity. No eval numbers were fabricated.

## Analysis — why two-stage regresses (from `eval/results/SUMMARY.md`)
The reported regression (92.1% → 89.5%, ROAD_DAMAGE 100% → 92%) is driven entirely by **three `X → OTHER` flips** after the stage-1 observation pass:

| Case | Baseline | Two-stage |
| --- | --- | --- |
| `Flood_damage_in_American_Fork_Canyon_…_2023` | ROAD_DAMAGE | OTHER |
| `Vddj-1.jpg` | ROAD_DAMAGE | OTHER |
| `M_Infraestrutura.jpg` | STREETLIGHT_OUTAGE | OTHER |

Plausible causes, ranked:

1. **Low-signal observation poisoning the stage-2 prompt (most likely).** All three flips go *to* OTHER (the "doesn't clearly fit" bucket). `renderObservation` previously emitted a `Stage-1 visual observations:` header even when the observation carried no concrete objects/conditions/hazards — a content-free block that primes the classifier to hedge. The stage-1 model (`gpt-4o-mini`, `detail:"low"`, 250 tokens) is exactly the configuration most likely to return a thin observation on a hard image.
2. **No quality gate on stage 1.** Any successfully-parsed observation, however thin, was fed forward. The prompt legitimately returns empty arrays for blurry/empty images, and that empty result was still rendered.
3. **Consensus tie-break was order-dependent.** `pickWinner` used `reduce(... a.confidence >= b.confidence ...)`, which on an exact confidence tie kept whichever provider responded first in the `Promise.all` array — an undocumented tiebreaker. (It fired 5× baseline / 0× two-stage, so it is a latent determinism bug, not the direct cause of the three flips.)
4. **Preprocessing** (downscale + EXIF) is ruled out as a classification-flip cause; it mainly fixed Anthropic 5 MB rejections and added EXIF GPS.

## Conservative changes (justifiable without eval data — none can move two-stage *away* from baseline)
- **`observe.ts` — observation quality gate.** `renderObservation` drops an observation carrying fewer than `MIN_OBSERVATION_SIGNALS` (= 1) concrete signals, collapsing the stage-2 prompt back to the exact baseline single-stage prompt. `scene` is excluded from the signal count (the prompt fills it even for empty images). `MIN_OBSERVATION_SIGNALS` is exported as a tunable constant; raising it trades grounding for safety and must be validated empirically.
- **`consensus.ts` — deterministic tie-break.** `pickWinner` now breaks exact confidence ties by lexicographic provider name and selects the majority block deterministically (votes → peak confidence → issue type). Behavior-preserving whenever there is a clear confidence max; only the previously-arbitrary tie case changes.
- **`eval/run.ts` + `eval/metrics.ts` — measurable reporting.** New `flipReport`/`renderFlipReport` print and persist (`eval/results/flips.json`) the exact gained/regressed cases plus the per-category net contribution of the observation stage, so the regression is inspectable rather than a single number.

## Tests
- Added unit tests for the observation gate (zero-signal and scene-only dropped; one-signal kept) and for the deterministic tie-break (provider-name tie; majority peak).
- The pinned classify unit tests were not changed in intent — the existing scenarios still pass unchanged.
- Full suite: **350 passed**.

## REQUIRED empirical validation (human / CI)
Run with real keys and compare:
```bash
cd nexa
cp .env.example .env.local   # fill OPENAI / ANTHROPIC / GOOGLE
npm run eval:fetch:download
npm run eval                 # --mode=both: prints flip diff + writes flips.json
# or A/B separately:
npm run eval:baseline
npm run eval:two-stage
```
Then confirm against #96 acceptance criteria:
- [ ] The three known regressions no longer flip to OTHER (or the trade-off is recorded).
- [ ] Overall two-stage accuracy ≥ baseline and ≥ 80% (O1.KR1).
- [ ] ROAD_DAMAGE per-class accuracy not regressed.
- [ ] `eval/results/flips.json` shows the per-category observation delta.

If the gate alone does not recover all three, the next lever to evaluate empirically is raising `MIN_OBSERVATION_SIGNALS` or adding a stage-1 confidence signal — neither shipped here without data.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated)
- `npm run format:check` — clean
- `npm test` — 350 passed