### PR TITLE
feat(backend): guard report status-machine transitions [#104]

### DIFF
--- a/nexa/src/app/api/cron/poll-status/route.ts
+++ b/nexa/src/app/api/cron/poll-status/route.ts
@@ -4,8 +4,11 @@ import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
 import {
   fetchOpen311Status,
   parseOpen311Config,
-  STATUS_RANK,
 } from "@/lib/submission/open311";
+import {
+  canTransition,
+  isForwardTransition,
+} from "@/lib/reports/status-machine";
 import { sendPush } from "@/lib/push";
 
 // GET /api/cron/poll-status
@@ -109,8 +112,13 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      // Never regress: only advance to a status strictly later in the lifecycle.
-      if (STATUS_RANK[result.reportStatus] <= STATUS_RANK[report.status]) {
+      // Never regress: only advance to a status strictly later in the
+      // lifecycle, and only along a transition the status machine permits.
+      // (Both are centralized in src/lib/reports/status-machine.ts.)
+      if (
+        !isForwardTransition(report.status, result.reportStatus) ||
+        !canTransition(report.status, result.reportStatus)
+      ) {
         continue;
       }
 

--- a/nexa/src/app/api/reports/[id]/resolution/route.test.ts
+++ b/nexa/src/app/api/reports/[id]/resolution/route.test.ts
@@ -1,209 +1,186 @@
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
+import { ReportStatus } from "@/generated/prisma/enums";
 import { makeReport } from "@/test/factories/report";
 import { prismaMock } from "@/test/prisma-mock";
 
-// Resolution is owner-only: it gates on getSession(), so mock the auth module.
-vi.mock("@/lib/auth", () => ({ getSession: vi.fn() }));
-import { getSession } from "@/lib/auth";
+const getSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => getSession(),
+}));
 
 import { POST } from "./route";
 
-const mockedGetSession = vi.mocked(getSession);
+beforeEach(() => {
+  getSession.mockReset();
+  getSession.mockResolvedValue({ userId: "user_1", email: "u@x.com" });
+});
 
-function resolutionRequest(body: unknown): NextRequest {
-  return new NextRequest("http://localhost/api/reports/report_1/resolution", {
+function postRequest(id: string, resolved: boolean): NextRequest {
+  return new NextRequest(`http://localhost/api/reports/${id}/resolution`, {
     method: "POST",
-    body: JSON.stringify(body),
+    body: JSON.stringify({ resolved }),
   });
 }
 
-function params(id: string) {
-  return { params: Promise.resolve({ id }) };
+function call(id: string, resolved: boolean) {
+  return POST(postRequest(id, resolved), {
+    params: Promise.resolve({ id }),
+  });
 }
 
-describe("POST /api/reports/[id]/resolution", () => {
-  beforeEach(() => {
-    mockedGetSession.mockReset();
-  });
+describe("POST /api/reports/[id]/resolution status guard (#104)", () => {
+  it.each([
+    ReportStatus.DRAFT,
+    ReportStatus.CLASSIFYING,
+    ReportStatus.CONFIRMED,
+    ReportStatus.SUBMITTING,
+  ])(
+    "rejects resolving a pre-submission report (%s) with 409",
+    async (status) => {
+      const report = makeReport({
+        id: "r1",
+        userId: "user_1",
+        status,
+        issueGroupId: null,
+      });
+      prismaMock.report.findUnique.mockResolvedValue(report);
 
-  it("returns 401 when the caller is not authenticated", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue(null);
+      const response = await call("r1", true);
 
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: true }),
-      params("report_1"),
+      expect(response.status).toBe(409);
+      const body = await response.json();
+      expect(body.code).toBe("INVALID_STATUS_TRANSITION");
+      // The illegal transition must never be written.
+      expect(prismaMock.report.update).not.toHaveBeenCalled();
+      expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ReportStatus.SUBMITTED,
+    ReportStatus.ACKNOWLEDGED,
+    ReportStatus.IN_PROGRESS,
+  ])("marks a post-submission report (%s) RESOLVED", async (status) => {
+    const report = makeReport({
+      id: "r1",
+      userId: "user_1",
+      status,
+      issueGroupId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue(report);
+    prismaMock.report.update.mockResolvedValue({
+      id: "r1",
+      userResolved: true,
+      status: ReportStatus.RESOLVED,
+    } as Awaited<ReturnType<typeof prismaMock.report.update>>);
+
+    const response = await call("r1", true);
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.report.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: ReportStatus.RESOLVED }),
+      }),
     );
-    const body = await response.json();
+  });
 
-    // Assert
+  it("un-resolving (resolved=false) never changes status, even pre-submission", async () => {
+    const report = makeReport({
+      id: "r1",
+      userId: "user_1",
+      status: ReportStatus.CONFIRMED,
+      issueGroupId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue(report);
+    prismaMock.report.update.mockResolvedValue({
+      id: "r1",
+      userResolved: false,
+      status: ReportStatus.CONFIRMED,
+    } as Awaited<ReturnType<typeof prismaMock.report.update>>);
+
+    const response = await call("r1", false);
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.report.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: ReportStatus.CONFIRMED }),
+      }),
+    );
+  });
+
+  it("group resolution only advances user-resolvable members", async () => {
+    const report = makeReport({
+      id: "r1",
+      userId: "user_1",
+      status: ReportStatus.SUBMITTED,
+      issueGroupId: "group_1",
+    });
+    prismaMock.report.findUnique.mockResolvedValue(report);
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    const response = await call("r1", true);
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.$transaction).toHaveBeenCalled();
+    // The members updateMany must filter by the user-resolvable status set, not
+    // merely "not CLOSED", so pre-submission members aren't forced to RESOLVED.
+    const txArgs = prismaMock.report.updateMany.mock.calls[0]?.[0];
+    expect(txArgs?.where?.status).toEqual({
+      in: expect.arrayContaining([
+        ReportStatus.SUBMITTED,
+        ReportStatus.ACKNOWLEDGED,
+        ReportStatus.IN_PROGRESS,
+        ReportStatus.RESOLVED,
+      ]),
+    });
+  });
+
+  it("rejects resolving a CLOSED report with 409", async () => {
+    const report = makeReport({
+      id: "r1",
+      userId: "user_1",
+      status: ReportStatus.CLOSED,
+      issueGroupId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue(report);
+
+    const response = await call("r1", true);
+
+    expect(response.status).toBe(409);
+    expect(prismaMock.report.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when there is no session", async () => {
+    getSession.mockResolvedValue(null);
+
+    const response = await call("r1", true);
+
     expect(response.status).toBe(401);
-    expect(body).toEqual({ success: false, error: "Not authenticated." });
     expect(prismaMock.report.findUnique).not.toHaveBeenCalled();
   });
 
-  it("returns 400 when `resolved` is not a boolean", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
-
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: "yes" }),
-      params("report_1"),
-    );
-    const body = await response.json();
-
-    // Assert
-    expect(response.status).toBe(400);
-    expect(body.success).toBe(false);
-    // The parser prefixes the failing field path onto the schema message.
-    expect(body.error).toBe("resolved: Field `resolved` must be a boolean.");
-    expect(prismaMock.report.update).not.toHaveBeenCalled();
-  });
-
   it("returns 404 when the report does not exist", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
     prismaMock.report.findUnique.mockResolvedValue(null);
 
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: true }),
-      params("missing"),
-    );
-    const body = await response.json();
+    const response = await call("missing", true);
 
-    // Assert
     expect(response.status).toBe(404);
-    expect(body).toEqual({ success: false, error: "Report not found." });
   });
 
   it("returns 403 when the caller does not own the report", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
-    prismaMock.report.findUnique.mockResolvedValue(
-      makeReport({
-        id: "report_1",
-        userId: "someone_else",
-        issueGroupId: null,
-      }),
-    );
+    const report = makeReport({
+      id: "r1",
+      userId: "someone_else",
+      status: ReportStatus.SUBMITTED,
+      issueGroupId: null,
+    });
+    prismaMock.report.findUnique.mockResolvedValue(report);
 
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: true }),
-      params("report_1"),
-    );
-    const body = await response.json();
+    const response = await call("r1", true);
 
-    // Assert
     expect(response.status).toBe(403);
-    expect(body).toEqual({
-      success: false,
-      error: "You can only update your own reports.",
-    });
     expect(prismaMock.report.update).not.toHaveBeenCalled();
-  });
-
-  it("marks an ungrouped report resolved and promotes its status to RESOLVED", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
-    prismaMock.report.findUnique.mockResolvedValue(
-      makeReport({
-        id: "report_1",
-        userId: "owner",
-        issueGroupId: null,
-        status: "CONFIRMED",
-      }),
-    );
-    // The route returns exactly what `update` resolves to; the real query uses a
-    // narrowed `select`, so mirror that shape here.
-    prismaMock.report.update.mockResolvedValue({
-      id: "report_1",
-      userResolved: true,
-      status: "RESOLVED",
-    } as Awaited<ReturnType<typeof prismaMock.report.update>>);
-
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: true }),
-      params("report_1"),
-    );
-    const body = await response.json();
-
-    // Assert
-    expect(response.status).toBe(200);
-    expect(body).toEqual({
-      success: true,
-      data: { id: "report_1", userResolved: true, status: "RESOLVED" },
-    });
-
-    const updateArgs = prismaMock.report.update.mock.calls[0][0];
-    expect(updateArgs.where).toEqual({ id: "report_1" });
-    expect(updateArgs.data).toMatchObject({
-      userResolved: true,
-      status: "RESOLVED",
-    });
-    expect(updateArgs.data?.userResolvedAt).toBeInstanceOf(Date);
-  });
-
-  it("keeps the existing status when un-resolving (resolved=false)", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
-    prismaMock.report.findUnique.mockResolvedValue(
-      makeReport({
-        id: "report_1",
-        userId: "owner",
-        issueGroupId: null,
-        status: "CONFIRMED",
-      }),
-    );
-    prismaMock.report.update.mockResolvedValue({
-      id: "report_1",
-      userResolved: false,
-      status: "CONFIRMED",
-    } as Awaited<ReturnType<typeof prismaMock.report.update>>);
-
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: false }),
-      params("report_1"),
-    );
-    const body = await response.json();
-
-    // Assert
-    expect(response.status).toBe(200);
-    const updateArgs = prismaMock.report.update.mock.calls[0][0];
-    // resolved=false leaves status untouched (stays CONFIRMED).
-    expect(updateArgs.data).toMatchObject({
-      userResolved: false,
-      status: "CONFIRMED",
-    });
-  });
-
-  it("returns 500 when the update throws", async () => {
-    // Arrange
-    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
-    prismaMock.report.findUnique.mockResolvedValue(
-      makeReport({ id: "report_1", userId: "owner", issueGroupId: null }),
-    );
-    prismaMock.report.update.mockRejectedValue(new Error("db down"));
-
-    // Act
-    const response = await POST(
-      resolutionRequest({ resolved: true }),
-      params("report_1"),
-    );
-    const body = await response.json();
-
-    // Assert
-    expect(response.status).toBe(500);
-    expect(body).toEqual({
-      success: false,
-      error: "Failed to update resolution. Please try again.",
-    });
   });
 });

--- a/nexa/src/app/api/reports/[id]/resolution/route.ts
+++ b/nexa/src/app/api/reports/[id]/resolution/route.ts
@@ -8,6 +8,11 @@ import {
   parseErrorResponse,
 } from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
+import { ReportStatus } from "@/generated/prisma/enums";
+import {
+  USER_RESOLVABLE_FROM,
+  canTransition,
+} from "@/lib/reports/status-machine";
 
 export async function POST(
   request: NextRequest,
@@ -37,10 +42,25 @@ export async function POST(
 
     const resolvedAt = new Date();
 
+    // Status-machine guard (#104): a user may only mark a report RESOLVED once
+    // it has at least reached SUBMITTED. Resolving a DRAFT / CLASSIFYING /
+    // CONFIRMED / SUBMITTING report would bypass the submission flow, so reject
+    // it rather than writing an illegal transition. Un-resolving (resolved =
+    // false) never moves status, so it's always allowed.
+    if (resolved && !USER_RESOLVABLE_FROM.includes(report.status)) {
+      return errorResponse(
+        "This report can't be marked resolved yet — it hasn't been submitted.",
+        409,
+        "INVALID_STATUS_TRANSITION",
+      );
+    }
+
     // Shared resolution: when a report that belongs to an IssueGroup is marked
     // resolved, the whole case resolves for every reporter linked to it. The
-    // group is flagged resolved and every non-closed member report is updated to
-    // match. Reports with no group keep the single-report behavior below.
+    // group is flagged resolved and every member report that is itself
+    // user-resolvable is advanced to RESOLVED — members still pre-submission (or
+    // already CLOSED) keep their status, so the case resolution never forces an
+    // illegal transition on them.
     if (report.issueGroupId && resolved) {
       await prisma.$transaction([
         prisma.issueGroup.update({
@@ -54,12 +74,12 @@ export async function POST(
         prisma.report.updateMany({
           where: {
             issueGroupId: report.issueGroupId,
-            status: { not: "CLOSED" },
+            status: { in: USER_RESOLVABLE_FROM },
           },
           data: {
             userResolved: true,
             userResolvedAt: resolvedAt,
-            status: "RESOLVED",
+            status: ReportStatus.RESOLVED,
           },
         }),
       ]);
@@ -67,12 +87,21 @@ export async function POST(
       return successResponse({
         id: report.id,
         userResolved: true,
-        status: report.status === "CLOSED" ? "CLOSED" : "RESOLVED",
+        status: ReportStatus.RESOLVED,
       });
     }
 
-    const nextStatus =
-      resolved && report.status !== "CLOSED" ? "RESOLVED" : report.status;
+    // Single-report path. The guard above guarantees that when `resolved` is
+    // true the report is in a user-resolvable status, so RESOLVED is always a
+    // legal target here; this assertion documents that invariant.
+    const nextStatus = resolved ? ReportStatus.RESOLVED : report.status;
+    if (resolved && !canTransition(report.status, nextStatus)) {
+      return errorResponse(
+        "This report can't be marked resolved yet.",
+        409,
+        "INVALID_STATUS_TRANSITION",
+      );
+    }
 
     const updated = await prisma.report.update({
       where: { id },

--- a/nexa/src/app/api/reports/route.ts
+++ b/nexa/src/app/api/reports/route.ts
@@ -11,6 +11,7 @@ import {
   parseErrorResponse,
 } from "@/lib/api/request-parser";
 import { successResponse, errorResponse } from "@/lib/api/response";
+import { ReportStatus } from "@/generated/prisma/enums";
 
 export async function POST(request: NextRequest) {
   try {
@@ -86,7 +87,13 @@ export async function POST(request: NextRequest) {
         imageUrl,
         agencyId,
         issueGroupId,
-        status: "CONFIRMED",
+        // A report row is only created once the user has reviewed the AI
+        // classification and confirmed it client-side (the `/api/reports/classify`
+        // endpoint is stateless and persists nothing). So the report is born
+        // CONFIRMED — the DRAFT / CLASSIFYING enum values model the pre-creation
+        // stages that live in the client and are never persisted on this path.
+        // This is the start state of the lifecycle in src/lib/reports/status-machine.ts.
+        status: ReportStatus.CONFIRMED,
       },
     });
 

--- a/nexa/src/lib/reports/status-machine.test.ts
+++ b/nexa/src/lib/reports/status-machine.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { ReportStatus } from "@/generated/prisma/enums";
+import {
+  STATUS_RANK,
+  USER_RESOLVABLE_FROM,
+  TERMINAL_STATUSES,
+  canTransition,
+  isForwardTransition,
+  assertTransition,
+  InvalidStatusTransitionError,
+} from "./status-machine";
+
+// The forward "happy path" every report follows. Each adjacent pair must be a
+// legal transition; this is the contract the mutation sites depend on.
+const HAPPY_PATH: ReportStatus[] = [
+  ReportStatus.DRAFT,
+  ReportStatus.CLASSIFYING,
+  ReportStatus.CONFIRMED,
+  ReportStatus.SUBMITTING,
+  ReportStatus.SUBMITTED,
+  ReportStatus.ACKNOWLEDGED,
+  ReportStatus.IN_PROGRESS,
+  ReportStatus.RESOLVED,
+  ReportStatus.CLOSED,
+];
+
+describe("STATUS_RANK", () => {
+  it("ranks the lifecycle strictly monotonically", () => {
+    for (let i = 1; i < HAPPY_PATH.length; i++) {
+      expect(STATUS_RANK[HAPPY_PATH[i]]).toBeGreaterThan(
+        STATUS_RANK[HAPPY_PATH[i - 1]],
+      );
+    }
+  });
+
+  it("assigns a distinct rank to every status", () => {
+    const ranks = Object.values(STATUS_RANK);
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});
+
+describe("canTransition", () => {
+  it("allows every adjacent step of the happy path", () => {
+    for (let i = 1; i < HAPPY_PATH.length; i++) {
+      expect(canTransition(HAPPY_PATH[i - 1], HAPPY_PATH[i])).toBe(true);
+    }
+  });
+
+  it("treats staying in the same status as a no-op (always allowed)", () => {
+    for (const status of HAPPY_PATH) {
+      expect(canTransition(status, status)).toBe(true);
+    }
+  });
+
+  it("rejects skipping submission: pre-submission states cannot jump to RESOLVED", () => {
+    for (const from of [
+      ReportStatus.DRAFT,
+      ReportStatus.CLASSIFYING,
+      ReportStatus.CONFIRMED,
+      ReportStatus.SUBMITTING,
+    ]) {
+      expect(canTransition(from, ReportStatus.RESOLVED)).toBe(false);
+    }
+  });
+
+  it("allows RESOLVED from each user-resolvable post-submission state", () => {
+    for (const from of [
+      ReportStatus.SUBMITTED,
+      ReportStatus.ACKNOWLEDGED,
+      ReportStatus.IN_PROGRESS,
+    ]) {
+      expect(canTransition(from, ReportStatus.RESOLVED)).toBe(true);
+    }
+  });
+
+  it("treats CLOSED as terminal", () => {
+    for (const to of HAPPY_PATH) {
+      if (to === ReportStatus.CLOSED) continue;
+      expect(canTransition(ReportStatus.CLOSED, to)).toBe(false);
+    }
+  });
+
+  it("allows the orchestrator rollback SUBMITTING -> CONFIRMED", () => {
+    expect(canTransition(ReportStatus.SUBMITTING, ReportStatus.CONFIRMED)).toBe(
+      true,
+    );
+  });
+
+  it("allows the agency to reopen RESOLVED -> IN_PROGRESS", () => {
+    expect(canTransition(ReportStatus.RESOLVED, ReportStatus.IN_PROGRESS)).toBe(
+      true,
+    );
+  });
+
+  it("rejects regressing a confirmed report back to draft", () => {
+    expect(canTransition(ReportStatus.CONFIRMED, ReportStatus.DRAFT)).toBe(
+      false,
+    );
+  });
+});
+
+describe("isForwardTransition", () => {
+  it("is true only when the target ranks strictly higher", () => {
+    expect(
+      isForwardTransition(ReportStatus.SUBMITTED, ReportStatus.IN_PROGRESS),
+    ).toBe(true);
+    expect(
+      isForwardTransition(ReportStatus.IN_PROGRESS, ReportStatus.SUBMITTED),
+    ).toBe(false);
+    expect(
+      isForwardTransition(ReportStatus.SUBMITTED, ReportStatus.SUBMITTED),
+    ).toBe(false);
+  });
+});
+
+describe("assertTransition", () => {
+  it("does not throw on a legal transition", () => {
+    expect(() =>
+      assertTransition(ReportStatus.CONFIRMED, ReportStatus.SUBMITTING),
+    ).not.toThrow();
+  });
+
+  it("throws InvalidStatusTransitionError on an illegal transition", () => {
+    expect(() =>
+      assertTransition(ReportStatus.DRAFT, ReportStatus.RESOLVED),
+    ).toThrow(InvalidStatusTransitionError);
+  });
+});
+
+describe("constants", () => {
+  it("USER_RESOLVABLE_FROM contains exactly the post-submission, non-closed states", () => {
+    expect(new Set(USER_RESOLVABLE_FROM)).toEqual(
+      new Set([
+        ReportStatus.SUBMITTED,
+        ReportStatus.ACKNOWLEDGED,
+        ReportStatus.IN_PROGRESS,
+        ReportStatus.RESOLVED,
+      ]),
+    );
+  });
+
+  it("TERMINAL_STATUSES are RESOLVED and CLOSED", () => {
+    expect(new Set(TERMINAL_STATUSES)).toEqual(
+      new Set([ReportStatus.RESOLVED, ReportStatus.CLOSED]),
+    );
+  });
+});

--- a/nexa/src/lib/reports/status-machine.ts
+++ b/nexa/src/lib/reports/status-machine.ts
@@ -1,0 +1,159 @@
+import { ReportStatus } from "@/generated/prisma/enums";
+
+// ---------------------------------------------------------------------------
+// Report status machine (issue #104)
+//
+// A single source of truth for the report lifecycle: which `ReportStatus`
+// transitions are allowed, and a `canTransition` / `assertTransition` pair the
+// mutation sites use so an invalid transition (e.g. DRAFT -> RESOLVED, or the
+// poller demoting a report) is rejected rather than silently written.
+//
+// Lifecycle (forward, "happy path"):
+//
+//   DRAFT -> CLASSIFYING -> CONFIRMED -> SUBMITTING -> SUBMITTED
+//         -> ACKNOWLEDGED -> IN_PROGRESS -> RESOLVED -> CLOSED
+//
+//   - DRAFT        a report row exists but hasn't been classified/confirmed.
+//                  (Schema default; today the create flow in src/app/api/reports
+//                  confirms immediately, since classification runs client-side
+//                  before the row is created — see the route's comment.)
+//   - CLASSIFYING  AI classification is in flight. Optional intermediate state.
+//   - CONFIRMED    the user confirmed the report; it is ready to submit.
+//   - SUBMITTING   a submission agent has atomically claimed the report.
+//   - SUBMITTED    filed with the agency; the poller now tracks it.
+//   - ACKNOWLEDGED / IN_PROGRESS  agency-reported progress (from the poller).
+//   - RESOLVED     the issue is resolved (by the agency or the reporter).
+//   - CLOSED       terminal; no further transitions.
+//
+// Besides the forward path there are a few legitimate non-forward edges:
+//   - SUBMITTING -> CONFIRMED   rollback when a submission attempt fails.
+//   - CLASSIFYING -> DRAFT      classification was cancelled / reset.
+//   - any non-terminal -> CLOSED  an admin/cleanup may close a report.
+//   - RESOLVED -> IN_PROGRESS   the agency reopened a "resolved" case.
+//
+// The poller additionally only ever moves a report *forward* by rank
+// (see STATUS_RANK + isForwardTransition) so an Open311 "open" can never demote
+// a report a human already advanced.
+// ---------------------------------------------------------------------------
+
+/**
+ * Monotonic rank of each lifecycle state. Used to detect forward vs. backward
+ * movement (e.g. the status poller never regresses a report). This is the
+ * single ranking for the app; `open311.ts` re-exports it for backward compat.
+ */
+export const STATUS_RANK: Record<ReportStatus, number> = {
+  [ReportStatus.DRAFT]: 0,
+  [ReportStatus.CLASSIFYING]: 1,
+  [ReportStatus.CONFIRMED]: 2,
+  [ReportStatus.SUBMITTING]: 3,
+  [ReportStatus.SUBMITTED]: 4,
+  [ReportStatus.ACKNOWLEDGED]: 5,
+  [ReportStatus.IN_PROGRESS]: 6,
+  [ReportStatus.RESOLVED]: 7,
+  [ReportStatus.CLOSED]: 8,
+};
+
+/**
+ * Allowed transitions, keyed by the *from* status. A transition is permitted
+ * iff the target appears in the source's set. CLOSED is terminal (empty set).
+ *
+ * Re-entering the same status is treated as a no-op and always allowed (see
+ * `canTransition`), so idempotent writes don't need to be special-cased here.
+ */
+const ALLOWED_TRANSITIONS: Record<ReportStatus, ReportStatus[]> = {
+  [ReportStatus.DRAFT]: [
+    ReportStatus.CLASSIFYING,
+    ReportStatus.CONFIRMED,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.CLASSIFYING]: [
+    ReportStatus.CONFIRMED,
+    ReportStatus.DRAFT,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.CONFIRMED]: [ReportStatus.SUBMITTING, ReportStatus.CLOSED],
+  [ReportStatus.SUBMITTING]: [
+    ReportStatus.SUBMITTED,
+    // Rollback when a submission attempt fails (orchestrator).
+    ReportStatus.CONFIRMED,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.SUBMITTED]: [
+    ReportStatus.ACKNOWLEDGED,
+    ReportStatus.IN_PROGRESS,
+    ReportStatus.RESOLVED,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.ACKNOWLEDGED]: [
+    ReportStatus.IN_PROGRESS,
+    ReportStatus.RESOLVED,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.IN_PROGRESS]: [ReportStatus.RESOLVED, ReportStatus.CLOSED],
+  [ReportStatus.RESOLVED]: [
+    // The agency can reopen a case it previously marked resolved.
+    ReportStatus.IN_PROGRESS,
+    ReportStatus.CLOSED,
+  ],
+  [ReportStatus.CLOSED]: [],
+};
+
+/**
+ * The statuses from which a *user* may mark a report RESOLVED. A report must
+ * have at least been submitted before it can be user-resolved — resolving a
+ * DRAFT / CLASSIFYING / CONFIRMED / SUBMITTING report would bypass the
+ * submission flow. (Enforced by the resolution endpoint, issue #104.)
+ */
+export const USER_RESOLVABLE_FROM: ReportStatus[] = [
+  ReportStatus.SUBMITTED,
+  ReportStatus.ACKNOWLEDGED,
+  ReportStatus.IN_PROGRESS,
+  ReportStatus.RESOLVED,
+];
+
+/** Terminal states the poller (and other automations) stop tracking. */
+export const TERMINAL_STATUSES: ReportStatus[] = [
+  ReportStatus.RESOLVED,
+  ReportStatus.CLOSED,
+];
+
+/**
+ * Whether moving from `from` to `to` is a legal status transition. Staying in
+ * the same status is always allowed (idempotent no-op write).
+ */
+export function canTransition(from: ReportStatus, to: ReportStatus): boolean {
+  if (from === to) return true;
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/** True when `to` is strictly later in the lifecycle than `from` by rank. */
+export function isForwardTransition(
+  from: ReportStatus,
+  to: ReportStatus,
+): boolean {
+  return STATUS_RANK[to] > STATUS_RANK[from];
+}
+
+/** Thrown by `assertTransition` when a transition isn't allowed. */
+export class InvalidStatusTransitionError extends Error {
+  readonly from: ReportStatus;
+  readonly to: ReportStatus;
+
+  constructor(from: ReportStatus, to: ReportStatus) {
+    super(`Invalid report status transition: ${from} -> ${to}.`);
+    this.name = "InvalidStatusTransitionError";
+    this.from = from;
+    this.to = to;
+  }
+}
+
+/**
+ * Asserts that `from -> to` is a legal transition, throwing
+ * `InvalidStatusTransitionError` otherwise. Use at mutation sites that aren't
+ * already guarded by a conditional DB update.
+ */
+export function assertTransition(from: ReportStatus, to: ReportStatus): void {
+  if (!canTransition(from, to)) {
+    throw new InvalidStatusTransitionError(from, to);
+  }
+}

--- a/nexa/src/lib/submission/open311.ts
+++ b/nexa/src/lib/submission/open311.ts
@@ -441,22 +441,11 @@ export function mapOpen311Status(open311Status: string): ReportStatus | null {
   }
 }
 
-/**
- * Monotonic rank of our lifecycle states, used by the poller to avoid moving a
- * report *backwards* (e.g. an endpoint that reports "open" should never demote
- * a report a human already marked IN_PROGRESS).
- */
-export const STATUS_RANK: Record<ReportStatus, number> = {
-  [ReportStatus.DRAFT]: 0,
-  [ReportStatus.CLASSIFYING]: 1,
-  [ReportStatus.CONFIRMED]: 2,
-  [ReportStatus.SUBMITTING]: 3,
-  [ReportStatus.SUBMITTED]: 4,
-  [ReportStatus.ACKNOWLEDGED]: 5,
-  [ReportStatus.IN_PROGRESS]: 6,
-  [ReportStatus.RESOLVED]: 7,
-  [ReportStatus.CLOSED]: 8,
-};
+// Monotonic rank of our lifecycle states, used by the poller to avoid moving a
+// report *backwards* (e.g. an endpoint that reports "open" should never demote
+// a report a human already marked IN_PROGRESS). The canonical definition lives
+// in the report status machine; re-exported here for existing importers.
+export { STATUS_RANK } from "@/lib/reports/status-machine";
 
 function stringOrNull(value: unknown): string | null {
   if (typeof value === "string" && value.trim()) return value.trim();


### PR DESCRIPTION
Closes #104.

## What
Centralizes the report status machine into a single source of truth and enforces it at every status-mutation site, so genuinely-invalid transitions are rejected. Happy-path behavior is unchanged.

New module `src/lib/reports/status-machine.ts` exports:
- `STATUS_RANK` (moved here; re-exported from `open311.ts` for existing importers — no parallel ranking)
- `canTransition(from, to)` / `assertTransition(from, to)` (+ `InvalidStatusTransitionError`)
- `isForwardTransition(from, to)` (rank-based monotonic check, used by the poller)
- `USER_RESOLVABLE_FROM`, `TERMINAL_STATUSES`

## Transition table
`from -> [allowed to]` (staying in the same status is always allowed as an idempotent no-op):

| From | Allowed to |
|---|---|
| DRAFT | CLASSIFYING, CONFIRMED, CLOSED |
| CLASSIFYING | CONFIRMED, DRAFT, CLOSED |
| CONFIRMED | SUBMITTING, CLOSED |
| SUBMITTING | SUBMITTED, CONFIRMED (rollback), CLOSED |
| SUBMITTED | ACKNOWLEDGED, IN_PROGRESS, RESOLVED, CLOSED |
| ACKNOWLEDGED | IN_PROGRESS, RESOLVED, CLOSED |
| IN_PROGRESS | RESOLVED, CLOSED |
| RESOLVED | IN_PROGRESS (agency reopen), CLOSED |
| CLOSED | — (terminal) |

User-may-mark-RESOLVED-from (`USER_RESOLVABLE_FROM`): SUBMITTED, ACKNOWLEDGED, IN_PROGRESS, RESOLVED.

## Where it's enforced
- **`src/app/api/reports/[id]/resolution/route.ts`** — a user may only set RESOLVED from a post-submission state. Pre-submission (DRAFT/CLASSIFYING/CONFIRMED/SUBMITTING) and CLOSED reports are rejected with `409 INVALID_STATUS_TRANSITION` (previously RESOLVED was settable from ANY non-CLOSED state). Group resolution's `updateMany` now filters members by `USER_RESOLVABLE_FROM` instead of `{ not: CLOSED }`, so pre-submission members in a case aren't yanked to RESOLVED. `resolved=false` (un-resolve) never moves status and stays allowed.
- **`src/app/api/cron/poll-status/route.ts`** — advances only when the change is both forward by rank (`isForwardTransition`) AND a legal transition (`canTransition`), replacing the inline `STATUS_RANK` comparison. Monotonic, never-regress behavior preserved.
- **`src/app/api/reports/route.ts`** — create still starts at CONFIRMED (unchanged happy path); now uses the typed `ReportStatus.CONFIRMED` and documents why (classification runs client-side before the row is created, so DRAFT/CLASSIFYING are pre-creation client stages, never persisted on this path).
- **`src/lib/submission/orchestrate.ts`** — already enforces transitions via atomic conditional updates (CONFIRMED->SUBMITTING claim, SUBMITTING->SUBMITTED, rollback to CONFIRMED); all are valid edges in the table. Left as-is (the DB-level guard is the strongest form).

## DRAFT/CLASSIFYING semantics
The `classify` route is stateless (persists nothing), so CLASSIFYING was never written. Rather than removing enum values (which would need a migration), the lifecycle is documented: DRAFT/CLASSIFYING model the pre-creation client stages; the persisted lifecycle starts at CONFIRMED. Schema default left untouched (no migration).

## Tests
- `src/lib/reports/status-machine.test.ts` — ranking monotonicity, happy-path edges, rejected skips (pre-submission -> RESOLVED), rollback/reopen edges, terminal CLOSED, assert/throw.
- `src/app/api/reports/[id]/resolution/route.test.ts` — 409 for pre-submission and CLOSED, success for post-submission, un-resolve no-op, group-member filtering.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated)
- `npm run format:check` — clean
- `npm test` — 447 passed (43 files)