### PR TITLE
fix(a11y): keyboard adjustment for the location-map pin [#203]

### DIFF
--- a/nexa/src/components/report/location-map.test.tsx
+++ b/nexa/src/components/report/location-map.test.tsx
@@ -83,6 +83,50 @@ describe("LocationMap", () => {
     expect(onMove).toHaveBeenCalledWith(markerLatLng.lat, markerLatLng.lng);
   });
 
+  it("nudges the coordinates from the keyboard control via onMove", async () => {
+    // Arrange: keyboard parity for the draggable pin (a11y, issue #203).
+    const onMove = vi.fn();
+    const { user } = renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={onMove} />,
+    );
+    // The keyboard control nudges relative to the marker, so wait for setup.
+    await waitFor(() => expect(L.marker).toHaveBeenCalled());
+
+    const control = screen.getByRole("button", {
+      name: /adjust location pin/i,
+    });
+    control.focus();
+
+    // Act: arrow keys move the pin off the marker's current position.
+    await user.keyboard("{ArrowUp}");
+    expect(onMove).toHaveBeenLastCalledWith(
+      markerLatLng.lat + 0.00005,
+      markerLatLng.lng,
+    );
+
+    await user.keyboard("{ArrowRight}");
+    expect(onMove).toHaveBeenLastCalledWith(
+      markerLatLng.lat,
+      markerLatLng.lng + 0.00005,
+    );
+
+    expect(onMove).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes screen-reader instructions for the keyboard control", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <LocationMap latitude={37.4} longitude={-122.1} onMove={vi.fn()} />,
+    );
+
+    // Assert: the focusable control is described by arrow-key instructions.
+    const control = screen.getByRole("button", {
+      name: /adjust location pin/i,
+    });
+    expect(control).toHaveAttribute("aria-describedby");
+    expect(screen.getByText(/press the arrow keys/i)).toBeInTheDocument();
+  });
+
   it("repositions the marker when coordinates change", async () => {
     // Arrange
     const { rerender } = renderWithProviders(

--- a/nexa/src/components/report/location-map.tsx
+++ b/nexa/src/components/report/location-map.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef, type KeyboardEvent } from "react";
 import type { Map as LeafletMap, Marker as LeafletMarker } from "leaflet";
 import "leaflet/dist/leaflet.css";
+
+import { useI18n } from "@/i18n/provider";
 
 interface LocationMapProps {
   latitude: number;
@@ -18,11 +20,15 @@ const MARKER_ICON_2X_URL =
 const MARKER_SHADOW_URL =
   "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png";
 
+/** Degrees nudged per arrow-key press (~5.5m of latitude). */
+const KEYBOARD_STEP = 0.00005;
+
 export default function LocationMap({
   latitude,
   longitude,
   onMove,
 }: LocationMapProps) {
+  const { t } = useI18n();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<LeafletMap | null>(null);
   const markerRef = useRef<LeafletMarker | null>(null);
@@ -30,6 +36,14 @@ export default function LocationMap({
   useEffect(() => {
     onMoveRef.current = onMove;
   }, [onMove]);
+
+  // Latest coordinates, so keyboard nudges work before the first drag too.
+  const positionRef = useRef({ latitude, longitude });
+  useEffect(() => {
+    positionRef.current = { latitude, longitude };
+  }, [latitude, longitude]);
+
+  const instructionsId = useId();
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -102,12 +116,67 @@ export default function LocationMap({
     map.setView([latitude, longitude], map.getZoom(), { animate: true });
   }, [latitude, longitude]);
 
+  // Keyboard parity with mouse drag: arrow keys nudge the pin and feed the same
+  // onMove handler. Falls back to props so it works even before Leaflet loads.
+  const nudge = (deltaLat: number, deltaLng: number) => {
+    const marker = markerRef.current;
+    const current = marker
+      ? marker.getLatLng()
+      : {
+          lat: positionRef.current.latitude,
+          lng: positionRef.current.longitude,
+        };
+    const nextLat = current.lat + deltaLat;
+    const nextLng = current.lng + deltaLng;
+    onMoveRef.current(nextLat, nextLng);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    switch (event.key) {
+      case "ArrowUp":
+        event.preventDefault();
+        nudge(KEYBOARD_STEP, 0);
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        nudge(-KEYBOARD_STEP, 0);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        nudge(0, -KEYBOARD_STEP);
+        break;
+      case "ArrowRight":
+        event.preventDefault();
+        nudge(0, KEYBOARD_STEP);
+        break;
+      default:
+        break;
+    }
+  };
+
   return (
-    <div
-      ref={containerRef}
-      className="mt-3 h-48 w-full overflow-hidden rounded-lg border border-border"
-      role="application"
-      aria-label="Map showing detected location. Drag the pin to adjust."
-    />
+    <div className="relative mt-3">
+      <div
+        ref={containerRef}
+        className="h-48 w-full overflow-hidden rounded-lg border border-border"
+        role="application"
+        aria-label={t("report.mapAdjustLabel")}
+      />
+      {/* Keyboard parity for the draggable pin: a focusable control that nudges
+          the marker via the same onMove handler. Sibling (not a Leaflet-owned
+          child) so Leaflet's DOM ownership of the container is never disturbed. */}
+      <button
+        type="button"
+        aria-label={t("report.mapPinKeyboardLabel")}
+        aria-describedby={instructionsId}
+        onKeyDown={handleKeyDown}
+        className="absolute left-2 top-2 z-[1000] rounded-md border border-border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t("report.mapPinKeyboardLabel")}
+      </button>
+      <p id={instructionsId} className="sr-only">
+        {t("report.mapPinKeyboardInstructions")}
+      </p>
+    </div>
   );
 }

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -133,6 +133,11 @@ const enMessages = {
   "report.addressSuggestions": "Address suggestions",
   "report.gpsAccuracy": "Location accuracy: {meters} meters",
   "report.dragPin": "Drag the pin to correct",
+  "report.mapAdjustLabel":
+    "Map showing detected location. Drag the pin or use the keyboard control to adjust.",
+  "report.mapPinKeyboardLabel": "Adjust location pin",
+  "report.mapPinKeyboardInstructions":
+    "Press the arrow keys to nudge the location pin: up and down change latitude, left and right change longitude.",
   "report.analyze": "Analyze Issue",
   "report.analyzing": "Analyzing with AI...",
   "report.reviewLabel": "/ Review Classification",
@@ -381,6 +386,11 @@ export const messages = {
     "report.addressSuggestions": "Sugerencias de direcciones",
     "report.gpsAccuracy": "Precisión de ubicación: {meters} metros",
     "report.dragPin": "Arrastra el pin para corregir",
+    "report.mapAdjustLabel":
+      "Mapa que muestra la ubicación detectada. Arrastra el pin o usa el control de teclado para ajustar.",
+    "report.mapPinKeyboardLabel": "Ajustar el pin de ubicación",
+    "report.mapPinKeyboardInstructions":
+      "Pulsa las teclas de flecha para mover el pin de ubicación: arriba y abajo cambian la latitud, izquierda y derecha cambian la longitud.",
     "report.analyze": "Analizar problema",
     "report.analyzing": "Analizando con IA...",
     "report.reviewLabel": "/ Revisar clasificación",
@@ -614,6 +624,11 @@ export const messages = {
     "report.addressSuggestions": "地址建议",
     "report.gpsAccuracy": "位置精度：{meters} 米",
     "report.dragPin": "拖动图钉以校正",
+    "report.mapAdjustLabel":
+      "地图显示检测到的位置。拖动图钉或使用键盘控件进行调整。",
+    "report.mapPinKeyboardLabel": "调整位置图钉",
+    "report.mapPinKeyboardInstructions":
+      "按方向键移动位置图钉：上下键调整纬度，左右键调整经度。",
     "report.analyze": "分析问题",
     "report.analyzing": "正在用 AI 分析...",
     "report.reviewLabel": "/ 检查分类",
@@ -854,6 +869,11 @@ export const messages = {
     "report.addressSuggestions": "Suggestions d'adresses",
     "report.gpsAccuracy": "Précision de localisation : {meters} mètres",
     "report.dragPin": "Déplacez l'épingle pour corriger",
+    "report.mapAdjustLabel":
+      "Carte montrant la position détectée. Déplacez l'épingle ou utilisez la commande clavier pour ajuster.",
+    "report.mapPinKeyboardLabel": "Ajuster l'épingle de position",
+    "report.mapPinKeyboardInstructions":
+      "Appuyez sur les touches fléchées pour déplacer l'épingle : haut et bas modifient la latitude, gauche et droite modifient la longitude.",
     "report.analyze": "Analyser le problème",
     "report.analyzing": "Analyse par IA...",
     "report.reviewLabel": "/ Vérifier la classification",


### PR DESCRIPTION
Closes #203.

## Problem
`LocationMap` set the marker `draggable: true` and wired `dragend`, but the pin could only be moved with a mouse. Combined with `role="application"` (which suppresses default semantic focus handling), keyboard-only users had no way to correct the detected report location.

## Fix
Added a focusable, labeled control beside the map that nudges the pin with the arrow keys, feeding the **same** `onMove` coordinate callback that mouse drag already uses (no parallel state path).

- Arrow keys nudge the pin by ~0.00005° (~5.5 m) per press: Up/Down change latitude, Left/Right change longitude.
- The control has an accessible name and `aria-describedby` pointing at screen-reader arrow-key instructions.
- The keyboard control is a sibling of the Leaflet container (not a Leaflet-owned child), so Leaflet's DOM ownership is never disturbed.
- Mouse drag is unchanged.
- New/updated i18n keys (`report.mapAdjustLabel`, `report.mapPinKeyboardLabel`, `report.mapPinKeyboardInstructions`) across all four locales (en/es/zh/fr).

## Tests
Extended `location-map.test.tsx` (Leaflet is mocked): asserts arrow-key presses on the control call `onMove` with nudged coordinates, and that the control exposes screen-reader instructions. Existing drag/reposition/unmount tests retained.

## Verification
- `npx tsc --noEmit` clean
- `npm run lint` no errors (only pre-existing img warnings)
- `npm run format:check` clean
- `npm test` 548 passed

## Acceptance criteria
- [x] A keyboard user can adjust the report coordinates without a mouse
- [x] Focusable control has an accessible name
- [x] `location-map.test.tsx` asserts keyboard adjustment updates coordinates