### PR TITLE
fix(devops): build no longer swallows real migration failures [#194]

### DIFF
--- a/nexa/package.json
+++ b/nexa/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && ([ -n \"$DATABASE_URL\" ] && prisma migrate deploy || true) && next build",
+    "build": "prisma generate && ([ -z \"$DATABASE_URL\" ] || prisma migrate deploy) && next build",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Closes #194.

The `nexa` build script guarded the Prisma migration with:

```
prisma generate && ([ -n "$DATABASE_URL" ] && prisma migrate deploy || true) && next build
```

The trailing `|| true` was intended to no-op the migrate step when `DATABASE_URL` is unset (e.g. local/CI builds without a DB). However, because `|| true` wraps the entire `&&` chain, it **also swallowed genuine migration failures** (SQL syntax errors, advisory-lock contention, drift/incompatibility) when `DATABASE_URL` *was* set — letting a broken deploy succeed and ship a stale schema to production.

## Fix

Restructure so the env guard short-circuits *before* invoking migrate, with no error suppression on migrate itself:

```
prisma generate && ([ -z "$DATABASE_URL" ] || prisma migrate deploy) && next build
```

- `[ -z "$DATABASE_URL" ]` is true when unset → short-circuits the `||`, migrate is **skipped**, build proceeds.
- When set, `[ -z ... ]` is false → `prisma migrate deploy` runs, and a **non-zero exit propagates** through the `&&` chain, failing the build.

No separate deploy wrapper added; only the one build script references migrate.

## Verification

Script logic exercised all three ways:
- `DATABASE_URL=` → migrate **skipped**, exit 0.
- `DATABASE_URL` set + **failing** migrate → exit **non-zero** (`next build` not reached).
- `DATABASE_URL` set + succeeding migrate → build proceeds, exit 0.

CI green: `tsc --noEmit` clean, `eslint` 0 errors, `prettier --check` passes, `vitest` 546/546 tests pass.

## Acceptance criteria
- [x] With DATABASE_URL unset, build skips migrate and succeeds
- [x] With DATABASE_URL set and a failing migration, build exits non-zero
- [x] No `|| true` (or equivalent suppression) wraps `prisma migrate deploy`