### PR TITLE
test(classify): unit tests for openai/anthropic/google provider adapters [#201]

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.test.ts
+++ b/nexa/src/lib/classify/anthropic-provider.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
+import { classifyWithAnthropic } from "./anthropic-provider";
+
+// `classifyWithAnthropic` constructs `new Anthropic(...)` and calls
+// `.messages.create()`. We mock the SDK module so no network/LLM call or API
+// key is needed, and so we can drive response parsing/normalization by
+// controlling the raw model content it returns.
+const createMock = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+  },
+}));
+
+/** Build the SDK response shape `classifyWithAnthropic` reads. */
+function reply(text: string) {
+  return { content: [{ type: "text", text }] };
+}
+
+describe("classifyWithAnthropic", () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it("normalizes a well-formed SDK response into a ProviderResult", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(JSON.stringify(classificationResult)));
+
+    // Act
+    const result = await classifyWithAnthropic("a pothole", null);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.severity).toBe(classificationResult.severity);
+    expect(result.aiDescription).toBe(classificationResult.aiDescription);
+    expect(result.confidence).toBe(classificationResult.confidence);
+    expect(result.provider).toBe("anthropic/claude-haiku-4-5");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("rejects with a validation error on a malformed response (bad enum)", async () => {
+    // Arrange: severity is not a member of the enum, so parsing must fail
+    // traceably rather than cast an invalid value through.
+    createMock.mockResolvedValue(
+      reply(
+        JSON.stringify({
+          ...classificationResult,
+          severity: "catastrophic",
+        }),
+      ),
+    );
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("desc", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("rejects with a SyntaxError when the response contains no JSON object", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply("no json here"));
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("desc", null)).rejects.toThrow(
+      SyntaxError,
+    );
+  });
+
+  it("passes the configured LLM timeout to the SDK", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(JSON.stringify(classificationResult)));
+
+    // Act
+    await classifyWithAnthropic("desc", null);
+
+    // Assert: the timeout option (request-options second arg) is forwarded.
+    const options = createMock.mock.calls[0][1];
+    expect(options).toMatchObject({ timeout: DEFAULT_LLM_TIMEOUT_MS });
+  });
+});

--- a/nexa/src/lib/classify/google-provider.test.ts
+++ b/nexa/src/lib/classify/google-provider.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
+import { classifyWithGoogle } from "./google-provider";
+
+// `classifyWithGoogle` constructs `new GoogleGenAI(...)` and calls
+// `.models.generateContent()`. We mock the SDK module so no network/LLM call or
+// API key is needed, and so we can drive response parsing/normalization by
+// controlling the raw `response.text` it returns.
+const generateContentMock = vi.fn();
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    models = { generateContent: generateContentMock };
+  },
+}));
+
+/** Build the SDK response shape `classifyWithGoogle` reads. */
+function reply(text: string) {
+  return { text };
+}
+
+describe("classifyWithGoogle", () => {
+  beforeEach(() => {
+    generateContentMock.mockReset();
+  });
+
+  it("normalizes a well-formed SDK response into a ProviderResult", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(
+      reply(JSON.stringify(classificationResult)),
+    );
+
+    // Act
+    const result = await classifyWithGoogle("a pothole", null);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.severity).toBe(classificationResult.severity);
+    expect(result.aiDescription).toBe(classificationResult.aiDescription);
+    expect(result.confidence).toBe(classificationResult.confidence);
+    expect(result.provider).toBe("google/gemini-2.5-flash");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("rejects with a validation error on a malformed response (missing field)", async () => {
+    // Arrange: confidence is missing, so the schema must fail traceably rather
+    // than cast a partial object through as a ClassificationResult.
+    const { confidence: _omit, ...withoutConfidence } = classificationResult;
+    generateContentMock.mockResolvedValue(
+      reply(JSON.stringify(withoutConfidence)),
+    );
+
+    // Act / Assert
+    await expect(classifyWithGoogle("desc", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("rejects with a SyntaxError when the response contains no JSON object", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply("no json here"));
+
+    // Act / Assert
+    await expect(classifyWithGoogle("desc", null)).rejects.toThrow(SyntaxError);
+  });
+
+  it("passes the configured LLM timeout to the SDK via httpOptions", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(
+      reply(JSON.stringify(classificationResult)),
+    );
+
+    // Act
+    await classifyWithGoogle("desc", null);
+
+    // Assert: the timeout is nested under config.httpOptions for this SDK.
+    const arg = generateContentMock.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      config: { httpOptions: { timeout: DEFAULT_LLM_TIMEOUT_MS } },
+    });
+  });
+});

--- a/nexa/src/lib/classify/openai-provider.test.ts
+++ b/nexa/src/lib/classify/openai-provider.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+import { DEFAULT_LLM_TIMEOUT_MS } from "@/lib/http";
+import { classifyWithOpenAI } from "./openai-provider";
+
+// `classifyWithOpenAI` constructs `new OpenAI(...)` and calls
+// `.chat.completions.create()`. We mock the SDK module so no network/LLM call
+// or API key is needed, and so we can drive response parsing/normalization by
+// controlling the raw model content it returns.
+const createMock = vi.fn();
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create: createMock } };
+  },
+}));
+
+/** Build the SDK response shape `classifyWithOpenAI` reads. */
+function reply(content: string | null) {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("classifyWithOpenAI", () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it("normalizes a well-formed SDK response into a ProviderResult", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(JSON.stringify(classificationResult)));
+
+    // Act
+    const result = await classifyWithOpenAI("a pothole", null);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.severity).toBe(classificationResult.severity);
+    expect(result.aiDescription).toBe(classificationResult.aiDescription);
+    expect(result.confidence).toBe(classificationResult.confidence);
+    expect(result.provider).toBe("openai/gpt-4o-mini");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("rejects with a validation error on a malformed response (bad enum)", async () => {
+    // Arrange: issueType is not a member of the enum, so parsing must fail
+    // traceably rather than cast an invalid value through.
+    createMock.mockResolvedValue(
+      reply(
+        JSON.stringify({
+          ...classificationResult,
+          issueType: "NOT_A_REAL_TYPE",
+        }),
+      ),
+    );
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("desc", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("rejects with a SyntaxError when the response contains no JSON object", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply("no json here"));
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("desc", null)).rejects.toThrow(SyntaxError);
+  });
+
+  it("passes the configured LLM timeout to the SDK", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(JSON.stringify(classificationResult)));
+
+    // Act
+    await classifyWithOpenAI("desc", null);
+
+    // Assert: the timeout option (request-options second arg) is forwarded.
+    const options = createMock.mock.calls[0][1];
+    expect(options).toMatchObject({ timeout: DEFAULT_LLM_TIMEOUT_MS });
+  });
+});


### PR DESCRIPTION
## Summary
Adds colocated unit tests for the three concrete LLM provider adapters, closing the gap identified in #201: `openai-provider.ts`, `anthropic-provider.ts`, and `google-provider.ts` previously had zero direct unit tests (only mocked at the consensus boundary).

Each provider test mocks its SDK module (`vi.mock` on `openai` / `@anthropic-ai/sdk` / `@google/genai`) — no network, no API keys — mirroring the existing `observe.test.ts` pattern, and reuses the shared `classificationResult` fixture from `@/test`.

## Coverage (per provider, AAA + deterministic)
- Well-formed SDK response → correct normalized `ProviderResult` (issueType/severity/description/confidence, provider id, measured `latencyMs`).
- Malformed/invalid response → the real validation/error behavior (per #129): bad enum / missing field → `invalid classification response`; no JSON object → `SyntaxError`.
- The `DEFAULT_LLM_TIMEOUT_MS` timeout option (from #102) is forwarded to the SDK (request-options for OpenAI/Anthropic; `config.httpOptions` for Google).

## Verification
- `npm test`: 558 passed (12 new).
- `npx tsc --noEmit`: clean.
- `npm run format:check`: clean.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)