### PR TITLE
fix(report): review-step fallback when agency-candidate fetch fails/empty [#205]

### DIFF
--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -253,6 +253,9 @@ export default function ReportPage() {
               officialForm={formLookup.officialForm}
               officialFormLoading={formLookup.loading}
               agencyCandidates={agencyCandidates.result}
+              agencyCandidatesLoading={agencyCandidates.loading}
+              agencyCandidatesError={agencyCandidates.error}
+              onRetryAgencyCandidates={agencyCandidates.retry}
               selectedAgencyId={selectedAgencyId}
               onSelectAgency={setSelectedAgencyId}
               onDescriptionChange={handleDescriptionChange}

--- a/nexa/src/components/report/review-step.test.tsx
+++ b/nexa/src/components/report/review-step.test.tsx
@@ -23,6 +23,9 @@ function baseProps() {
     officialForm: null as OfficialForm,
     officialFormLoading: false,
     agencyCandidates: null as Candidates,
+    agencyCandidatesLoading: false,
+    agencyCandidatesError: false,
+    onRetryAgencyCandidates: vi.fn(),
     selectedAgencyId: null as string | null,
     onSelectAgency: vi.fn(),
     onDescriptionChange: vi.fn(),
@@ -299,6 +302,68 @@ describe("ReviewStep", () => {
 
     // Assert: no picker, no regression to the submit button.
     expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Submit Report/ }),
+    ).not.toBeDisabled();
+  });
+
+  it("shows an error message and a retry when the candidate fetch fails", async () => {
+    // Arrange: fetch failed (no candidates), error flagged.
+    const props = baseProps();
+    const { user } = renderWithProviders(
+      <ReviewStep {...props} agencyCandidates={null} agencyCandidatesError />,
+    );
+
+    // Assert: informative error + retry, and submission is NOT blocked (the
+    // user is never stuck — the create route still routes server-side).
+    expect(
+      screen.getByText(/We couldn't load filing options/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Submit Report/ }),
+    ).not.toBeDisabled();
+
+    // Act: retry re-runs the lookup.
+    await user.click(screen.getByRole("button", { name: /^Retry$/ }));
+
+    // Assert
+    expect(props.onRetryAgencyCandidates).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the retry button and shows retrying text while reloading", () => {
+    // Arrange / Act: error flagged and a retry already in flight.
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        agencyCandidates={null}
+        agencyCandidatesError
+        agencyCandidatesLoading
+      />,
+    );
+
+    // Assert
+    const retrying = screen.getByText("Retrying...");
+    expect(retrying.closest("button")).toBeDisabled();
+  });
+
+  it("shows an informative message when the candidate list is empty", () => {
+    // Arrange / Act: fetch succeeded but no agency covers this spot.
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        agencyCandidates={{
+          agencyId: null,
+          candidates: [],
+          disambiguation: null,
+        }}
+      />,
+    );
+
+    // Assert: no picker, an informative message, submission unblocked.
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/No specific agency matched this location/),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Submit Report/ }),
     ).not.toBeDisabled();

--- a/nexa/src/components/report/review-step.tsx
+++ b/nexa/src/components/report/review-step.tsx
@@ -33,6 +33,16 @@ interface ReviewStepProps {
    * picker so the user disambiguates which one to file with.
    */
   agencyCandidates: AgencyCandidatesResult | null;
+  /** Whether the candidate fetch is still in flight. */
+  agencyCandidatesLoading: boolean;
+  /**
+   * True when the candidate fetch failed. The user is never blocked by this —
+   * the create route still routes/validates server-side — but we surface a
+   * retry so they aren't left at a silent dead-end.
+   */
+  agencyCandidatesError: boolean;
+  /** Re-runs the candidate fetch after a failure. */
+  onRetryAgencyCandidates: () => void;
   /** The agency the user has selected from an ambiguous candidate set. */
   selectedAgencyId: string | null;
   onSelectAgency: (agencyId: string) => void;
@@ -52,6 +62,9 @@ export function ReviewStep({
   officialForm,
   officialFormLoading,
   agencyCandidates,
+  agencyCandidatesLoading,
+  agencyCandidatesError,
+  onRetryAgencyCandidates,
   selectedAgencyId,
   onSelectAgency,
   onDescriptionChange,
@@ -68,6 +81,14 @@ export function ReviewStep({
   const isAmbiguous =
     !!agencyCandidates &&
     agencyCandidates.candidates.length > 1 &&
+    !agencyCandidates.agencyId;
+
+  // The fetch resolved but no agency covers this location + issue type. Not an
+  // error: the user can still submit and the create route routes/validates it.
+  // We say so plainly rather than leaving the section blank.
+  const isEmptyCandidates =
+    !!agencyCandidates &&
+    agencyCandidates.candidates.length === 0 &&
     !agencyCandidates.agencyId;
 
   return (
@@ -235,6 +256,38 @@ export function ReviewStep({
               );
             })}
           </div>
+        </div>
+      )}
+
+      {agencyCandidatesError && (
+        <div className="flex flex-col gap-3">
+          <ErrorBanner message={t("report.candidateError")} />
+          <button
+            type="button"
+            className="btn-cta btn-cta-outline self-start"
+            onClick={onRetryAgencyCandidates}
+            disabled={agencyCandidatesLoading}
+          >
+            {agencyCandidatesLoading ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                {t("report.candidateRetrying")}
+              </>
+            ) : (
+              t("report.candidateRetry")
+            )}
+          </button>
+        </div>
+      )}
+
+      {isEmptyCandidates && (
+        <div className="ep-card p-6">
+          <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            {t("report.chooseAgency")}
+          </span>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t("report.noAgencyMatch")}
+          </p>
         </div>
       )}
 

--- a/nexa/src/hooks/use-agency-candidates.ts
+++ b/nexa/src/hooks/use-agency-candidates.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { ApiResponse } from "@/lib/api/response";
 import type { AgencyCandidatesResult } from "@/lib/api/types";
 
@@ -20,9 +20,21 @@ export interface AgencyCandidatesLocation {
 export function useAgencyCandidates() {
   const [result, setResult] = useState<AgencyCandidatesResult | null>(null);
   const [loading, setLoading] = useState(false);
+  // True when the last lookup failed (network error or a non-OK response). The
+  // review step uses this to surface a retry, distinguishing a real failure
+  // from "not resolved yet" (both leave `result` null).
+  const [error, setError] = useState(false);
+  // The most recent lookup arguments, kept so `retry` can re-run them without
+  // the caller having to thread the issue type + location back through.
+  const lastRequest = useRef<{
+    issueType: string;
+    location: AgencyCandidatesLocation;
+  } | null>(null);
 
   const lookup = useCallback(
     async (issueType: string, location: AgencyCandidatesLocation) => {
+      lastRequest.current = { issueType, location };
+
       // Routing is polygon-based, so without coordinates there is nothing to
       // resolve. Clear any stale result and skip the request.
       if (
@@ -30,10 +42,12 @@ export function useAgencyCandidates() {
         typeof location.longitude !== "number"
       ) {
         setResult(null);
+        setError(false);
         return;
       }
 
       setLoading(true);
+      setError(false);
       try {
         const res = await fetch("/api/reports/agency-candidates", {
           method: "POST",
@@ -55,8 +69,11 @@ export function useAgencyCandidates() {
       } catch (err) {
         console.error("Agency candidates lookup failed:", err);
         // A failed lookup must not block submission — fall back to no
-        // disambiguation (server still routes/validates on create).
+        // disambiguation (server still routes/validates on create). We flag the
+        // error so the review step can offer a retry instead of silently
+        // dropping the disambiguation flow.
         setResult(null);
+        setError(true);
       } finally {
         setLoading(false);
       }
@@ -64,10 +81,20 @@ export function useAgencyCandidates() {
     [],
   );
 
+  // Re-run the last lookup. Used by the review step's error fallback so the user
+  // can recover from a transient failure without restarting the flow.
+  const retry = useCallback(() => {
+    const last = lastRequest.current;
+    if (!last) return;
+    void lookup(last.issueType, last.location);
+  }, [lookup]);
+
   const reset = useCallback(() => {
     setResult(null);
     setLoading(false);
+    setError(false);
+    lastRequest.current = null;
   }, []);
 
-  return { result, loading, lookup, reset };
+  return { result, loading, error, lookup, retry, reset };
 }

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -153,6 +153,12 @@ const enMessages = {
   "report.intake.WEB_FORM": "Web form",
   "report.intake.EMAIL": "Email",
   "report.intake.PHONE": "Phone",
+  "report.candidateError":
+    "We couldn't load filing options. You can still submit and we'll route your report for you.",
+  "report.candidateRetry": "Retry",
+  "report.candidateRetrying": "Retrying...",
+  "report.noAgencyMatch":
+    "No specific agency matched this location. You can still submit and we'll route your report for you.",
   "report.noOfficialForm": "No official city form found.",
   "report.submit": "Submit Report",
   "report.submitting": "Submitting...",
@@ -400,6 +406,12 @@ export const messages = {
     "report.intake.WEB_FORM": "Formulario web",
     "report.intake.EMAIL": "Correo electrónico",
     "report.intake.PHONE": "Teléfono",
+    "report.candidateError":
+      "No pudimos cargar las opciones de envío. Aún puedes enviarlo y dirigiremos tu reporte por ti.",
+    "report.candidateRetry": "Reintentar",
+    "report.candidateRetrying": "Reintentando...",
+    "report.noAgencyMatch":
+      "Ninguna agencia específica coincidió con esta ubicación. Aún puedes enviarlo y dirigiremos tu reporte por ti.",
     "report.noOfficialForm": "No se encontró formulario oficial de la ciudad.",
     "report.submit": "Enviar reporte",
     "report.submitting": "Enviando...",
@@ -633,6 +645,12 @@ export const messages = {
     "report.intake.WEB_FORM": "网页表单",
     "report.intake.EMAIL": "电子邮件",
     "report.intake.PHONE": "电话",
+    "report.candidateError":
+      "无法加载提交选项。您仍可提交，我们会为您转交报告。",
+    "report.candidateRetry": "重试",
+    "report.candidateRetrying": "正在重试...",
+    "report.noAgencyMatch":
+      "没有与此位置匹配的特定机构。您仍可提交，我们会为您转交报告。",
     "report.noOfficialForm": "未找到官方城市表格。",
     "report.submit": "提交报告",
     "report.submitting": "正在提交...",
@@ -873,6 +891,12 @@ export const messages = {
     "report.intake.WEB_FORM": "Formulaire web",
     "report.intake.EMAIL": "E-mail",
     "report.intake.PHONE": "Téléphone",
+    "report.candidateError":
+      "Impossible de charger les options de dépôt. Vous pouvez tout de même soumettre et nous acheminerons votre signalement pour vous.",
+    "report.candidateRetry": "Réessayer",
+    "report.candidateRetrying": "Nouvel essai...",
+    "report.noAgencyMatch":
+      "Aucune agence spécifique ne correspond à cet emplacement. Vous pouvez tout de même soumettre et nous acheminerons votre signalement pour vous.",
     "report.noOfficialForm": "Aucun formulaire officiel trouvé.",
     "report.submit": "Envoyer le signalement",
     "report.submitting": "Envoi...",


### PR DESCRIPTION
## Summary

Closes #205. The review step rendered the disambiguation picker only when there was more than one candidate, with no branch for a failed fetch or an empty candidate list — a silent dead-end in the routing/disambiguation flow.

This adds a sensible error/empty fallback. The user is never blocked: the create route still routes and validates server-side, so both fallbacks let them proceed.

## Changes

- **`use-agency-candidates` hook**: now exposes an `error` flag (set when the lookup throws or returns non-OK) and a `retry` callback that re-runs the last lookup. The existing "a failed lookup must not block submission" behavior is preserved — `result` still falls back to `null`.
- **`review-step.tsx`**:
  - On fetch **error**: renders the existing `ErrorBanner` with a clear message plus a **Retry** button (disabled/"Retrying..." while a retry is in flight). No new banner component.
  - On **empty** candidate list: renders an informative "no specific agency matched" message. No forced disambiguation.
  - Normal single-match and multi-candidate behavior unchanged.
- **`report/page.tsx`**: wires the new `agencyCandidatesLoading` / `agencyCandidatesError` / `onRetryAgencyCandidates` props.
- **i18n** (`messages.ts`): added `report.candidateError`, `report.candidateRetry`, `report.candidateRetrying`, `report.noAgencyMatch` to all four locales (en/es/zh/fr).
- **`review-step.test.tsx`**: covers the error path (message + retry click + submit not blocked), the retrying/disabled state, and the empty-list path.

## Acceptance criteria

- [x] On candidate fetch error, an error message and retry are shown
- [x] On empty candidate list, an informative state is shown
- [x] `review-step.test.tsx` covers error and empty cases

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (only pre-existing `<img>` warnings)
- `npm run format:check` — passes
- `npm test` — 549 passed (55 files)