### PR TITLE
feat(devops): enforce coverage thresholds in CI with ratchet floor [#120]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,42 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
-      - name: Run tests
-        run: npm run test
+      # Runs the suite WITH coverage. `npm run test:coverage` exits non-zero when
+      # any global or per-directory threshold in nexa/vitest.config.ts is unmet,
+      # so this step is the CI coverage gate (ratchet floor). This replaces the
+      # plain `npm run test` — coverage runs the same suite plus enforcement.
+      # `tee` keeps the human-readable report in the live log while we capture the
+      # text-summary block for the job summary below.
+      - name: Run tests with coverage gate
+        # `pipefail` is essential: without it the step's exit code is tee's (0),
+        # which would silently swallow a coverage-threshold failure.
+        run: |
+          set -o pipefail
+          npm run test:coverage 2>&1 | tee coverage-run.log
+        shell: bash
+
+      # Publish the v8 text-summary to the GitHub Actions job summary so coverage
+      # is visible on every PR without any paid/3rd-party service. Self-contained:
+      # no Codecov token required (built-in threshold failure is the gate).
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Coverage summary"
+            echo '```'
+            sed -n '/Coverage summary/,/=====/p' coverage-run.log | grep -E "Statements|Branches|Functions|Lines" || echo "no coverage summary captured"
+            echo '```'
+            echo "_Gate: thresholds enforced via vitest (nexa/vitest.config.ts); ratchet floor — see nexa/src/test/README.md._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Upload lcov + HTML report as an artifact for inspection on the PR.
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: nexa/coverage
+          if-no-files-found: warn
 
   eval:
     runs-on: ubuntu-latest

--- a/nexa/src/test/README.md
+++ b/nexa/src/test/README.md
@@ -86,3 +86,37 @@ globally mocked in `vitest.setup.tsx`.
 time don't crash. `NEXT_PUBLIC_POSTHOG_*` are intentionally left unset (the app
 tolerates their absence). For more overrides use a committed `.env.test`; never
 require real secrets in this suite.
+
+## Coverage gate & ratchet policy
+
+Coverage is enforced as a CI gate, not just reported. `npm run test:coverage`
+(v8 provider) fails — locally and in CI — when coverage drops below the
+thresholds in [`vitest.config.ts`](../../vitest.config.ts). The `test` job in
+`.github/workflows/ci.yml` runs this command, publishes the v8 text-summary to
+the GitHub Actions job summary, and uploads the lcov/HTML report as an artifact.
+No Codecov token is required — the built-in threshold failure is the gate.
+
+**Thresholds are a one-way ratchet.** They may only ever be **raised, never
+lowered.** Each floor is pinned a few points under the real measured coverage so
+the current suite passes while making regression impossible.
+
+Floors as of this writing (measured baseline → floor):
+
+| Scope                             | Statements | Branches | Functions | Lines |
+| --------------------------------- | ---------- | -------- | --------- | ----- |
+| **Global** (baseline 86/77/85/89) | 85         | 75       | 83        | 87    |
+| `src/lib/classify/**`             | 95         | —        | —         | 95    |
+| `src/lib/submission/**`           | 90         | —        | —         | 90    |
+| `src/lib/jurisdictions/**`        | 90         | —        | —         | 90    |
+| `src/lib/auth.ts`                 | 90         | —        | —         | 90    |
+
+Rules:
+
+1. A PR that **raises** real coverage should bump the matching floor up to lock
+   the gain in. Long-term target: **global lines 80% / branches 70%** and above
+   (the suite already exceeds this — keep ratcheting toward 90%+).
+2. **Never lower a floor to make a red build green.** Fix it by adding tests, or
+   by `exclude`-ing genuinely non-source paths (generated code, config, the
+   `src/test/` toolkit, `eval/`, `e2e/`) — already excluded in the config.
+3. Coverage is a behavior-coverage gate (QA), kept separate from the eval job
+   (#92), which gates LLM/routing accuracy. They are distinct steps/jobs.

--- a/nexa/vitest.config.ts
+++ b/nexa/vitest.config.ts
@@ -56,16 +56,47 @@ export default defineConfig({
     ],
     coverage: {
       provider: "v8",
-      reporter: ["text", "html", "lcov"],
+      // `text-summary` is also written to the CI job summary ($GITHUB_STEP_SUMMARY);
+      // `lcov` is uploaded as a CI artifact. See .github/workflows/ci.yml.
+      reporter: ["text", "text-summary", "html", "lcov"],
       reportsDirectory: "./coverage",
-      // No thresholds yet — the coverage-gate issue owns enforcement.
       exclude: [
         ...SHARED_EXCLUDE,
+        // Config files, ambient type decls, and the shared test toolkit are not
+        // application source and must not dilute (or be measured by) coverage.
         "**/*.config.*",
         "**/*.d.ts",
         "src/test/**",
         "vitest.setup.tsx",
       ],
+      // ── Coverage gate (issue #120) ──────────────────────────────────────────
+      // RATCHET POLICY: thresholds are a one-way floor — they may only ever be
+      // RAISED, never lowered. They are pinned just under the CURRENT measured
+      // coverage so the suite passes today but coverage can never regress; when a
+      // PR genuinely raises coverage, bump the matching floor up to lock the gain
+      // in. Long-term target: global lines 80% / branches 70%. See
+      // src/test/README.md for the full policy. Do NOT drop a floor to make a
+      // failing build pass — add tests, or `exclude` non-source paths instead.
+      //
+      // Measured baseline on main (2026-06): statements 86.47%, branches 77.43%,
+      // functions 84.94%, lines 88.82%. Global floors sit a few points below.
+      thresholds: {
+        statements: 85,
+        branches: 75,
+        functions: 83,
+        lines: 87,
+        // Per-directory floors for the most-tested, highest-stakes code. These
+        // are intentionally stricter than the global floor. Measured baseline:
+        //   classify       S 100   / L 100
+        //   submission     S 94.6  / L 95.9
+        //   jurisdictions  S 92.2  / L 97.6
+        //   auth.ts        S 100   / L 100
+        // Floor held at >= 85% lines/statements per #120.
+        "src/lib/classify/**": { statements: 95, lines: 95 },
+        "src/lib/submission/**": { statements: 90, lines: 90 },
+        "src/lib/jurisdictions/**": { statements: 90, lines: 90 },
+        "src/lib/auth.ts": { statements: 90, lines: 90 },
+      },
     },
   },
 });


### PR DESCRIPTION
## What

Turns Vitest coverage into a CI gate with a **ratchet floor**, closing the gap left by the test foundation (#112), which emitted coverage but enforced nothing. Coverage QA stays a distinct concern from the eval pass-rate gate (#92) — separate steps/jobs in the one shared `ci.yml`; the eval job is untouched.

## Measured baseline (on `main`)

`npm run test:coverage` before any change:

| Metric     | Baseline |
| ---------- | -------- |
| Statements | 86.47%   |
| Branches   | 77.43%   |
| Functions  | 84.94%   |
| Lines      | 88.82%   |

Per-directory baseline: `classify` S/L 100, `submission` S 94.6 / L 95.9, `jurisdictions` S 92.2 / L 97.6, `auth.ts` S/L 100.

## Threshold floor set

Pinned a few points **below** the measured baseline so the current suite passes but coverage can never regress.

| Scope                            | Statements | Branches | Functions | Lines |
| -------------------------------- | ---------- | -------- | --------- | ----- |
| **Global**                       | 85         | 75       | 83        | 87    |
| `src/lib/classify/**`            | 95         | —        | —         | 95    |
| `src/lib/submission/**`          | 90         | —        | —         | 90    |
| `src/lib/jurisdictions/**`       | 90         | —        | —         | 90    |
| `src/lib/auth.ts`                | 90         | —        | —         | 90    |

Per-directory floors meet #120's "≥ 85% lines/statements for the high-stakes libs" requirement. Non-source dirs (`src/generated`, `eval`, `e2e`, `*.config.*`, `src/test`, type decls, `vitest.setup.tsx`) are excluded so they don't dilute the floor.

## Ratchet policy

Documented in `nexa/src/test/README.md` and in a `vitest.config.ts` comment: thresholds are a **one-way floor — only ever raised, never lowered.** PRs that genuinely raise coverage should bump the matching floor to lock the gain in; long-term target is global lines 80% / branches 70% and upward. Never lower a floor to make a red build green — add tests or exclude genuine non-source paths.

## How CI enforces it

The existing `test` job (`working-directory: nexa`) now runs `npm run test:coverage` instead of `npm run test`. `npm run test:coverage` (v8 provider) **exits non-zero** when any global or per-directory threshold is unmet, so the step is the gate. Additionally:

- The v8 text-summary is published to `$GITHUB_STEP_SUMMARY` (visible on every PR) using `set -o pipefail` + `tee` so the gate's exit code is preserved.
- lcov + HTML are uploaded as a `coverage-report` artifact.
- **Self-contained — no Codecov token required.** The built-in vitest threshold failure is the gate.

## Verification (local)

- `npm run test:coverage` → **exit 0** with the configured thresholds (suite passes).
- Sanity-checked the gate actually fails: forcing `--coverage.thresholds.lines=99` → **exit 1** with `ERROR: Coverage for lines (88.82%) does not meet global threshold (99%)`.
- `npx tsc --noEmit`, `npm run lint` (0 errors; 2 pre-existing `<img>` warnings only), `npm run format:check` → all clean.

Closes #120.
