### PR TITLE
test(e2e): core report loop + auth journey [#119]

### DIFF
--- a/nexa/e2e/anonymous-report.spec.ts
+++ b/nexa/e2e/anonymous-report.spec.ts
@@ -1,0 +1,210 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// End-to-end of the core report loop a *guest* (no account) can complete:
+//   home -> /report -> describe (text + stubbed address suggestion) ->
+//   Analyze Issue -> review classification -> Submit -> confirmation page.
+//
+// Every network call the client makes is intercepted with `page.route` so the
+// run is deterministic and offline: no real LLM consensus, no Nominatim/Google
+// geocoding, no Open311 submission, no database. We assert on rendered screen
+// state (text/roles/urls) per the issue — never on internal server logic.
+
+// --- Deterministic stub payloads -------------------------------------------
+
+const CLASSIFY_RESULT = {
+  success: true,
+  data: {
+    winner: {
+      issueType: "ROAD_DAMAGE",
+      aiDescription:
+        "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+      severity: "high",
+      confidence: 0.95,
+    },
+    allResults: [
+      {
+        provider: "stub-model",
+        latencyMs: 12,
+        issueType: "ROAD_DAMAGE",
+        aiDescription:
+          "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+        severity: "high",
+        confidence: 0.95,
+      },
+    ],
+    consensus: true,
+    method: "unanimous",
+  },
+};
+
+// The created report row echoed back by POST /api/reports. The confirmation
+// screen renders this id, so we assert on it as the terminal state.
+const CREATED_REPORT = {
+  success: true,
+  data: {
+    id: "rep_e2e_stub_0001",
+    issueType: "ROAD_DAMAGE",
+    description: null,
+    aiDescription:
+      "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+    createdAt: "2026-06-09T12:00:00.000Z",
+  },
+};
+
+const ADDRESS_SUGGESTIONS = {
+  success: true,
+  data: {
+    suggestions: [
+      {
+        displayName: "123 Main St, Springfield",
+        latitude: 37.422,
+        longitude: -122.084,
+      },
+    ],
+  },
+};
+
+/**
+ * Register all client-side route stubs for the report flow. Routes are matched
+ * by URL so minor UI changes (selectors/text) don't break the network layer.
+ */
+async function stubReportRoutes(page: Page) {
+  // Guest session check — the report page calls this on mount.
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({ status: 401, json: { success: false, error: "Not authenticated" } }),
+  );
+
+  // LLM classification consensus — stubbed winner + single provider result.
+  await page.route("**/api/reports/classify", (route) =>
+    route.fulfill({ json: CLASSIFY_RESULT }),
+  );
+
+  // Official-form lookup fires after a successful classify. Return a benign
+  // "not found" so the review step renders without an external Places/Nominatim
+  // call. The exact body is non-load-bearing for this happy path.
+  await page.route("**/api/reports/form-link", (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        data: {
+          status: "not_found",
+          cityName: null,
+          message: "No official form found.",
+          reason: "Stubbed for e2e.",
+        },
+      },
+    }),
+  );
+
+  // Address suggestions (Google -> Nominatim fallback on the server) collapsed
+  // to one deterministic result so selecting it sets coordinates offline.
+  await page.route("**/api/location/suggest**", (route) =>
+    route.fulfill({ json: ADDRESS_SUGGESTIONS }),
+  );
+
+  // Report creation — the row whose id the confirmation page shows.
+  await page.route("**/api/reports", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ json: CREATED_REPORT });
+    }
+    return route.continue();
+  });
+
+  // The confirmation screen's SubmissionAssistant POSTs here on mount. Report a
+  // successful automated filing so it lands in a stable "submitted" state.
+  await page.route("**/api/reports/*/submit", (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        data: {
+          reportId: CREATED_REPORT.data.id,
+          status: "SUBMITTED",
+          submitted: true,
+          externalTrackingId: "TRK-STUB-1",
+        },
+      },
+    }),
+  );
+}
+
+test("guest completes the core report loop and reaches the confirmation page", async ({
+  page,
+}) => {
+  await stubReportRoutes(page);
+
+  // Enter via the homepage CTA so we exercise the real navigation, not a deep
+  // link, matching how a first-time visitor arrives.
+  await page.goto("/");
+  await page
+    .getByRole("link", { name: /report an issue/i })
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/report$/);
+
+  // --- Describe step ---------------------------------------------------------
+  // The mic toggle also carries a "...description" aria-label, so target the
+  // textbox by its exact accessible name rather than a substring match.
+  const description = page.getByRole("textbox", { name: "Description" });
+  await description.fill(
+    "Large pothole on Main St near the crosswalk, deep enough to damage a tire.",
+  );
+
+  // Type a partial address to trigger the (stubbed) suggestion dropdown, then
+  // pick the suggestion — selecting it sets latitude/longitude offline.
+  // A language <select> in the nav is also a combobox, so scope to the address
+  // input by its accessible name ("Location").
+  const addressInput = page.getByRole("combobox", { name: "Location" });
+  await addressInput.fill("123 Main");
+  const suggestion = page.getByRole("option", { name: /123 Main St/i });
+  await expect(suggestion).toBeVisible();
+  await suggestion.click();
+
+  // GPS coordinates from the selected suggestion now render on the describe step.
+  await expect(page.getByText(/GPS:\s*37\.422/)).toBeVisible();
+
+  // Trigger classification (stubbed) -> advances to the review step.
+  await page.getByRole("button", { name: /analyze issue/i }).click();
+
+  // --- Review step -----------------------------------------------------------
+  // The classified issue type + AI description are rendered for the user to confirm.
+  await expect(page.getByText(/road damage/i).first()).toBeVisible();
+  await expect(page.getByText(/large pothole in the roadway/i)).toBeVisible();
+
+  // Confirm and submit (stubbed POST /api/reports).
+  await page.getByRole("button", { name: /^submit report$/i }).click();
+
+  // --- Confirmed step (terminal state) --------------------------------------
+  // Acceptance: the confirmation screen shows the created report id.
+  await expect(page.getByText(/report submitted!/i)).toBeVisible();
+  await expect(page.getByText(CREATED_REPORT.data.id)).toBeVisible();
+});
+
+test("classification failure shows the error banner and stays on the describe step", async ({
+  page,
+}) => {
+  await stubReportRoutes(page);
+  // Override classify with a server failure for this spec only.
+  await page.route("**/api/reports/classify", (route) =>
+    route.fulfill({
+      status: 500,
+      json: { success: false, error: "Classifier unavailable" },
+    }),
+  );
+
+  await page.goto("/report");
+  await page
+    .getByRole("textbox", { name: "Description" })
+    .fill("Streetlight out on the corner of 4th and Elm.");
+  await page.getByRole("button", { name: /analyze issue/i }).click();
+
+  // The hook surfaces the server's error message in the inline banner and the
+  // flow does not advance to review (the Submit Report button never appears).
+  // Scope to <main> so the dev-mode Next error overlay (which echoes the same
+  // console.error text) doesn't create a strict-mode ambiguity.
+  await expect(
+    page.getByRole("main").getByText(/classifier unavailable/i),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /^submit report$/i }),
+  ).toHaveCount(0);
+});

--- a/nexa/e2e/authenticated-journey.spec.ts
+++ b/nexa/e2e/authenticated-journey.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type Page } from "@playwright/test";
+import { SignJWT } from "jose";
+
+// Authenticated-user journey, exercised offline against the Playwright
+// webServer. Two things are deterministic and stubbable here:
+//
+//   1. Proxy auth-gating (src/proxy.ts): a guest hitting a protected route is
+//      redirected to /login?redirect=..., and an authenticated user is bounced
+//      away from /login. Both are driven by verifyToken() over the session
+//      cookie, signed with the SAME JWT_SECRET the webServer boots with.
+//   2. The register -> login UI with /api/auth/* stubbed.
+//
+// NOTE (documented limitation): the dashboard *page* (src/app/dashboard) is a
+// server component that queries Prisma/Postgres directly. That DB access is not
+// reachable by `page.route` (which only intercepts browser fetches), so a fully
+// offline render of the dashboard with seeded reports is out of scope for this
+// e2e layer and is covered by integration tests. This spec therefore asserts on
+// the auth gating + register/login flow, whose terminal states (the login
+// redirect and the post-auth bounce) are explicit acceptance criteria for #119.
+
+// Must match playwright.config.ts -> webServer.env.JWT_SECRET so a token minted
+// here verifies inside the app's proxy/verifyToken.
+const JWT_SECRET = "e2e-test-secret-do-not-use-in-production";
+const SESSION_COOKIE = "nexa-session";
+
+/** Mint a session JWT the app's verifyToken() will accept. */
+async function signSession(userId: string, email: string): Promise<string> {
+  return new SignJWT({ userId, email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("7d")
+    .sign(new TextEncoder().encode(JWT_SECRET));
+}
+
+/** Install a valid session cookie so the proxy treats the visitor as logged in. */
+async function authenticate(page: Page) {
+  const token = await signSession("user_e2e_1", "e2e@example.com");
+  await page.context().addCookies([
+    {
+      name: SESSION_COOKIE,
+      value: token,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+}
+
+test("guest visiting a protected route is redirected to login (terminal state)", async ({
+  page,
+}) => {
+  // No session cookie -> the proxy redirects /dashboard to the login page,
+  // preserving the intended destination in the `redirect` query param.
+  await page.goto("/dashboard");
+
+  await expect(page).toHaveURL(/\/login\?redirect=%2Fdashboard/);
+  await expect(
+    page.getByRole("heading", { name: /welcome back/i }),
+  ).toBeVisible();
+});
+
+test("registration submits and navigates away from the register form", async ({
+  page,
+}) => {
+  // Stub the account-creation endpoint so no real user is written.
+  await page.route("**/api/auth/register", (route) =>
+    route.fulfill({
+      json: { success: true, data: { id: "user_new", email: "new@example.com" } },
+    }),
+  );
+
+  await page.goto("/register");
+  await expect(
+    page.getByRole("heading", { name: /create an account/i }),
+  ).toBeVisible();
+
+  await page.getByLabel(/email/i).fill("new@example.com");
+  // Password >= 8 chars per the issue's registration constraint.
+  await page.getByLabel(/password/i).fill("supersecret123");
+  await page
+    .getByRole("button", { name: /create account/i })
+    .click();
+
+  // On success the form routes to the home page; assert we left /register.
+  await expect(page).toHaveURL((url) => !url.pathname.startsWith("/register"));
+});
+
+test("login sets a session and the proxy then bounces the user off /login", async ({
+  page,
+}) => {
+  // Stub login to succeed AND set a real, correctly-signed session cookie so the
+  // subsequent proxy check sees an authenticated user (mirrors the reviewer
+  // correction on #119: cookie obtained via the stubbed /api/auth/login).
+  const token = await signSession("user_e2e_1", "e2e@example.com");
+  await page.route("**/api/auth/login", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: {
+        "set-cookie": `${SESSION_COOKIE}=${token}; Path=/; HttpOnly; SameSite=Lax`,
+      },
+      json: {
+        success: true,
+        data: { id: "user_e2e_1", email: "e2e@example.com" },
+      },
+    }),
+  );
+
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill("e2e@example.com");
+  await page.getByLabel(/password/i).fill("supersecret123");
+  await page.getByRole("button", { name: /^sign in$/i }).click();
+
+  // After login the client navigates to the redirect target (home by default);
+  // we left the login form.
+  await expect(page).toHaveURL((url) => !url.pathname.startsWith("/login"));
+
+  // The session cookie is now set: re-visiting /login makes the proxy bounce the
+  // authenticated user back to home — a deterministic terminal auth state.
+  await page.goto("/login");
+  await expect(page).toHaveURL(/\/$|\/$/);
+  await expect(
+    page.getByRole("heading", { name: /welcome back/i }),
+  ).toHaveCount(0);
+});
+
+test("an authenticated user is bounced from /login by the proxy", async ({
+  page,
+}) => {
+  // Pre-seed a valid session cookie (storageState-style) before any navigation.
+  await authenticate(page);
+
+  await page.goto("/login");
+  // proxy.ts redirects logged-in users away from auth routes to home.
+  await expect(page).toHaveURL((url) => url.pathname === "/");
+});


### PR DESCRIPTION
Closes #119.

Adds two thin Playwright e2e specs on top of the #112 foundation
(`playwright.config.ts`, `e2e/smoke.spec.ts`). They drive the **real** UI
against `next dev` (booted by the Playwright `webServer` with a fixed
`JWT_SECRET`) and stub every external/expensive call via `page.route`, so the
suite runs **offline and deterministically** — no real LLM consensus,
geocoding, Open311, or database.

## Specs added
- **`e2e/anonymous-report.spec.ts`** — the core report loop for a guest:
  - homepage → "Report an Issue" → `/report`
  - fill the description, type a partial address, pick a **stubbed** suggestion
    (sets GPS coords), trigger a **stubbed** classify → review the
    classification → **Submit** → confirmation page **shows the created report
    id** (terminal state).
  - a second case: a stubbed classify `500` shows the inline error banner and
    the flow stays on the describe step (no Submit button appears).
- **`e2e/authenticated-journey.spec.ts`** — auth gating + register/login:
  - guest visiting `/dashboard` is redirected to `/login?redirect=%2Fdashboard`
    (terminal state).
  - register submits (stubbed `/api/auth/register`) and navigates off the form.
  - login (stubbed `/api/auth/login`) sets a session cookie signed with the
    **same** `JWT_SECRET` the `webServer` boots with; `src/proxy.ts` then bounces
    the now-authenticated user off `/login`.
  - a pre-seeded valid cookie (storageState-style) is also bounced off `/login`.

Routes stubbed: `/api/reports/classify`, `/api/reports` POST,
`/api/reports/*/submit`, `/api/reports/form-link`, `/api/location/suggest`,
`/api/auth/*`, `/api/auth/me`.

## What ran locally (this machine)
- `npm install` — ok
- `npx prisma generate` — ok
- `npx tsc --noEmit` — **clean** (exit 0)
- `npx playwright install chromium && npm run test:e2e` — **7 passed** (smoke +
  2 report + 4 auth), ~5s.

## Documented limitation (not faked)
The dashboard *page* (`src/app/dashboard/page.tsx`) is a server component that
queries Postgres directly via Prisma. `page.route` only intercepts **browser**
fetches, not server-side DB access, and no Postgres is available in this
offline runner — so a fully offline render of the dashboard with **seeded
reports** is out of scope for this e2e layer (it belongs to integration tests).
The authenticated journey therefore asserts the deterministic auth **terminal
states** (login redirect / post-auth bounce), which are the acceptance criteria
called out in #119, rather than rendering seeded dashboard rows.

Does not overlap #93 (submission-readiness harness stops short of submit; here
submission is stubbed and the app UI is exercised through to confirmation).