### PR TITLE
test: integration + Open311 idempotency tests for classify/submit/form-link/cron [#116]

### DIFF
--- a/nexa/src/app/api/location/suggest/route.test.ts
+++ b/nexa/src/app/api/location/suggest/route.test.ts
@@ -21,20 +21,24 @@ vi.mock("@/lib/http", async (importOriginal) => {
 });
 
 import { GET } from "./route";
+import { __resetRateLimitStore } from "@/lib/rate-limit";
 
 function request(query: string): NextRequest {
   return new NextRequest(
     `http://localhost/api/location/suggest?q=${encodeURIComponent(query)}`,
+    { headers: { "x-forwarded-for": "10.2.0.1" } },
   );
 }
 
 describe("GET /api/location/suggest", () => {
   beforeEach(() => {
+    __resetRateLimitStore();
     // No Google key so the route falls through to the Nominatim branch.
     getGoogleMapsApiKey.mockReturnValue(undefined);
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
@@ -75,5 +79,102 @@ describe("GET /api/location/suggest", () => {
     expect(body).not.toHaveProperty("data");
 
     errorSpy.mockRestore();
+  });
+
+  it("maps Google autocomplete + details to the top-5 suggestions when a key is set", async () => {
+    // Arrange: a Google key is present, so the route uses the Google branch.
+    getGoogleMapsApiKey.mockReturnValue("g-key");
+    fetchWithTimeout.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/autocomplete/json")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              status: "OK",
+              predictions: [
+                { description: "1 Main St", place_id: "p1" },
+                { description: "2 Main St", place_id: "p2" },
+              ],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      // Place details: a different fixed location per place_id.
+      const lat = url.includes("place_id=p1") ? 37.1 : 37.2;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            status: "OK",
+            result: {
+              formatted_address:
+                lat === 37.1 ? "1 Main St, CA" : "2 Main St, CA",
+              geometry: { location: { lat, lng: -122.0 } },
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    // Act
+    const res = await GET(request("1 Main"));
+    const body = await res.json();
+
+    // Assert: each prediction mapped to {displayName, latitude, longitude}.
+    expect(res.status).toBe(200);
+    expect(body.data.suggestions).toEqual([
+      { displayName: "1 Main St, CA", latitude: 37.1, longitude: -122.0 },
+      { displayName: "2 Main St, CA", latitude: 37.2, longitude: -122.0 },
+    ]);
+  });
+
+  it("falls back to Nominatim when Google returns no usable predictions", async () => {
+    // Arrange: Google key set but autocomplete is empty -> Nominatim fallback.
+    getGoogleMapsApiKey.mockReturnValue("g-key");
+    fetchWithTimeout.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("maps.googleapis.com")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: "ZERO_RESULTS" }), {
+            status: 200,
+          }),
+        );
+      }
+      // Nominatim hit.
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            { display_name: "Nominatim Pl", lat: "37.5", lon: "-122.3" },
+          ]),
+          { status: 200 },
+        ),
+      );
+    });
+
+    // Act
+    const res = await GET(request("somewhere"));
+    const body = await res.json();
+
+    // Assert
+    expect(body.data.suggestions).toEqual([
+      { displayName: "Nominatim Pl", latitude: 37.5, longitude: -122.3 },
+    ]);
+  });
+
+  it("returns a 429 with a Retry-After header when the rate limit is exceeded", async () => {
+    // Arrange: a limit of 1 means the second call from the same IP is blocked.
+    vi.stubEnv("RATE_LIMIT_MAX", "1");
+
+    // Act: first request consumes the single allowed slot.
+    const first = await GET(request("first call"));
+    const second = await GET(request("second call"));
+
+    // Assert
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.headers.get("Retry-After")).toBeTruthy();
+    const body = await second.json();
+    expect(body.code).toBe("RATE_LIMITED");
   });
 });

--- a/nexa/src/app/api/reports/classify/route.test.ts
+++ b/nexa/src/app/api/reports/classify/route.test.ts
@@ -1,0 +1,179 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { comparisonResult } from "@/test/fixtures/classification";
+
+// The route fans out to paid LLM providers via `classifyWithConsensus`; mock it
+// so the route's own logic (validation, LocationContext assembly, error mapping)
+// runs with zero network/LLM. `vi.hoisted` lets the hoisted `vi.mock` factory
+// reference the spy without a TDZ error.
+const { classifyWithConsensus } = vi.hoisted(() => ({
+  classifyWithConsensus: vi.fn(),
+}));
+vi.mock("@/lib/classify/consensus", () => ({ classifyWithConsensus }));
+
+import { POST } from "./route";
+import { __resetRateLimitStore } from "@/lib/rate-limit";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/reports/classify", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": "10.0.0.1",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const extendedResult = {
+  ...comparisonResult,
+  observation: null,
+  preprocess: null,
+  locationUsed: null,
+};
+
+describe("POST /api/reports/classify", () => {
+  beforeEach(() => {
+    __resetRateLimitStore();
+    classifyWithConsensus.mockReset();
+    classifyWithConsensus.mockResolvedValue(extendedResult);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 400 when neither description nor imageBase64 is provided", async () => {
+    // Act
+    const res = await POST(post({}));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error: "Provide a description or image.",
+    });
+    expect(classifyWithConsensus).not.toHaveBeenCalled();
+  });
+
+  it("classifies a description-only request and returns the consensus result", async () => {
+    // Act
+    const res = await POST(post({ description: "Pothole on Main St" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: extendedResult });
+    expect(classifyWithConsensus).toHaveBeenCalledWith(
+      "Pothole on Main St",
+      null,
+      { twoStage: true, location: null },
+    );
+  });
+
+  it("proceeds with an image-only request (no description)", async () => {
+    // Act
+    const res = await POST(post({ imageBase64: "data:image/png;base64,AAAA" }));
+
+    // Assert: empty-string description, image forwarded, no location.
+    expect(res.status).toBe(200);
+    expect(classifyWithConsensus).toHaveBeenCalledWith(
+      "",
+      "data:image/png;base64,AAAA",
+      { twoStage: true, location: null },
+    );
+  });
+
+  it("builds a LocationContext from lat/lon/address/jurisdiction", async () => {
+    // Act
+    await POST(
+      post({
+        description: "Streetlight out",
+        latitude: 37.44,
+        longitude: -122.14,
+        address: "123 Main St",
+        jurisdiction: "Palo Alto",
+      }),
+    );
+
+    // Assert
+    expect(classifyWithConsensus).toHaveBeenCalledWith(
+      "Streetlight out",
+      null,
+      {
+        twoStage: true,
+        location: {
+          latitude: 37.44,
+          longitude: -122.14,
+          address: "123 Main St",
+          jurisdiction: "Palo Alto",
+        },
+      },
+    );
+  });
+
+  it("builds a LocationContext when only an address is supplied (no coords)", async () => {
+    // Act
+    await POST(post({ description: "x", address: "456 Elm St" }));
+
+    // Assert: missing coords become null, address present -> location built.
+    expect(classifyWithConsensus).toHaveBeenCalledWith("x", null, {
+      twoStage: true,
+      location: {
+        latitude: null,
+        longitude: null,
+        address: "456 Elm St",
+        jurisdiction: null,
+      },
+    });
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    // Arrange: malformed JSON body exercises the RequestParseError path.
+    const req = new NextRequest("http://localhost/api/reports/classify", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "10.0.0.2",
+      },
+      body: "{ not json",
+    });
+
+    // Act
+    const res = await POST(req);
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(classifyWithConsensus).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when latitude is out of WGS84 range (schema bound)", async () => {
+    // Act
+    const res = await POST(post({ description: "x", latitude: 200 }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(classifyWithConsensus).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when consensus classification throws", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    classifyWithConsensus.mockRejectedValue(new Error("provider down"));
+
+    // Act
+    const res = await POST(post({ description: "x" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Classification failed. Please try again.",
+    });
+  });
+});

--- a/nexa/src/app/api/reports/form-link/route.test.ts
+++ b/nexa/src/app/api/reports/form-link/route.test.ts
@@ -1,0 +1,327 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IssueType } from "@/generated/prisma/enums";
+
+// External boundaries the route depends on, all mocked so no real Nominatim /
+// OpenAI / polygon-data network or compute runs:
+//   - fetchWithTimeout: Nominatim reverse (coords->city) and search (address->coords)
+//   - resolveJurisdiction: the curated polygon registry
+//   - getOpenAI().responses.create: the LLM fallback
+// `vi.hoisted` lets the hoisted `vi.mock` factories reference the spies.
+const { fetchWithTimeout, resolveJurisdiction, responsesCreate } = vi.hoisted(
+  () => ({
+    fetchWithTimeout: vi.fn(),
+    resolveJurisdiction: vi.fn(),
+    responsesCreate: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/http")>();
+  return { ...actual, fetchWithTimeout };
+});
+
+vi.mock("@/lib/jurisdictions/resolve", () => ({ resolveJurisdiction }));
+
+vi.mock("@/lib/openai", () => ({
+  getOpenAI: () => ({ responses: { create: responsesCreate } }),
+}));
+
+import { POST } from "./route";
+import { __resetRateLimitStore } from "@/lib/rate-limit";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/reports/form-link", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": "10.1.0.1",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Build a Nominatim reverse-lookup Response (object with `.address`). */
+function reverseResponse(city: string | null, state: string | null): Response {
+  const address: Record<string, string> = {};
+  if (city) address.city = city;
+  if (state) address.state = state;
+  return new Response(JSON.stringify({ address }), { status: 200 });
+}
+
+/** An LLM Responses payload carrying `output_text` with the JSON verdict. */
+function llmResponse(json: unknown) {
+  return { output_text: JSON.stringify(json), output: [] };
+}
+
+describe("POST /api/reports/form-link", () => {
+  beforeEach(() => {
+    __resetRateLimitStore();
+    fetchWithTimeout.mockReset();
+    resolveJurisdiction.mockReset();
+    responsesCreate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 400 when issueType is missing/invalid", async () => {
+    // Act
+    const res = await POST(post({ address: "123 Main St" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns a verified portal when a polygon match has one (found)", async () => {
+    // Arrange: coords resolve, polygon match carries a verified portal.
+    fetchWithTimeout.mockResolvedValue(
+      reverseResponse("Palo Alto", "California"),
+    );
+    resolveJurisdiction.mockReturnValue({
+      jurisdiction: { displayName: "Palo Alto" },
+      portal: {
+        url: "https://www.paloalto.gov/311",
+        reason: "Palo Alto 311 portal.",
+        confidence: "high",
+      },
+    });
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert: deterministic portal wins; the LLM is never consulted.
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual({
+      status: "found",
+      cityName: "Palo Alto",
+      formUrl: "https://www.paloalto.gov/311",
+      reason: "Palo Alto 311 portal.",
+      confidence: "high",
+    });
+    expect(responsesCreate).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the LLM and validates a .gov URL via isOfficialCityGovUrl (found)", async () => {
+    // Arrange: city resolved from coords, no polygon match -> LLM fallback.
+    fetchWithTimeout.mockResolvedValue(
+      reverseResponse("Palo Alto", "California"),
+    );
+    resolveJurisdiction.mockReturnValue(null);
+    responsesCreate.mockResolvedValue(
+      llmResponse({
+        status: "found",
+        formUrl: "https://www.paloalto.gov/Report-an-Issue",
+        reason: "City 311 page.",
+        confidence: "high",
+      }),
+    );
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(body.data).toMatchObject({
+      status: "found",
+      cityName: "Palo Alto",
+      formUrl: "https://www.paloalto.gov/Report-an-Issue",
+      confidence: "high",
+    });
+  });
+
+  it("degrades to not_found when the LLM returns a non-official (non .gov/.us) URL", async () => {
+    // Arrange
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchWithTimeout.mockResolvedValue(
+      reverseResponse("Palo Alto", "California"),
+    );
+    resolveJurisdiction.mockReturnValue(null);
+    responsesCreate.mockResolvedValue(
+      llmResponse({
+        status: "found",
+        formUrl: "https://paloalto.example.com/report",
+        reason: "Third-party site.",
+        confidence: "high",
+      }),
+    );
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert: isOfficialCityGovUrl rejects the non-gov host -> not_found.
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("not_found");
+    expect(body.data.cityName).toBe("Palo Alto");
+  });
+
+  it("uses the jurisdiction display name as the LLM hint when a polygon matched without a verified portal", async () => {
+    // Arrange: reverse lookup yields no city, polygon matches but has no portal.
+    fetchWithTimeout.mockResolvedValue(reverseResponse(null, null));
+    resolveJurisdiction.mockReturnValue({
+      jurisdiction: { displayName: "Menlo Park" },
+      portal: null,
+    });
+    responsesCreate.mockResolvedValue(
+      llmResponse({
+        status: "found",
+        formUrl: "https://www.menlopark.gov/report",
+        reason: "City portal.",
+        confidence: "medium",
+      }),
+    );
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.45,
+        longitude: -122.18,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert: cityName came from the polygon display name, LLM was consulted.
+    expect(responsesCreate).toHaveBeenCalledTimes(1);
+    expect(body.data).toMatchObject({
+      status: "found",
+      cityName: "Menlo Park",
+      formUrl: "https://www.menlopark.gov/report",
+    });
+  });
+
+  it("geocodes the typed address when no coords are supplied", async () => {
+    // Arrange: forward geocode (search) returns one hit with coords + city.
+    fetchWithTimeout.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            address: { city: "Palo Alto", state: "California" },
+            lat: "37.44",
+            lon: "-122.14",
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    resolveJurisdiction.mockReturnValue({
+      jurisdiction: { displayName: "Palo Alto" },
+      portal: {
+        url: "https://www.paloalto.gov/311",
+        reason: "311 portal.",
+        confidence: "high",
+      },
+    });
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        address: "123 Main St, Palo Alto",
+      }),
+    );
+    const body = await res.json();
+
+    // Assert: address path resolves the city and the portal is returned.
+    expect(fetchWithTimeout).toHaveBeenCalledWith(
+      expect.stringContaining("nominatim.openstreetmap.org/search"),
+      expect.anything(),
+    );
+    expect(body.data.status).toBe("found");
+    expect(body.data.cityName).toBe("Palo Alto");
+  });
+
+  it("returns not_found when no city can be determined from the location", async () => {
+    // Arrange: reverse lookup yields no city, no polygon match, no address.
+    fetchWithTimeout.mockResolvedValue(reverseResponse(null, null));
+    resolveJurisdiction.mockReturnValue(null);
+
+    // Act
+    const res = await POST(
+      post({ issueType: IssueType.ROAD_DAMAGE, latitude: 0, longitude: 0 }),
+    );
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toMatchObject({
+      status: "not_found",
+      cityName: null,
+    });
+    expect(responsesCreate).not.toHaveBeenCalled();
+  });
+
+  it("degrades to not_found when Nominatim errors (graceful upstream failure)", async () => {
+    // Arrange: geocoder throws; resolveLocation swallows it -> no city.
+    fetchWithTimeout.mockRejectedValue(new Error("nominatim down"));
+    resolveJurisdiction.mockReturnValue(null);
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert: a hung geocoder degrades to not_found, not a 500.
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("not_found");
+  });
+
+  it("returns 500 when the LLM lookup throws", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchWithTimeout.mockResolvedValue(
+      reverseResponse("Palo Alto", "California"),
+    );
+    resolveJurisdiction.mockReturnValue(null);
+    responsesCreate.mockRejectedValue(new Error("openai 500"));
+
+    // Act
+    const res = await POST(
+      post({
+        issueType: IssueType.ROAD_DAMAGE,
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to look up official city form.",
+    });
+  });
+});

--- a/nexa/src/lib/submission/open311.test.ts
+++ b/nexa/src/lib/submission/open311.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { IssueType, ReportStatus } from "@/generated/prisma/enums";
-import { open311Config } from "@/test/fixtures/open311";
+import { open311Config, open311Responses } from "@/test/fixtures/open311";
+import { TimeoutError } from "@/lib/http";
 
 import {
   buildRequestParams,
+  fetchOpen311Status,
   mapOpen311Status,
   parseOpen311Config,
   resolveServiceCode,
   STATUS_RANK,
+  submitToOpen311,
   type Open311Config,
   type SubmittableReport,
 } from "./open311";
@@ -361,5 +364,485 @@ describe("STATUS_RANK", () => {
 
     // Assert: no two states share a rank.
     expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Network functions — exercised with an injected `fetchImpl` so there is no
+// real network. These cover the resilience/idempotency contract from #102/#164:
+// a POST must not be retried after a timeout (could file a duplicate ticket) but
+// IS retried once when the connection never reached the server; a status GET
+// retries transient 5xx and surfaces the failure after exhaustion.
+// ---------------------------------------------------------------------------
+
+const NETWORK_REPORT: SubmittableReport = {
+  issueType: IssueType.ROAD_DAMAGE,
+  description: "Big pothole on Main St",
+  aiDescription: null,
+  latitude: 37.44,
+  longitude: -122.14,
+  address: "123 Main St",
+};
+
+/** A JSON Response stub, as the global `fetch` would return. */
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A Node/undici-style connection error carrying a retryable `code`. */
+function connectionError(code: string): Error {
+  return Object.assign(new Error(`connect ${code}`), { code });
+}
+
+describe("submitToOpen311 (network)", () => {
+  it("returns an error when no endpoint is configured", async () => {
+    // Arrange
+    const fetchImpl = vi.fn();
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: {},
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert: it never even attempts a request.
+    expect(result).toEqual({
+      status: "error",
+      httpStatus: null,
+      message: "No Open311 endpoint configured for this agency.",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when no service code maps to the issue type", async () => {
+    // Arrange
+    const fetchImpl = vi.fn();
+
+    // Act
+    const result = await submitToOpen311(
+      { ...NETWORK_REPORT, issueType: null },
+      {
+        config: open311Config,
+        intakeUrl: null,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      },
+    );
+
+    // Assert
+    expect(result.status).toBe("error");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("POSTs form-urlencoded to /requests.json and returns the service_request_id", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(open311Responses.createSuccess));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert: result shape + the exact request the agent made.
+    expect(result).toEqual({
+      status: "submitted",
+      serviceRequestId: "REQ-12345",
+      token: null,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://sandbox.open311.org/v2/requests.json");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(init.body).toContain("service_code=POTHOLES");
+  });
+
+  it("returns the token for a token-based async acknowledgement", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(open311Responses.createWithToken));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "submitted",
+      serviceRequestId: null,
+      token: "tok_abc123",
+    });
+  });
+
+  it("reads the GeoReport error description on a non-2xx response", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse([{ code: 400, description: "Bad service_code." }], 400),
+      );
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "error",
+      httpStatus: 400,
+      message: "Bad service_code.",
+    });
+  });
+
+  it("returns an error with httpStatus null on a network throw", async () => {
+    // Arrange
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("socket hang up"));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "error",
+      httpStatus: null,
+      message: "socket hang up",
+    });
+  });
+
+  it("returns an error when the success body is not valid JSON", async () => {
+    // Arrange
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "error",
+      httpStatus: 200,
+      message: "Open311 response was not valid JSON.",
+    });
+  });
+
+  it("returns an error when the response carries neither id nor token", async () => {
+    // Arrange
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([{}]));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "error",
+      httpStatus: 200,
+      message: "Open311 response contained no service_request_id or token.",
+    });
+  });
+
+  it("accepts a bare object response (not wrapped in an array)", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ service_request_id: "OBJ-1" }));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "submitted",
+      serviceRequestId: "OBJ-1",
+      token: null,
+    });
+  });
+
+  // --- Idempotency: the gap #164 flagged ----------------------------------
+
+  it("does NOT retry on a TimeoutError — no duplicate POST", async () => {
+    // Arrange: a timeout could mean the ticket was already filed, so retrying
+    // risks a duplicate. The agent must give up after exactly one attempt.
+    const fetchImpl = vi.fn().mockRejectedValue(new TimeoutError(12_000));
+
+    // Act
+    const result = await submitToOpen311(NETWORK_REPORT, {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert: exactly one POST, terminal timeout error.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      status: "error",
+      httpStatus: null,
+      message: "Open311 endpoint timed out.",
+    });
+  });
+
+  it("retries once on a pre-request connection error (ECONNREFUSED), then succeeds", async () => {
+    // Arrange: the connection was refused before any bytes were sent, so the
+    // request provably never reached the server — safe to retry exactly once.
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockRejectedValueOnce(connectionError("ECONNREFUSED"))
+        .mockResolvedValueOnce(jsonResponse(open311Responses.createSuccess));
+
+      // Act: drive the withRetry backoff sleep to completion under fake timers.
+      const pending = submitToOpen311(NETWORK_REPORT, {
+        config: open311Config,
+        intakeUrl: null,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      // Assert: two attempts (1 fail + 1 success), one ticket filed.
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        status: "submitted",
+        serviceRequestId: "REQ-12345",
+        token: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("fetchOpen311Status (network)", () => {
+  it("returns an error when no endpoint is configured", async () => {
+    // Arrange
+    const fetchImpl = vi.fn();
+
+    // Act
+    const result = await fetchOpen311Status("REQ-1", {
+      config: {},
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toMatchObject({ status: "error", httpStatus: null });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("GETs with api_key and jurisdiction_id query params and maps open -> ACKNOWLEDGED", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(open311Responses.statusOpen));
+
+    // Act
+    const result = await fetchOpen311Status("REQ-12345", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert: status mapping + the exact request URL/query.
+    expect(result).toEqual({
+      status: "ok",
+      open311Status: "open",
+      reportStatus: ReportStatus.ACKNOWLEDGED,
+      statusNotes: "Received and queued for inspection.",
+    });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toContain(
+      "https://sandbox.open311.org/v2/requests/REQ-12345.json",
+    );
+    expect(url).toContain("api_key=test-api-key");
+    expect(url).toContain("jurisdiction_id=city-palo-alto");
+    expect(init.method).toBe("GET");
+  });
+
+  it("maps closed -> RESOLVED and preserves status_notes", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(open311Responses.statusClosed));
+
+    // Act
+    const result = await fetchOpen311Status("REQ-12345", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "ok",
+      open311Status: "closed",
+      reportStatus: ReportStatus.RESOLVED,
+      statusNotes: "Pothole filled.",
+    });
+  });
+
+  it("maps an unrecognized status to a null reportStatus", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse([{ status: "pending" }]));
+
+    // Act
+    const result = await fetchOpen311Status("REQ-1", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "ok",
+      open311Status: "pending",
+      reportStatus: null,
+    });
+  });
+
+  it("returns not_found on a 404", async () => {
+    // Arrange
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse([], 404));
+
+    // Act
+    const result = await fetchOpen311Status("missing", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("returns an error when the body has no status field", async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse([{ service_request_id: "REQ-1" }]));
+
+    // Act
+    const result = await fetchOpen311Status("REQ-1", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      status: "error",
+      message: "Open311 response had no status field.",
+    });
+  });
+
+  it("returns an error on a network throw with httpStatus null", async () => {
+    // Arrange: a non-transient throw is not retried, surfaces immediately.
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("boom"));
+
+    // Act
+    const result = await fetchOpen311Status("REQ-1", {
+      config: open311Config,
+      intakeUrl: null,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Assert
+    expect(result).toEqual({
+      status: "error",
+      httpStatus: null,
+      message: "boom",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient 5xx then succeeds once the endpoint recovers", async () => {
+    // Arrange: a 500 is retryable for an idempotent GET; the second attempt OK.
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse([{ code: 500 }], 500))
+        .mockResolvedValueOnce(jsonResponse(open311Responses.statusOpen));
+
+      // Act
+      const pending = fetchOpen311Status("REQ-12345", {
+        config: open311Config,
+        intakeUrl: null,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      // Assert: two attempts, success surfaced.
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({
+        status: "ok",
+        reportStatus: ReportStatus.ACKNOWLEDGED,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces the 5xx error after exhausting all retry attempts", async () => {
+    // Arrange: the endpoint stays down for every attempt (3 total).
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValue(jsonResponse([{ code: 503 }], 503));
+
+      // Act
+      const pending = fetchOpen311Status("REQ-12345", {
+        config: open311Config,
+        intakeUrl: null,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      // Assert: retried up to the attempt cap, then the 5xx is surfaced.
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+      expect(result).toMatchObject({ status: "error", httpStatus: 503 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Implements #116. Adds colocated integration tests for the external-IO-heavy API routes and the two network-driven Open311 library functions. All external HTTP (LLM SDKs, Nominatim/Google, Open311) is mocked via injected `fetchImpl` or `vi.mock`; Prisma is deep-mocked. No real network, LLM, or DB.

## What's covered

**`reports/classify` route** (new file, 8 tests) — `classifyWithConsensus` mocked: 400 when neither description nor image is provided; description-only and image-only paths; `LocationContext` assembled from lat/lon/address/jurisdiction (and the address-only/null-coords variant); invalid-JSON 400; out-of-range latitude 400 (schema bound); consensus-throw 500.

**`reports/form-link` route** (new file, 9 tests) — `resolveJurisdiction`, `getOpenAI().responses.create`, and Nominatim `fetchWithTimeout` mocked: missing `issueType` 400; polygon+portal `found`; LLM fallback validating a `.gov` URL via `isOfficialCityGovUrl`; non-official URL degrades to `not_found`; polygon-match-without-portal uses the jurisdiction display name as the LLM hint; address-only forward-geocode path; `not_found` when no city resolves; graceful `not_found` when Nominatim errors; LLM-throw 500.

**`location/suggest` route** (extended, +3 tests) — adds the Google autocomplete+details top-5 mapping, the Google→Nominatim fallback, and the 429 rate-limit branch (the existing file already covered the Nominatim/no-key path and the #126 upstream-failure 500).

**`open311.ts` network functions** (extended, +20 tests) — `submitToOpen311` and `fetchOpen311Status` driven by an injected `fetchImpl`. Covers no-endpoint/no-service-code errors, the form-urlencoded POST + `Content-Type` assertion, id-vs-token results, array-vs-object bodies, non-2xx error-description reads, bad JSON, network throws, the status query string (`api_key`/`jurisdiction_id`), open→ACKNOWLEDGED / closed→RESOLVED mapping, 404→not_found, missing-status error.

The key gap #164 flagged — **network idempotency**:
- `submitToOpen311` does **not** retry on a `TimeoutError` (exactly one POST, no duplicate ticket) but **does** retry once on a pre-request `ECONNREFUSED`, then succeeds.
- `fetchOpen311Status` retries a transient 5xx then succeeds, and surfaces the 5xx after exhausting all attempts.

The existing `cron/poll-status` and `[id]/submit` route tests on `main` already cover those routes (orchestrator-outcome shapes for submit; CRON auth / status-advance / errorCount summary for cron), so they are left as-is to avoid duplication.

## Verification
- `npm test` — 488 passing (49 files), including the 40 new tests.
- `npx tsc --noEmit` — clean.
- `npm run format:check` — clean.