### PR TITLE
feat(submission): email submission agent for EMAIL-intake agencies (env-gated) [#31]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -34,10 +34,24 @@ NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # --- Email (Brevo) ---
+# Citizen-facing NOTIFICATION emails (welcome / report status updates).
 # Create a free account at https://app.brevo.com, then generate an API key under
 # Settings → SMTP & API → API Keys. BREVO_SENDER_EMAIL must be a verified sender.
 BREVO_API_KEY=
 BREVO_SENDER_EMAIL=noreply@nexa.app
+
+# --- Email submission agent (Resend) ---
+# AGENCY-facing SUBMISSION emails: for agencies whose intakeMethod is EMAIL, the
+# submission orchestrator composes a report email (photo attached) to the
+# agency's intakeEmail and sends it via Resend. This is SEPARATE from the Brevo
+# notification path above.
+# ENV-GATED: when RESEND_API_KEY is unset the agent is a no-op — the orchestrator
+# falls back to the manual-assist path, so EMAIL-intake reports stay CONFIRMED
+# rather than failing. Set BOTH vars to activate automated email submission.
+# Create an account at https://resend.com, add an API key, and use a verified
+# domain sender for SUBMISSION_FROM_EMAIL.
+RESEND_API_KEY=
+SUBMISSION_FROM_EMAIL=reports@nexa.app
 
 # --- Manual reminder job ---
 # Protects POST /api/reports/send-follow-up-reminders. Generate with:

--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -29,6 +29,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-leaflet": "^5.0.0",
+        "resend": "^6.12.4",
         "shadcn": "^4.3.1",
         "sharp": "^0.34.5",
         "tailwind-merge": "^3.5.0",
@@ -11349,6 +11350,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -11966,6 +11973,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -52,6 +52,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-leaflet": "^5.0.0",
+    "resend": "^6.12.4",
     "shadcn": "^4.3.1",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",

--- a/nexa/src/lib/submission/email.test.ts
+++ b/nexa/src/lib/submission/email.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IssueType } from "@/generated/prisma/enums";
+
+import {
+  composeSubmissionEmail,
+  submitViaEmail,
+  type EmailSubmittableReport,
+} from "./email";
+
+// A report with every field present; tests override only what they exercise.
+function makeEmailReport(
+  overrides: Partial<EmailSubmittableReport> = {},
+): EmailSubmittableReport {
+  return {
+    id: "report_1",
+    issueType: IssueType.ROAD_DAMAGE,
+    description: "Large pothole on University Ave",
+    aiDescription: "AI: a deep pothole",
+    latitude: 37.4419,
+    longitude: -122.143,
+    address: "University Ave, Palo Alto, CA",
+    imageUrl: "https://cdn.example.com/photos/abc123.png",
+    ...overrides,
+  };
+}
+
+// The minimal client shape submitViaEmail accepts. We pass a `vi.fn()` for
+// `send` and cast, since the real overloaded signature is irrelevant to these
+// dispatch tests.
+type FakeSend = ReturnType<typeof vi.fn>;
+function fakeResend(
+  send: FakeSend,
+): Parameters<typeof submitViaEmail>[1]["resendClient"] {
+  return { emails: { send } } as unknown as Parameters<
+    typeof submitViaEmail
+  >[1]["resendClient"];
+}
+
+// The first payload passed to a fake `send`. `vi.fn()` has no call signature, so
+// its `mock.calls` tuple is typed empty — read through `unknown` to inspect it.
+function firstSendPayload(send: FakeSend): unknown {
+  return (send.mock.calls as unknown as unknown[][])[0][0];
+}
+
+// A fetch stub for the photo download that returns a small PNG-ish payload.
+function fakePhotoFetch(): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+  })) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  delete process.env.RESEND_API_KEY;
+  delete process.env.SUBMISSION_FROM_EMAIL;
+  vi.restoreAllMocks();
+});
+
+describe("composeSubmissionEmail", () => {
+  it("includes issue type, location, coordinates, and description", () => {
+    // Arrange / Act
+    const email = composeSubmissionEmail(makeEmailReport(), {
+      agencyName: "Palo Alto Public Works",
+    });
+
+    // Assert
+    expect(email.subject).toContain("Road Damage");
+    expect(email.text).toContain("Issue type: Road Damage");
+    expect(email.text).toContain("University Ave, Palo Alto, CA");
+    expect(email.text).toContain("37.4419, -122.143");
+    expect(email.text).toContain("Large pothole on University Ave");
+    expect(email.text).toContain("Palo Alto Public Works");
+    expect(email.text).toContain("A photo of the issue is attached");
+    expect(email.html).toContain("<strong>Issue type:</strong> Road Damage");
+  });
+
+  it("falls back to the AI description and notes a missing photo", () => {
+    // Arrange / Act
+    const email = composeSubmissionEmail(
+      makeEmailReport({ description: null, imageUrl: null }),
+      { agencyName: "City 311" },
+    );
+
+    // Assert
+    expect(email.text).toContain("AI: a deep pothole");
+    expect(email.text).toContain("No photo was provided");
+  });
+
+  it("escapes HTML in user-supplied content", () => {
+    // Arrange / Act
+    const email = composeSubmissionEmail(
+      makeEmailReport({ description: "<script>alert(1)</script>" }),
+      { agencyName: "City 311" },
+    );
+
+    // Assert: the raw tag must not survive into the HTML body.
+    expect(email.html).not.toContain("<script>");
+    expect(email.html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("submitViaEmail — env gating (no-op without config)", () => {
+  it("returns not_configured when RESEND_API_KEY is unset", async () => {
+    // Arrange: no key in the test env, and no injected client.
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "City 311",
+      intakeEmail: "311@city.gov",
+    });
+
+    // Assert
+    expect(result.status).toBe("not_configured");
+  });
+
+  it("returns not_configured when SUBMISSION_FROM_EMAIL is unset", async () => {
+    // Arrange: a client is available but the sender address is not configured.
+    const send = vi.fn();
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "City 311",
+      intakeEmail: "311@city.gov",
+      resendClient: fakeResend(send),
+    });
+
+    // Assert: env-gated off; no email attempted.
+    expect(result.status).toBe("not_configured");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("returns not_configured when the agency has no intake email", async () => {
+    // Arrange
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    const send = vi.fn();
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "City 311",
+      intakeEmail: null,
+      resendClient: fakeResend(send),
+    });
+
+    // Assert
+    expect(result.status).toBe("not_configured");
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("submitViaEmail — sending", () => {
+  it("sends a composed email with the photo attached and returns the message id", async () => {
+    // Arrange
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    const send = vi.fn(async () => ({ data: { id: "msg-123" }, error: null }));
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "Palo Alto Public Works",
+      intakeEmail: "311@paloalto.gov",
+      resendClient: fakeResend(send),
+      fetchImpl: fakePhotoFetch(),
+    });
+
+    // Assert
+    expect(result).toEqual({ status: "submitted", messageId: "msg-123" });
+    const payload = firstSendPayload(send) as {
+      from: string;
+      to: string;
+      subject: string;
+      attachments?: { filename: string }[];
+    };
+    expect(payload.from).toBe("reports@nexa.app");
+    expect(payload.to).toBe("311@paloalto.gov");
+    expect(payload.subject).toContain("Road Damage");
+    expect(payload.attachments).toHaveLength(1);
+    expect(payload.attachments?.[0].filename).toBe("abc123.png");
+  });
+
+  it("still sends (no attachment) when the photo download fails", async () => {
+    // Arrange
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    const send = vi.fn(async () => ({ data: { id: "msg-456" }, error: null }));
+    const failingFetch = vi.fn(async () => ({
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    })) as unknown as typeof fetch;
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "City 311",
+      intakeEmail: "311@city.gov",
+      resendClient: fakeResend(send),
+      fetchImpl: failingFetch,
+    });
+
+    // Assert: a missing photo never blocks the submission.
+    expect(result).toEqual({ status: "submitted", messageId: "msg-456" });
+    const payload = firstSendPayload(send) as { attachments?: unknown };
+    expect(payload.attachments).toBeUndefined();
+  });
+
+  it("returns an error when Resend rejects the message", async () => {
+    // Arrange
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    const send = vi.fn(async () => ({
+      data: null,
+      error: { name: "validation_error", message: "Invalid sender" },
+    }));
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport({ imageUrl: null }), {
+      agencyName: "City 311",
+      intakeEmail: "311@city.gov",
+      resendClient: fakeResend(send),
+    });
+
+    // Assert
+    expect(result).toEqual({ status: "error", message: "Invalid sender" });
+  });
+
+  it("returns an error when the transport throws", async () => {
+    // Arrange
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    const send = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport({ imageUrl: null }), {
+      agencyName: "City 311",
+      intakeEmail: "311@city.gov",
+      resendClient: fakeResend(send),
+    });
+
+    // Assert
+    expect(result).toEqual({ status: "error", message: "network down" });
+  });
+});

--- a/nexa/src/lib/submission/email.ts
+++ b/nexa/src/lib/submission/email.ts
@@ -1,0 +1,296 @@
+import { Resend } from "resend";
+
+import { IssueType } from "@/generated/prisma/enums";
+import { ISSUE_TYPE_LABELS } from "@/lib/constants";
+import {
+  fetchWithTimeout,
+  TimeoutError,
+  DEFAULT_HTTP_TIMEOUT_MS,
+} from "@/lib/http";
+
+// ---------------------------------------------------------------------------
+// Email submission agent (issue #31)
+//
+// For agencies whose `intakeMethod` is EMAIL, there is no machine API to file
+// against — the accepted channel is a human-readable email to the agency's
+// `intakeEmail`. This agent composes that email (report description, location,
+// issue type, and the photo as an attachment when present) and sends it via
+// Resend (https://resend.com).
+//
+// It is ENV-GATED: when `RESEND_API_KEY` is unset we never construct a client
+// or hit the network. Instead we return a typed `not_configured` result so the
+// orchestrator can fall back to the existing manual-assist path. The code is
+// complete and activates the moment the key (and `SUBMISSION_FROM_EMAIL`) are
+// set — no further changes required.
+//
+// This is the SUBMISSION email agent. It is distinct from `src/lib/email`,
+// which sends *notification* emails to the citizen (welcome / status updates)
+// via Brevo. Those two paths intentionally do not share infrastructure.
+//
+// Like `open311.ts`, this never throws to its caller: every outcome is a typed
+// discriminated result the orchestrator maps onto a submission outcome.
+// ---------------------------------------------------------------------------
+
+/** The subset of a Report this agent needs to compose a submission email. */
+export type EmailSubmittableReport = {
+  id: string;
+  issueType: IssueType | null;
+  description: string | null;
+  aiDescription: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  address: string | null;
+  imageUrl: string | null;
+};
+
+/** Discriminated result of an email submission attempt — never throws. */
+export type EmailSubmitResult =
+  | {
+      // The email was accepted by Resend. `messageId` is Resend's id for the
+      // sent message, which doubles as the report's external tracking id.
+      status: "submitted";
+      messageId: string;
+    }
+  | {
+      // The agent is not wired up (no RESEND_API_KEY, or no SUBMISSION_FROM_EMAIL,
+      // or the agency has no intakeEmail). The caller should degrade to the
+      // manual-assist path rather than treat this as a hard failure.
+      status: "not_configured";
+      reason: string;
+    }
+  | {
+      // A genuine send failure (network/timeout/Resend rejected the message).
+      status: "error";
+      message: string;
+    };
+
+/** A composed email ready to hand to a transport. */
+export type ComposedEmail = {
+  subject: string;
+  text: string;
+  html: string;
+};
+
+// The minimal slice of the Resend client this agent uses. Narrowing to just
+// `emails.send` keeps the injectable transport (for tests) small while staying
+// structurally compatible with a real `Resend` instance.
+type EmailSender = {
+  emails: { send: Resend["emails"]["send"] };
+};
+
+function issueTypeLabel(issueType: IssueType | null): string {
+  if (!issueType) return "Unspecified issue";
+  return ISSUE_TYPE_LABELS[issueType] ?? issueType;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Composes the report submission email — a plain-text body for maximum agency
+ * compatibility plus a simple HTML rendering. The photo, when present, is
+ * attached separately (see `submitViaEmail`); the body references it so a
+ * recipient knows to look for it.
+ */
+export function composeSubmissionEmail(
+  report: EmailSubmittableReport,
+  options: { agencyName: string },
+): ComposedEmail {
+  const label = issueTypeLabel(report.issueType);
+  // Prefer the citizen's own words; fall back to the AI-generated summary.
+  const description =
+    report.description?.trim() || report.aiDescription?.trim() || null;
+
+  const hasCoords =
+    typeof report.latitude === "number" && typeof report.longitude === "number";
+  const coords = hasCoords ? `${report.latitude}, ${report.longitude}` : null;
+
+  const subject = `New ${label} report — ${report.address?.trim() || "location attached"}`;
+
+  // --- Plain text -------------------------------------------------------
+  const lines: string[] = [
+    `A resident has submitted the following report via Nexa for ${options.agencyName}.`,
+    "",
+    `Issue type: ${label}`,
+  ];
+  if (report.address?.trim()) lines.push(`Location: ${report.address.trim()}`);
+  if (coords) lines.push(`Coordinates: ${coords}`);
+  lines.push("");
+  lines.push("Description:");
+  lines.push(description ?? "(No description provided.)");
+  lines.push("");
+  lines.push(
+    report.imageUrl
+      ? "A photo of the issue is attached to this email."
+      : "No photo was provided with this report.",
+  );
+  lines.push("");
+  lines.push(`Nexa reference: ${report.id}`);
+  const text = lines.join("\n");
+
+  // --- HTML -------------------------------------------------------------
+  const htmlParts: string[] = [
+    `<p>A resident has submitted the following report via Nexa for ${escapeHtml(options.agencyName)}.</p>`,
+    "<ul>",
+    `<li><strong>Issue type:</strong> ${escapeHtml(label)}</li>`,
+  ];
+  if (report.address?.trim())
+    htmlParts.push(
+      `<li><strong>Location:</strong> ${escapeHtml(report.address.trim())}</li>`,
+    );
+  if (coords)
+    htmlParts.push(
+      `<li><strong>Coordinates:</strong> ${escapeHtml(coords)}</li>`,
+    );
+  htmlParts.push("</ul>");
+  htmlParts.push(
+    `<p><strong>Description:</strong><br/>${escapeHtml(description ?? "(No description provided.)")}</p>`,
+  );
+  htmlParts.push(
+    `<p>${
+      report.imageUrl
+        ? "A photo of the issue is attached to this email."
+        : "No photo was provided with this report."
+    }</p>`,
+  );
+  htmlParts.push(
+    `<p style="color:#888;font-size:12px">Nexa reference: ${escapeHtml(report.id)}</p>`,
+  );
+  const html = htmlParts.join("\n");
+
+  return { subject, text, html };
+}
+
+/**
+ * Fetches the report photo and returns it as a Resend attachment, or null if
+ * there is no photo or it can't be retrieved. A missing/unreachable photo must
+ * never fail the submission — the email still carries the report details.
+ */
+async function buildPhotoAttachment(
+  imageUrl: string | null,
+  fetchImpl: typeof fetch,
+): Promise<{ filename: string; content: Buffer } | null> {
+  if (!imageUrl) return null;
+  try {
+    const res = await fetchImpl(imageUrl);
+    if (!res.ok) return null;
+    const buffer = Buffer.from(await res.arrayBuffer());
+    // Derive a filename from the URL path, defaulting to a generic one.
+    let filename = "photo";
+    try {
+      const path = new URL(imageUrl).pathname;
+      const last = path.split("/").filter(Boolean).pop();
+      if (last) filename = last;
+    } catch {
+      // Non-absolute URL: keep the default filename.
+    }
+    if (!/\.[a-z0-9]+$/i.test(filename)) filename += ".jpg";
+    return { filename, content: buffer };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Composes and sends a report submission email to an EMAIL-intake agency.
+ *
+ * Never throws. Returns `not_configured` (so the orchestrator falls back to
+ * manual-assist) when the Resend key, the sender address, or the agency's
+ * intake email is missing. Returns `error` for a genuine send failure.
+ *
+ * The `resendClient` / `fetchImpl` options exist for testing — pass stubs to
+ * exercise composition and dispatch without a live Resend account or network.
+ */
+export async function submitViaEmail(
+  report: EmailSubmittableReport,
+  options: {
+    agencyName: string;
+    intakeEmail: string | null;
+    // Injected transport for tests. Production builds one from RESEND_API_KEY.
+    resendClient?: EmailSender;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<EmailSubmitResult> {
+  const fromEmail = process.env.SUBMISSION_FROM_EMAIL?.trim();
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+
+  // Env gate: without a transport configured we never touch the network. The
+  // orchestrator treats this as "fall back to manual assist", not a failure.
+  const client = options.resendClient ?? (apiKey ? new Resend(apiKey) : null);
+  if (!client) {
+    return {
+      status: "not_configured",
+      reason: "RESEND_API_KEY is not set; email submission is disabled.",
+    };
+  }
+  if (!fromEmail) {
+    return {
+      status: "not_configured",
+      reason: "SUBMISSION_FROM_EMAIL is not set; email submission is disabled.",
+    };
+  }
+  const to = options.intakeEmail?.trim();
+  if (!to) {
+    return {
+      status: "not_configured",
+      reason: "Agency has no intake email address.",
+    };
+  }
+
+  const composed = composeSubmissionEmail(report, {
+    agencyName: options.agencyName,
+  });
+
+  // A custom fetchImpl (tests) is used verbatim; otherwise fetchWithTimeout
+  // bounds the photo download so a hung asset host can't stall the submission.
+  const doFetch =
+    options.fetchImpl ??
+    ((input: RequestInfo | URL, init?: RequestInit) =>
+      fetchWithTimeout(input, {
+        ...init,
+        timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+      }));
+
+  const attachment = await buildPhotoAttachment(report.imageUrl, doFetch);
+
+  try {
+    const { data, error } = await client.emails.send({
+      from: fromEmail,
+      to,
+      subject: composed.subject,
+      text: composed.text,
+      html: composed.html,
+      ...(attachment ? { attachments: [attachment] } : {}),
+    });
+
+    if (error) {
+      return {
+        status: "error",
+        message: error.message || "Resend rejected the submission email.",
+      };
+    }
+    if (!data?.id) {
+      return {
+        status: "error",
+        message: "Resend returned no message id for the submission email.",
+      };
+    }
+    return { status: "submitted", messageId: data.id };
+  } catch (err) {
+    return {
+      status: "error",
+      message:
+        err instanceof TimeoutError
+          ? "Timed out sending the submission email."
+          : err instanceof Error
+            ? err.message
+            : "Network error sending the submission email.",
+    };
+  }
+}

--- a/nexa/src/lib/submission/orchestrate.test.ts
+++ b/nexa/src/lib/submission/orchestrate.test.ts
@@ -19,6 +19,13 @@ vi.mock("@/lib/submission/open311", async () => {
   };
 });
 
+// The EMAIL path delegates to submitViaEmail; stub it so these tests exercise
+// dispatch + status transitions, not the Resend client (tested in email.test.ts).
+const submitViaEmail = vi.fn();
+vi.mock("@/lib/submission/email", () => ({
+  submitViaEmail: (...args: unknown[]) => submitViaEmail(...args),
+}));
+
 // resolveAgencyId hits prisma; stub it so on-demand resolution is deterministic.
 const resolveAgencyId = vi.fn();
 vi.mock("@/lib/jurisdictions/agency", () => ({
@@ -29,6 +36,7 @@ import { orchestrateSubmission } from "./orchestrate";
 
 beforeEach(() => {
   submitToOpen311.mockReset();
+  submitViaEmail.mockReset();
   resolveAgencyId.mockReset();
 });
 
@@ -159,8 +167,8 @@ describe("orchestrateSubmission — API intake (automated)", () => {
   });
 });
 
-describe("orchestrateSubmission — non-API intake (graceful fallback)", () => {
-  it.each([IntakeMethod.WEB_FORM, IntakeMethod.EMAIL, IntakeMethod.PHONE])(
+describe("orchestrateSubmission — non-automated intake (graceful fallback)", () => {
+  it.each([IntakeMethod.WEB_FORM, IntakeMethod.PHONE])(
     "returns manual_assist (not an error) for %s intake",
     async (intakeMethod) => {
       // Arrange
@@ -188,8 +196,123 @@ describe("orchestrateSubmission — non-API intake (graceful fallback)", () => {
       });
       expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
       expect(submitToOpen311).not.toHaveBeenCalled();
+      expect(submitViaEmail).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("orchestrateSubmission — EMAIL intake (email agent, #31)", () => {
+  function stubEmailAgency(reportOverrides = {}): { reportId: string } {
+    return stubReportWithAgency(reportOverrides, {
+      intakeMethod: IntakeMethod.EMAIL,
+      name: "Palo Alto Public Works",
+      intakeUrl: null,
+      intakeEmail: "311@paloalto.gov",
+    });
+  }
+
+  it("claims the report, sends via the email agent, and advances to SUBMITTED", async () => {
+    // Arrange
+    const { reportId } = stubEmailAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitViaEmail.mockResolvedValue({
+      status: "submitted",
+      messageId: "msg-789",
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({
+        id: reportId,
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "msg-789",
+      }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toEqual({
+      status: "submitted",
+      reportId,
+      externalTrackingId: "msg-789",
+    });
+    // Claimed CONFIRMED -> SUBMITTING atomically before sending.
+    expect(prismaMock.report.updateMany).toHaveBeenCalledWith({
+      where: { id: reportId, status: ReportStatus.CONFIRMED },
+      data: { status: ReportStatus.SUBMITTING },
+    });
+    expect(submitViaEmail).toHaveBeenCalledOnce();
+    expect(submitToOpen311).not.toHaveBeenCalled();
+  });
+
+  it("falls back to manual_assist (env-gated off) and rolls back to CONFIRMED", async () => {
+    // Arrange: the agent is not configured (no RESEND_API_KEY).
+    const { reportId } = stubEmailAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitViaEmail.mockResolvedValue({
+      status: "not_configured",
+      reason: "RESEND_API_KEY is not set; email submission is disabled.",
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({ id: reportId, status: ReportStatus.CONFIRMED }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert: degrade gracefully, never an error; status rolled back.
+    expect(result).toEqual({
+      status: "manual_assist",
+      reportId,
+      intakeMethod: IntakeMethod.EMAIL,
+      agencyName: "Palo Alto Public Works",
+      intakeUrl: null,
+      intakeEmail: "311@paloalto.gov",
+    });
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: reportId },
+      data: { status: ReportStatus.CONFIRMED },
+    });
+  });
+
+  it("falls back to manual_assist and rolls back when the send errors", async () => {
+    // Arrange
+    const { reportId } = stubEmailAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitViaEmail.mockResolvedValue({
+      status: "error",
+      message: "Resend rejected the submission email.",
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({ id: reportId, status: ReportStatus.CONFIRMED }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "manual_assist",
+      intakeMethod: IntakeMethod.EMAIL,
+    });
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: reportId },
+      data: { status: ReportStatus.CONFIRMED },
+    });
+  });
+
+  it("reports in_progress when the atomic claim loses the race", async () => {
+    // Arrange
+    const { reportId } = stubEmailAgency({ userId: null });
+    prismaMock.report.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", code: "in_progress" });
+    expect(submitViaEmail).not.toHaveBeenCalled();
+  });
 });
 
 describe("orchestrateSubmission — preconditions", () => {

--- a/nexa/src/lib/submission/orchestrate.ts
+++ b/nexa/src/lib/submission/orchestrate.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
+import { submitViaEmail } from "@/lib/submission/email";
 
 // ---------------------------------------------------------------------------
 // Submission orchestrator (issue #34)
@@ -14,13 +15,18 @@ import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
 //   API                -> the Open311 GeoReport agent (`open311.ts`). Fully
 //                         automated: we file the request and store the returned
 //                         service_request_id / token. (issue #32)
-//   WEB_FORM / EMAIL    -> a graceful manual-assist fallback. The per-modality
-//                         email (#31) and web-form (#33) agents are separate;
-//                         until they land, we degrade gracefully by pointing the
-//                         user at the official form / address with their fields
-//                         pre-filled (the `submission-fields` route + assistant)
-//                         rather than failing the request. The report stays
-//                         CONFIRMED so it can be submitted manually.
+//   EMAIL              -> the email submission agent (`email.ts`, issue #31).
+//                         Composes a report email (photo attached) to the
+//                         agency's intakeEmail and sends it via Resend. ENV-
+//                         GATED: when RESEND_API_KEY / SUBMISSION_FROM_EMAIL are
+//                         unset the agent returns `not_configured` and we degrade
+//                         to the same manual-assist fallback below.
+//   WEB_FORM           -> a graceful manual-assist fallback. The web-form agent
+//                         (#33) is separate; until it lands, we degrade
+//                         gracefully by pointing the user at the official form
+//                         with their fields pre-filled (the `submission-fields`
+//                         route + assistant) rather than failing the request.
+//                         The report stays CONFIRMED so it can be filed manually.
 //   PHONE              -> same manual-assist fallback (no automated path).
 //
 // Like `open311.ts`, this never throws to its caller: every outcome is a typed
@@ -81,7 +87,11 @@ export type OrchestrationActor = {
  *       - API: atomically claim CONFIRMED -> SUBMITTING, run the Open311 agent,
  *         then SUBMITTING -> SUBMITTED (storing the tracking id) on success or
  *         roll back to CONFIRMED on failure.
- *       - WEB_FORM / EMAIL / PHONE: leave the report CONFIRMED and return a
+ *       - EMAIL: atomically claim CONFIRMED -> SUBMITTING, run the email agent,
+ *         then SUBMITTING -> SUBMITTED (storing the Resend message id) on
+ *         success; on `not_configured` (env-gated off) or send failure, roll
+ *         back to CONFIRMED and return `manual_assist`.
+ *       - WEB_FORM / PHONE: leave the report CONFIRMED and return a
  *         `manual_assist` result instead of erroring.
  */
 export async function orchestrateSubmission(
@@ -145,18 +155,71 @@ export async function orchestrateSubmission(
     };
   }
 
-  // Non-API intake has no automated agent wired yet (#31/#33). Degrade
-  // gracefully: the report stays CONFIRMED and the caller surfaces the
-  // manual-assist path rather than returning an error.
-  if (agency.intakeMethod !== IntakeMethod.API) {
-    return {
-      status: "manual_assist",
-      reportId: report.id,
-      intakeMethod: agency.intakeMethod,
+  // The manual-assist result every non-automated outcome degrades to: the
+  // report stays CONFIRMED and the caller surfaces the official form/email link
+  // with pre-filled fields rather than returning an error.
+  const manualAssist = (): OrchestrationResult => ({
+    status: "manual_assist",
+    reportId: report.id,
+    intakeMethod: agency!.intakeMethod,
+    agencyName: agency!.name,
+    intakeUrl: agency!.intakeUrl,
+    intakeEmail: agency!.intakeEmail,
+  });
+
+  // WEB_FORM / PHONE have no automated agent (#33 is separate). Degrade
+  // gracefully without claiming the report for submission.
+  if (
+    agency.intakeMethod !== IntakeMethod.API &&
+    agency.intakeMethod !== IntakeMethod.EMAIL
+  ) {
+    return manualAssist();
+  }
+
+  // --- EMAIL path: send a composed report email via Resend (#31) ----------
+  // Env-gated: when the agent is `not_configured` (no RESEND_API_KEY etc.) or a
+  // send fails, we roll the claim back to CONFIRMED and degrade to manual-assist
+  // — never a 400 — so this is a safe no-op until the key is set.
+  if (agency.intakeMethod === IntakeMethod.EMAIL) {
+    const claim = await prisma.report.updateMany({
+      where: { id: reportId, status: ReportStatus.CONFIRMED },
+      data: { status: ReportStatus.SUBMITTING },
+    });
+    if (claim.count !== 1) {
+      return {
+        status: "error",
+        code: "in_progress",
+        message: "This report is already being submitted.",
+      };
+    }
+
+    const emailResult = await submitViaEmail(report, {
       agencyName: agency.name,
-      intakeUrl: agency.intakeUrl,
       intakeEmail: agency.intakeEmail,
-    };
+    });
+
+    if (emailResult.status === "submitted") {
+      const updated = await prisma.report.update({
+        where: { id: reportId },
+        data: {
+          status: ReportStatus.SUBMITTED,
+          externalTrackingId: emailResult.messageId,
+        },
+      });
+      return {
+        status: "submitted",
+        reportId: updated.id,
+        externalTrackingId: updated.externalTrackingId as string,
+      };
+    }
+
+    // `not_configured` (env-gated off) or a send error: roll back so the report
+    // can be filed manually (or retried once the key is set).
+    await prisma.report.update({
+      where: { id: reportId },
+      data: { status: ReportStatus.CONFIRMED },
+    });
+    return manualAssist();
   }
 
   // --- API path: fully automated Open311 submission -----------------------


### PR DESCRIPTION
Closes #31.

## What

Adds an **email submission agent** for agencies whose `intakeMethod` is `EMAIL`. For these agencies there is no machine API to file against — the accepted channel is a human-readable email to the agency's `intakeEmail`.

### The agent — `src/lib/submission/email.ts`
- `composeSubmissionEmail()` builds the report email: issue type, location, coordinates, and description (citizen's words, falling back to the AI summary), as both plain text (max agency compatibility) and HTML (user content escaped).
- `submitViaEmail()` downloads the report photo and attaches it (a missing/unreachable photo never blocks the send), then sends via **Resend**.
- Mirrors `open311.ts`'s never-throw discriminated-result style: every outcome is a typed result (`submitted` / `not_configured` / `error`).

### Env-gated — **a no-op without the key**
The agent is **disabled until configured**. When `RESEND_API_KEY` or `SUBMISSION_FROM_EMAIL` is unset (or the agency has no intake email), it returns `not_configured` without constructing a client or touching the network. The orchestrator then degrades to the existing **manual-assist** fallback, so EMAIL-intake reports stay `CONFIRMED` rather than failing. The code is complete and **activates the moment both env vars are set** — no further changes required.

This is the **submission** agent and is intentionally distinct from the Brevo citizen-**notification** path in `src/lib/email` (welcome / status emails). They do not share infrastructure.

### Orchestrator wiring — `src/lib/submission/orchestrate.ts`
`intakeMethod === EMAIL` now:
1. Atomically claims the report (`CONFIRMED -> SUBMITTING`), the same concurrency guard as the API path.
2. Runs the email agent.
3. On `submitted`: advances to `SUBMITTED`, storing the Resend message id as `externalTrackingId`.
4. On `not_configured` / `error`: rolls the claim back to `CONFIRMED` and returns `manual_assist` — **never a 400**.

`WEB_FORM` / `PHONE` keep the existing manual-assist fallback.

### Env vars (documented in `.env.example`)
- `RESEND_API_KEY` — Resend API key. Unset = agent disabled (no-op).
- `SUBMISSION_FROM_EMAIL` — verified-domain sender address for submission emails.

## Tests
- Env-gated no-op (no key / no sender / no agency email).
- Email composition (fields, AI-description fallback, missing-photo note, HTML escaping).
- Send path (attachment included, attachment skipped on photo-fetch failure, Resend error, transport throw).
- Orchestrator EMAIL dispatch (claim + advance to SUBMITTED; rollback + manual-assist on not_configured / error; in_progress on lost claim race).

## Verification (all green)
- `npx tsc --noEmit`
- `npm run lint` (0 errors)
- `npm run format:check`
- `npm test` — 390 passed