### PR TITLE
feat(api): presigned S3/R2 image upload pipeline (env-gated, base64 fallback) [#30]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -89,5 +89,25 @@ VAPID_PRIVATE_KEY=
 # mailto:noreply@nexa.app when unset.
 VAPID_SUBJECT=mailto:noreply@nexa.app
 
+# --- Object storage for report images (S3 / Cloudflare R2, issue #30) ---
+# Optional. When unset, the image upload pipeline is a NO-OP: report photos are
+# stored inline as base64 data URLs exactly as before (ready-to-activate). Set
+# S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY and S3_PUBLIC_BASE_URL to
+# turn it on; clients then upload the resized image to a presigned URL and the
+# public object URL is stored as Report.imageUrl. See src/lib/storage.ts.
+#
+# Cloudflare R2: set S3_ENDPOINT to your R2 gateway
+#   (https://<account-id>.r2.cloudflarestorage.com); S3_REGION is then ignored
+#   (defaults to "auto"). For AWS S3, leave S3_ENDPOINT blank and set S3_REGION
+#   to the bucket's region.
+S3_BUCKET=
+S3_REGION=
+S3_ENDPOINT=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+# Public base URL objects are served from (R2 public bucket domain or a CDN).
+# The stored imageUrl is `${S3_PUBLIC_BASE_URL}/${key}`.
+S3_PUBLIC_BASE_URL=
+
 # --- App ---
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/nexa/package-lock.json
+++ b/nexa/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.95.2",
+        "@aws-sdk/client-s3": "^3.1065.0",
+        "@aws-sdk/s3-request-presigner": "^3.1065.0",
         "@base-ui/react": "^1.4.0",
         "@google/genai": "^2.2.0",
         "@prisma/adapter-pg": "^7.8.0",
@@ -159,6 +161,453 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.4.tgz",
+      "integrity": "sha512-Pt1JEVLu02jTWzpcUzUHciiWScyZg3JpHCTB1h9DtDPWY3dBufBnFJAevVHali/bAkmMdMhYUD8tH/VvPuBkUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1065.0.tgz",
+      "integrity": "sha512-KtCpg2vihUjhUpqpsZIcB6Dm1hv9lRn5hWwU6hXtYfSQionFD/dB/gTwgyn9AHX6eGiCFqHfjIZwETz5Cz4RWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.29",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.50",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.29.tgz",
+      "integrity": "sha512-ALTHDXk6YWVDfAWIHzXyaTZ82QFoMWhHENXlO61lv4ZqSMl3cvh2s0ZVOS89qbtw9LRJhIDoZaaC9FYo/Z4KLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.50.tgz",
+      "integrity": "sha512-yOXn9mmJQQODpbmwQB224IX1PLLneyqInX2Fv2nEmSHWpJj54nrzdrUT1TGQk/s8mr+XPssDQy1at/8GS4EFVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1065.0.tgz",
+      "integrity": "sha512-mquysBsag3Zxm/mCeUf4RR1udVzSRxuSS6yFk1OdZEWQjsUIK9VOA13FNmYCT/5m9Ookk8ZFZVbTth/bFvSvJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2683,6 +3132,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3831,6 +4292,126 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -5458,6 +6039,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5853,6 +6446,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -7899,6 +8498,43 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
@@ -11112,6 +11748,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -13011,6 +13662,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -14261,6 +14927,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.2",
+    "@aws-sdk/client-s3": "^3.1065.0",
+    "@aws-sdk/s3-request-presigner": "^3.1065.0",
     "@base-ui/react": "^1.4.0",
     "@google/genai": "^2.2.0",
     "@prisma/adapter-pg": "^7.8.0",

--- a/nexa/src/app/api/uploads/presign/route.test.ts
+++ b/nexa/src/app/api/uploads/presign/route.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the storage layer so the route can be exercised in both the configured
+// and not-configured modes with no AWS credentials. `vi.hoisted` lets the
+// hoisted `vi.mock` factory reference the spies without a TDZ error.
+const { isStorageConfigured, createPresignedUpload } = vi.hoisted(() => ({
+  isStorageConfigured: vi.fn(),
+  createPresignedUpload: vi.fn(),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  isStorageConfigured,
+  createPresignedUpload,
+}));
+
+import { POST } from "./route";
+import { __resetRateLimitStore } from "@/lib/rate-limit";
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/uploads/presign", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/uploads/presign", () => {
+  beforeEach(() => {
+    __resetRateLimitStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns configured:false (200) when storage is not configured, so the client falls back", async () => {
+    isStorageConfigured.mockReturnValue(false);
+
+    const response = await POST(request({ contentType: "image/jpeg" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { configured: false } });
+    expect(createPresignedUpload).not.toHaveBeenCalled();
+  });
+
+  it("returns the presigned + object URLs when storage is configured", async () => {
+    isStorageConfigured.mockReturnValue(true);
+    createPresignedUpload.mockResolvedValue({
+      uploadUrl: "https://bucket.example.com/reports/abc.jpg?X-Amz-Signature=x",
+      objectUrl: "https://cdn.example.com/reports/abc.jpg",
+      key: "reports/abc.jpg",
+      contentType: "image/jpeg",
+    });
+
+    const response = await POST(request({ contentType: "image/jpeg" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      configured: true,
+      uploadUrl: expect.stringContaining("X-Amz-Signature="),
+      objectUrl: "https://cdn.example.com/reports/abc.jpg",
+      contentType: "image/jpeg",
+    });
+    expect(createPresignedUpload).toHaveBeenCalledWith("image/jpeg");
+  });
+
+  it("defaults the content type to image/jpeg when omitted", async () => {
+    isStorageConfigured.mockReturnValue(true);
+    createPresignedUpload.mockResolvedValue({
+      uploadUrl: "https://bucket.example.com/reports/abc.jpg?sig",
+      objectUrl: "https://cdn.example.com/reports/abc.jpg",
+      key: "reports/abc.jpg",
+      contentType: "image/jpeg",
+    });
+
+    const response = await POST(request({}));
+    expect(response.status).toBe(200);
+    expect(createPresignedUpload).toHaveBeenCalledWith("image/jpeg");
+  });
+
+  it("rejects an unsupported content type with a 400 envelope", async () => {
+    isStorageConfigured.mockReturnValue(true);
+
+    const response = await POST(request({ contentType: "image/gif" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(createPresignedUpload).not.toHaveBeenCalled();
+  });
+
+  it("falls back to configured:false when presign unexpectedly yields null", async () => {
+    isStorageConfigured.mockReturnValue(true);
+    createPresignedUpload.mockResolvedValue(null);
+
+    const response = await POST(request({ contentType: "image/png" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { configured: false } });
+  });
+
+  it("returns a 500 envelope when presigning throws", async () => {
+    isStorageConfigured.mockReturnValue(true);
+    createPresignedUpload.mockRejectedValue(new Error("boom"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await POST(request({ contentType: "image/jpeg" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    errorSpy.mockRestore();
+  });
+});

--- a/nexa/src/app/api/uploads/presign/route.ts
+++ b/nexa/src/app/api/uploads/presign/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { PresignUploadSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { createPresignedUpload, isStorageConfigured } from "@/lib/storage";
+
+// POST /api/uploads/presign — hand the client a presigned PUT URL so it can
+// upload a (client-resized) report image straight to S3/R2, then submit the
+// resulting public object URL as `Report.imageUrl` (issue #30).
+//
+// ENV-GATED, SAFE FALLBACK: when storage is not configured this returns a
+// success envelope with `{ configured: false }` (HTTP 200) rather than an
+// error, so the client cleanly falls back to the existing inline base64 path.
+// The app therefore runs fine without any S3 credentials.
+//
+// Auth-aware like the other report routes: a session is used when present but
+// not required (guests can report). Rate-limited per IP because presigning is
+// an outbound AWS call and the route takes no auth.
+export async function POST(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request.headers);
+    if (limited) return limited;
+
+    const { contentType } = await parseJsonRequest(
+      request,
+      PresignUploadSchema,
+    );
+
+    // Not configured → tell the client to fall back to inline base64. This is a
+    // success, not an error: the absence of storage is an expected mode.
+    if (!isStorageConfigured()) {
+      return successResponse({ configured: false } as const);
+    }
+
+    const presigned = await createPresignedUpload(contentType);
+    if (!presigned) {
+      // Defensive: `isStorageConfigured()` was true, so this should not happen.
+      return successResponse({ configured: false } as const);
+    }
+
+    return successResponse({
+      configured: true,
+      uploadUrl: presigned.uploadUrl,
+      objectUrl: presigned.objectUrl,
+      contentType: presigned.contentType,
+    } as const);
+  } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
+    console.error("[uploads/presign] Unexpected error:", error);
+    return errorResponse("Could not prepare an upload. Please try again.", 500);
+  }
+}

--- a/nexa/src/hooks/use-report-submission.ts
+++ b/nexa/src/hooks/use-report-submission.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { queueReport } from "@/lib/offline-queue";
+import { uploadImageViaPresign } from "@/lib/upload-image";
 import type { ApiResponse } from "@/lib/api/response";
 import type {
   ClassificationResult,
@@ -143,7 +144,9 @@ export function useReportSubmission() {
       setSubmitting(true);
       setSubmitError(null);
 
-      const payload = {
+      // Offline-queue payload keeps the inline base64 so a parked report can be
+      // replayed without re-running the (online-only) presigned upload.
+      const queuePayload = {
         description: input.description,
         aiDescription: input.classification.aiDescription,
         issueType: input.classification.issueType,
@@ -154,10 +157,20 @@ export function useReportSubmission() {
       };
 
       try {
+        // When object storage is configured, upload the (already client-resized)
+        // image to a presigned URL and store its public URL instead of the
+        // bytes. `uploadImageViaPresign` returns null when storage is not
+        // configured or anything fails, so we fall back to the inline base64.
+        let imageUrl = input.imageBase64;
+        if (input.imageBase64) {
+          const objectUrl = await uploadImageViaPresign(input.imageBase64);
+          if (objectUrl) imageUrl = objectUrl;
+        }
+
         const res = await fetch("/api/reports", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
+          body: JSON.stringify({ ...queuePayload, imageUrl }),
         });
 
         const result = (await res.json()) as ApiResponse<CreatedReport>;
@@ -176,7 +189,7 @@ export function useReportSubmission() {
         // No connectivity: park the report locally and confirm optimistically.
         // PwaSetup replays the queue once the browser is back online.
         if (typeof navigator !== "undefined" && !navigator.onLine) {
-          queueReport(payload);
+          queueReport(queuePayload);
           const queued: CreatedReport = {
             id: "Pending sync",
             issueType: input.classification.issueType,

--- a/nexa/src/lib/api/schemas.ts
+++ b/nexa/src/lib/api/schemas.ts
@@ -122,3 +122,20 @@ export const PushUnsubscribeSchema = z.object({
   endpoint: z.string().min(1, "endpoint is required"),
 });
 export type PushUnsubscribeInput = z.infer<typeof PushUnsubscribeSchema>;
+
+/**
+ * `POST /api/uploads/presign` — request a presigned URL to upload a report
+ * image to object storage (#30). The client resizes to JPEG (and falls back to
+ * PNG for some sources), so we only allow those two content types; the value is
+ * signed into the URL and must match the PUT's `Content-Type` header. Defaults
+ * to `image/jpeg` to match the client resizer's output.
+ */
+export const PresignUploadSchema = z.object({
+  contentType: z
+    .enum(["image/jpeg", "image/png"], {
+      error: "contentType must be image/jpeg or image/png.",
+    })
+    .optional()
+    .default("image/jpeg"),
+});
+export type PresignUploadInput = z.infer<typeof PresignUploadSchema>;

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -103,6 +103,45 @@ export const getGoogleMapsApiKey = cached(() =>
   optionalEnv("GOOGLE_MAPS_API_KEY"),
 );
 
+// --- Object storage (S3 / Cloudflare R2) for image uploads (see src/lib/storage.ts) ---
+//
+// All optional: when unset the upload pipeline degrades gracefully to the
+// existing inline base64/data-URL behaviour, so the app runs with no creds.
+// The same vars drive both AWS S3 and S3-compatible providers (R2): point
+// `S3_ENDPOINT` at the R2 gateway and the rest of the config is identical.
+
+/** Target bucket name. Required for storage to be considered configured. */
+export const getS3Bucket = cached(() => optionalEnv("S3_BUCKET"));
+
+/**
+ * Region. AWS needs the bucket's real region; R2 ignores it but the SDK still
+ * requires a non-empty value, so callers default to `auto` when unset.
+ */
+export const getS3Region = cached(() => optionalEnv("S3_REGION"));
+
+/**
+ * Custom S3 endpoint. Omit for AWS S3; set to the R2 (or other S3-compatible)
+ * gateway, e.g. `https://<account>.r2.cloudflarestorage.com`.
+ */
+export const getS3Endpoint = cached(() => optionalEnv("S3_ENDPOINT"));
+
+/** Access key id for the upload credentials. Required for storage. */
+export const getS3AccessKeyId = cached(() => optionalEnv("S3_ACCESS_KEY_ID"));
+
+/** Secret access key for the upload credentials. Required for storage. */
+export const getS3SecretAccessKey = cached(() =>
+  optionalEnv("S3_SECRET_ACCESS_KEY"),
+);
+
+/**
+ * Public base URL under which uploaded objects are served (e.g. an R2 public
+ * bucket domain or a CloudFront distribution). The stored `imageUrl` becomes
+ * `${S3_PUBLIC_BASE_URL}/${key}`. Required for storage.
+ */
+export const getS3PublicBaseUrl = cached(() =>
+  optionalEnv("S3_PUBLIC_BASE_URL"),
+);
+
 // --- Duplicate-report detection (see src/lib/reports/dedup.ts) ---
 
 /** Default radius (metres) within which a same-type report counts as a dup. */

--- a/nexa/src/lib/storage.test.ts
+++ b/nexa/src/lib/storage.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the storage config getters so we can exercise the configured and
+// not-configured branches without any real AWS credentials. `vi.hoisted` lets
+// the hoisted `vi.mock` factory reference the spies without a TDZ error.
+const {
+  getS3Bucket,
+  getS3Region,
+  getS3Endpoint,
+  getS3AccessKeyId,
+  getS3SecretAccessKey,
+  getS3PublicBaseUrl,
+} = vi.hoisted(() => ({
+  getS3Bucket: vi.fn(),
+  getS3Region: vi.fn(),
+  getS3Endpoint: vi.fn(),
+  getS3AccessKeyId: vi.fn(),
+  getS3SecretAccessKey: vi.fn(),
+  getS3PublicBaseUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    getS3Bucket,
+    getS3Region,
+    getS3Endpoint,
+    getS3AccessKeyId,
+    getS3SecretAccessKey,
+    getS3PublicBaseUrl,
+  };
+});
+
+import {
+  __resetStorageClient,
+  createPresignedUpload,
+  isStorageConfigured,
+  publicObjectUrl,
+} from "./storage";
+
+/** Set every required var so storage is considered configured. */
+function configureStorage(overrides: Partial<Record<string, string>> = {}) {
+  getS3Bucket.mockReturnValue(overrides.bucket ?? "my-bucket");
+  getS3Region.mockReturnValue(overrides.region ?? "us-east-1");
+  getS3Endpoint.mockReturnValue(overrides.endpoint);
+  getS3AccessKeyId.mockReturnValue(overrides.accessKeyId ?? "AKIA_TEST");
+  getS3SecretAccessKey.mockReturnValue(overrides.secret ?? "secret-test");
+  getS3PublicBaseUrl.mockReturnValue(
+    overrides.publicBaseUrl ?? "https://cdn.example.com",
+  );
+}
+
+describe("storage — not configured (safe fallback)", () => {
+  beforeEach(() => {
+    // Every getter returns undefined: no storage env at all.
+    getS3Bucket.mockReturnValue(undefined);
+    getS3Region.mockReturnValue(undefined);
+    getS3Endpoint.mockReturnValue(undefined);
+    getS3AccessKeyId.mockReturnValue(undefined);
+    getS3SecretAccessKey.mockReturnValue(undefined);
+    getS3PublicBaseUrl.mockReturnValue(undefined);
+    __resetStorageClient();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports storage as not configured", () => {
+    expect(isStorageConfigured()).toBe(false);
+  });
+
+  it("createPresignedUpload returns null so callers fall back to base64", async () => {
+    await expect(createPresignedUpload("image/jpeg")).resolves.toBeNull();
+  });
+
+  it("publicObjectUrl returns null when not configured", () => {
+    expect(publicObjectUrl("reports/whatever.jpg")).toBeNull();
+  });
+
+  it("stays not-configured when only some vars are present", () => {
+    // Bucket + keys set, but no public base URL → still not configured.
+    getS3Bucket.mockReturnValue("my-bucket");
+    getS3AccessKeyId.mockReturnValue("AKIA_TEST");
+    getS3SecretAccessKey.mockReturnValue("secret-test");
+    getS3PublicBaseUrl.mockReturnValue(undefined);
+    expect(isStorageConfigured()).toBe(false);
+  });
+});
+
+describe("storage — configured", () => {
+  beforeEach(() => {
+    __resetStorageClient();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports storage as configured when all required vars are set", () => {
+    configureStorage();
+    expect(isStorageConfigured()).toBe(true);
+  });
+
+  it("publicObjectUrl joins the base URL and key, trimming a trailing slash", () => {
+    configureStorage({ publicBaseUrl: "https://cdn.example.com/" });
+    expect(publicObjectUrl("reports/abc.jpg")).toBe(
+      "https://cdn.example.com/reports/abc.jpg",
+    );
+  });
+
+  it("createPresignedUpload yields an upload URL and matching object URL", async () => {
+    configureStorage({ publicBaseUrl: "https://cdn.example.com" });
+
+    const result = await createPresignedUpload("image/png");
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    expect(result.contentType).toBe("image/png");
+    expect(result.key).toMatch(/^reports\/[0-9a-f-]+\.png$/);
+    expect(result.objectUrl).toBe(`https://cdn.example.com/${result.key}`);
+    // A presigned URL is a real, signed HTTPS URL carrying the SigV4 params.
+    expect(result.uploadUrl).toContain(result.key);
+    expect(result.uploadUrl).toMatch(/X-Amz-Signature=/);
+  });
+
+  it("defaults the content type to image/jpeg", async () => {
+    configureStorage();
+    const result = await createPresignedUpload();
+    expect(result?.contentType).toBe("image/jpeg");
+    expect(result?.key).toMatch(/\.jpg$/);
+  });
+});

--- a/nexa/src/lib/storage.ts
+++ b/nexa/src/lib/storage.ts
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------
+// S3 / Cloudflare R2 object storage for report images (issue #30).
+//
+// The report flow currently stores the photo inline as a base64 data URL in
+// `Report.imageUrl`. That works for the MVP but bloats request bodies and the
+// database. This module adds an OPTIONAL upload path: when S3-compatible
+// storage is configured, the client uploads the (already client-resized) image
+// straight to the bucket via a presigned PUT URL and we store the public object
+// URL instead of the bytes.
+//
+// ENV-GATED, SAFE FALLBACK: when storage is NOT configured, callers detect that
+// via `isStorageConfigured()` and the app keeps its existing inline base64
+// behaviour unchanged. No credentials are required for the app to run — the
+// pipeline is "ready to activate" by setting the S3_* env vars.
+//
+// S3 ⇄ R2: the same six env vars cover both. For Cloudflare R2 set `S3_ENDPOINT`
+// to the account R2 gateway and `S3_REGION` is irrelevant (the SDK still wants a
+// value, so we default it to "auto"). Everything else is identical.
+// ---------------------------------------------------------------------------
+
+import { randomUUID } from "node:crypto";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import {
+  getS3AccessKeyId,
+  getS3Bucket,
+  getS3Endpoint,
+  getS3PublicBaseUrl,
+  getS3Region,
+  getS3SecretAccessKey,
+} from "@/lib/config";
+
+/** How long a presigned PUT URL stays valid, in seconds. */
+const PRESIGN_EXPIRES_SECONDS = 300;
+
+/** Fallback region for S3-compatible providers (R2) that ignore it. */
+const DEFAULT_REGION = "auto";
+
+/** The fully-resolved storage config, present only when storage is configured. */
+interface StorageConfig {
+  bucket: string;
+  region: string;
+  endpoint: string | undefined;
+  accessKeyId: string;
+  secretAccessKey: string;
+  publicBaseUrl: string;
+}
+
+/**
+ * Resolve the storage config from env, returning `null` when any REQUIRED var
+ * is missing. `region` and `endpoint` are not part of the required set —
+ * `region` falls back to {@link DEFAULT_REGION} and `endpoint` is optional
+ * (AWS S3 needs none; R2 needs one).
+ */
+function resolveConfig(): StorageConfig | null {
+  const bucket = getS3Bucket();
+  const accessKeyId = getS3AccessKeyId();
+  const secretAccessKey = getS3SecretAccessKey();
+  const publicBaseUrl = getS3PublicBaseUrl();
+
+  if (!bucket || !accessKeyId || !secretAccessKey || !publicBaseUrl) {
+    return null;
+  }
+
+  return {
+    bucket,
+    region: getS3Region() ?? DEFAULT_REGION,
+    endpoint: getS3Endpoint(),
+    accessKeyId,
+    secretAccessKey,
+    // Trim a trailing slash so URL joins don't produce `//`.
+    publicBaseUrl: publicBaseUrl.replace(/\/+$/, ""),
+  };
+}
+
+/**
+ * Whether object storage is configured. When `false`, callers MUST keep the
+ * existing inline base64/data-URL behaviour — this is the safe fallback that
+ * lets the app run without any cloud credentials.
+ */
+export function isStorageConfigured(): boolean {
+  return resolveConfig() !== null;
+}
+
+/** Lazily-built S3 client, memoized so we don't reconstruct it per request. */
+let cachedClient: { client: S3Client; config: StorageConfig } | null = null;
+
+function getClient(config: StorageConfig): S3Client {
+  if (cachedClient && cachedClient.config === config) {
+    return cachedClient.client;
+  }
+  const client = new S3Client({
+    region: config.region,
+    // Only set `endpoint` when provided; passing `undefined` to the SDK is fine
+    // but being explicit keeps AWS-S3 behaviour on the default endpoint.
+    ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+    // R2 and most S3-compatibles want path-style addressing; it's also valid
+    // for AWS S3, so we use it uniformly to avoid bucket-in-hostname surprises.
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+  });
+  cachedClient = { client, config };
+  return client;
+}
+
+/** Result of a successful presign: where to PUT, and the eventual public URL. */
+export interface PresignResult {
+  /** The presigned URL the client uploads the image bytes to (HTTP PUT). */
+  uploadUrl: string;
+  /** The public URL the object is served from — stored as `Report.imageUrl`. */
+  objectUrl: string;
+  /** The object key within the bucket. */
+  key: string;
+  /** Content type the client must send on the PUT (must match what was signed). */
+  contentType: string;
+}
+
+/**
+ * Build a storage object key for a new upload. Namespaced under `reports/` and
+ * suffixed from the content type so the object has a sensible extension.
+ */
+function buildKey(contentType: string): string {
+  const ext = contentType === "image/png" ? "png" : "jpg";
+  return `reports/${randomUUID()}.${ext}`;
+}
+
+/**
+ * Compute the public URL an object is served from, given its key. Exposed so
+ * tests and callers can derive the URL without re-presigning.
+ */
+export function publicObjectUrl(key: string): string | null {
+  const config = resolveConfig();
+  if (!config) return null;
+  return `${config.publicBaseUrl}/${key}`;
+}
+
+/**
+ * Create a presigned PUT URL for a new report image and compute the public URL
+ * the object will be served from once uploaded.
+ *
+ * Returns `null` when storage is not configured so callers fall back to inline
+ * base64. `contentType` is signed into the URL: the client MUST send the same
+ * `Content-Type` header on its PUT or the upload is rejected.
+ */
+export async function createPresignedUpload(
+  contentType = "image/jpeg",
+): Promise<PresignResult | null> {
+  const config = resolveConfig();
+  if (!config) return null;
+
+  const key = buildKey(contentType);
+  const client = getClient(config);
+
+  const command = new PutObjectCommand({
+    Bucket: config.bucket,
+    Key: key,
+    ContentType: contentType,
+  });
+
+  const uploadUrl = await getSignedUrl(client, command, {
+    expiresIn: PRESIGN_EXPIRES_SECONDS,
+  });
+
+  return {
+    uploadUrl,
+    objectUrl: `${config.publicBaseUrl}/${key}`,
+    key,
+    contentType,
+  };
+}
+
+/** Test-only: drop the memoized client so config changes take effect. */
+export function __resetStorageClient(): void {
+  cachedClient = null;
+}

--- a/nexa/src/lib/upload-image.test.ts
+++ b/nexa/src/lib/upload-image.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { uploadImageViaPresign } from "./upload-image";
+
+// A 1x1 JPEG-ish data URL — the exact bytes don't matter, only that it's a
+// valid base64 data URL the helper can decode into a Blob.
+const DATA_URL = `data:image/jpeg;base64,${btoa("hello-bytes")}`;
+
+function presignResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("uploadImageViaPresign", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null for a non-data-URL input (nothing to upload)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const result = await uploadImageViaPresign("https://example.com/x.jpg");
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null (fallback to base64) when storage is not configured", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      presignResponse({ success: true, data: { configured: false } }),
+    );
+
+    const result = await uploadImageViaPresign(DATA_URL);
+    expect(result).toBeNull();
+  });
+
+  it("uploads to the presigned URL and returns the object URL when configured", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        presignResponse({
+          success: true,
+          data: {
+            configured: true,
+            uploadUrl: "https://bucket.example.com/reports/abc.jpg?sig",
+            objectUrl: "https://cdn.example.com/reports/abc.jpg",
+            contentType: "image/jpeg",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await uploadImageViaPresign(DATA_URL);
+
+    expect(result).toBe("https://cdn.example.com/reports/abc.jpg");
+    // Second call is the PUT to the presigned URL with the right content type.
+    const putCall = fetchSpy.mock.calls[1];
+    expect(putCall[0]).toBe("https://bucket.example.com/reports/abc.jpg?sig");
+    expect(putCall[1]).toMatchObject({
+      method: "PUT",
+      headers: { "Content-Type": "image/jpeg" },
+    });
+  });
+
+  it("returns null when the PUT upload fails", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        presignResponse({
+          success: true,
+          data: {
+            configured: true,
+            uploadUrl: "https://bucket.example.com/reports/abc.jpg?sig",
+            objectUrl: "https://cdn.example.com/reports/abc.jpg",
+            contentType: "image/jpeg",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 403 }));
+
+    const result = await uploadImageViaPresign(DATA_URL);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the presign request itself errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    const result = await uploadImageViaPresign(DATA_URL);
+    expect(result).toBeNull();
+  });
+
+  it("derives image/png content type from a PNG data URL", async () => {
+    const pngUrl = `data:image/png;base64,${btoa("png-bytes")}`;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        presignResponse({ success: true, data: { configured: false } }),
+      );
+
+    await uploadImageViaPresign(pngUrl);
+
+    const presignBody = JSON.parse(
+      (fetchSpy.mock.calls[0][1]?.body as string) ?? "{}",
+    );
+    expect(presignBody.contentType).toBe("image/png");
+  });
+});

--- a/nexa/src/lib/upload-image.ts
+++ b/nexa/src/lib/upload-image.ts
@@ -1,0 +1,94 @@
+// Client-side image upload via presigned URL (issue #30).
+//
+// Given an already-resized image data URL (produced by `useImageUpload`), this
+// asks the server for a presigned PUT URL and, when storage is configured,
+// uploads the bytes directly to S3/R2 and returns the public object URL to
+// store as `Report.imageUrl`.
+//
+// SAFE FALLBACK: returns `null` whenever storage is not configured OR anything
+// in the presign/upload path fails. Callers treat `null` as "keep the existing
+// inline base64 behaviour", so the report still submits with no storage creds.
+
+import type { ApiResponse } from "@/lib/api/response";
+
+/** Server response shape from `POST /api/uploads/presign`. */
+type PresignResponse =
+  | { configured: false }
+  | {
+      configured: true;
+      uploadUrl: string;
+      objectUrl: string;
+      contentType: string;
+    };
+
+/**
+ * Parse a `data:<mime>;base64,<payload>` URL into a Blob plus its MIME type.
+ * Returns `null` for inputs that are not base64 data URLs (e.g. an already
+ * remote URL), which the caller treats as "nothing to upload".
+ */
+function dataUrlToBlob(
+  dataUrl: string,
+): { blob: Blob; contentType: string } | null {
+  const match = /^data:([^;,]+);base64,([\s\S]*)$/.exec(dataUrl);
+  if (!match) return null;
+
+  const contentType = match[1];
+  try {
+    const binary = atob(match[2]);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return { blob: new Blob([bytes], { type: contentType }), contentType };
+  } catch {
+    return null;
+  }
+}
+
+/** Map an arbitrary image MIME type to one the presign route accepts. */
+function normalizeContentType(contentType: string): "image/jpeg" | "image/png" {
+  return contentType === "image/png" ? "image/png" : "image/jpeg";
+}
+
+/**
+ * Upload a resized image to object storage via a presigned URL.
+ *
+ * @param imageDataUrl the resized `data:image/...;base64,...` URL.
+ * @returns the public object URL on success, or `null` to fall back to inline
+ *          base64 (storage not configured, non-data-URL input, or any failure).
+ */
+export async function uploadImageViaPresign(
+  imageDataUrl: string,
+): Promise<string | null> {
+  const parsed = dataUrlToBlob(imageDataUrl);
+  if (!parsed) return null;
+
+  const contentType = normalizeContentType(parsed.contentType);
+
+  try {
+    const presignRes = await fetch("/api/uploads/presign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contentType }),
+    });
+
+    if (!presignRes.ok) return null;
+
+    const envelope = (await presignRes.json()) as ApiResponse<PresignResponse>;
+    if (!envelope.success || !envelope.data.configured) return null;
+
+    const { uploadUrl, objectUrl } = envelope.data;
+
+    const putRes = await fetch(uploadUrl, {
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      body: parsed.blob,
+    });
+    if (!putRes.ok) return null;
+
+    return objectUrl;
+  } catch {
+    // Network error, non-JSON response, etc. — fall back to inline base64.
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #30.

## What

Adds an optional object-storage path for report images. Previously the report photo is stored inline as a base64 data URL in `Report.imageUrl` (passed through `POST /api/reports`). This PR adds a presigned-upload pipeline behind that same field, env-gated with a safe fallback, so it is code-complete and ready to activate without cloud credentials.

## Flow

1. Client resizes/compresses the photo with the existing `useImageUpload` hook (unchanged, no parallel resizer added).
2. On submit, `use-report-submission` calls `uploadImageViaPresign()`:
   - `POST /api/uploads/presign` returns a presigned PUT URL + the final public object URL when storage is configured, else `{ configured: false }`.
   - When configured, the client PUTs the resized bytes straight to S3/R2 and submits the public object URL as `imageUrl`.
   - When not configured (or anything fails), it returns `null` and the client submits the inline base64 exactly as before.
3. `src/lib/storage.ts` builds the presigned URL and computes the public object URL over `@aws-sdk/client-s3` + `@aws-sdk/s3-request-presigner`.

## No-op without S3 creds

`isStorageConfigured()` returns `false` whenever any required `S3_*` var is missing, so the presign route returns `configured: false` (HTTP 200, not an error), the client keeps the current base64/data-URL behaviour, and the app runs unchanged with no credentials. Pure no-op fallback.

## Env vars (S3 + Cloudflare R2)

Documented in `.env.example`. The same vars cover AWS S3 and R2: `S3_BUCKET`, `S3_REGION`, `S3_ENDPOINT` (set to the R2 gateway for R2), `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_PUBLIC_BASE_URL`.

## Route

`POST /api/uploads/presign`: auth-aware (session used if present, not required), per-IP rate-limited (presigning is an outbound AWS call on an unauthenticated route), envelope responses, body validated to image/jpeg or image/png (defaults to jpeg).

## Tests

- `storage.test.ts`: not-configured fallback (all/partial vars) + configured presign/public-URL.
- `uploads/presign/route.test.ts`: configured/not-configured, default content type, bad content type (400), null-presign fallback, 500 on throw.
- `upload-image.test.ts`: not-a-data-URL, not-configured fallback, successful upload, PUT-failure fallback, network-error fallback, PNG content type.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors (2 pre-existing img warnings, unrelated)
- `npm run format:check`: clean
- `npm test`: 429 passed
- `npm run build`: succeeds (requires DATABASE_URL present, a pre-existing build requirement)
