### PR TITLE
test(classify): comprehensive provider adapter tests (coverage-gate safe) [#201]

### DIFF
--- a/nexa/src/lib/classify/anthropic-provider.test.ts
+++ b/nexa/src/lib/classify/anthropic-provider.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+
+import { classifyWithAnthropic } from "./anthropic-provider";
+
+// `classifyWithAnthropic` constructs `new Anthropic(...)` and calls
+// `.messages.create()`. Mock the SDK so no network/key is used and we can drive
+// every media-type, response-parsing, and error branch from the test.
+const createMock = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+  },
+}));
+
+/** Build the Anthropic response shape the provider reads. */
+function reply(blocks: Array<{ type: string; text?: string }>) {
+  return { content: blocks };
+}
+
+/** A text block carrying well-formed classification JSON. */
+function textReply(text: string) {
+  return reply([{ type: "text", text }]);
+}
+
+function validJson() {
+  return JSON.stringify(classificationResult);
+}
+
+describe("classifyWithAnthropic", () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it("parses a well-formed text block and tags provider + latency", async () => {
+    // Arrange
+    createMock.mockResolvedValue(textReply(validJson()));
+
+    // Act
+    const result = await classifyWithAnthropic("a pothole", null);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.provider).toBe("anthropic/claude-haiku-4-5");
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  it("appends the description to the text prompt and omits the image block when text-only", async () => {
+    // Arrange
+    createMock.mockResolvedValue(textReply(validJson()));
+
+    // Act
+    await classifyWithAnthropic("trash near the curb", null);
+
+    // Assert: no image content block, description folded into the text block.
+    const arg = createMock.mock.calls[0][0];
+    const content = arg.messages[0].content;
+    expect(content.some((b: { type: string }) => b.type === "image")).toBe(
+      false,
+    );
+    expect(JSON.stringify(content)).toContain("trash near the curb");
+  });
+
+  it("uses the default prompt with no description (empty/whitespace input)", async () => {
+    // Arrange: whitespace -> formatUserDescription returns "" (no append).
+    createMock.mockResolvedValue(textReply(validJson()));
+
+    // Act
+    await classifyWithAnthropic("   ", null);
+
+    // Assert
+    const arg = createMock.mock.calls[0][0];
+    const text = arg.messages[0].content.find(
+      (b: { type: string }) => b.type === "text",
+    ).text;
+    expect(text).toContain("civic issue classifier");
+    expect(text).not.toContain("USER_DESCRIPTION");
+  });
+
+  it("honors an override prompt", async () => {
+    // Arrange
+    createMock.mockResolvedValue(textReply(validJson()));
+
+    // Act
+    await classifyWithAnthropic("", null, { prompt: "OVERRIDE_PROMPT_Y" });
+
+    // Assert
+    const text = createMock.mock.calls[0][0].messages[0].content[0].text;
+    expect(text).toContain("OVERRIDE_PROMPT_Y");
+    expect(text).not.toContain("civic issue classifier");
+  });
+
+  it.each([
+    ["data:image/png;base64,QUJD", "image/png", "QUJD"],
+    ["data:image/gif;base64,QUJD", "image/gif", "QUJD"],
+    ["data:image/webp;base64,QUJD", "image/webp", "QUJD"],
+    ["data:image/jpeg;base64,QUJD", "image/jpeg", "QUJD"],
+    // No recognized prefix -> jpeg default, and stripDataUrlPrefix is a no-op.
+    ["QUJDRA==", "image/jpeg", "QUJDRA=="],
+  ])(
+    "maps %s to media_type %s on the image block",
+    async (input, expectedType, expectedData) => {
+      // Arrange
+      createMock.mockResolvedValue(textReply(validJson()));
+
+      // Act
+      await classifyWithAnthropic("", input);
+
+      // Assert
+      const arg = createMock.mock.calls[0][0];
+      const imageBlock = arg.messages[0].content.find(
+        (b: { type: string }) => b.type === "image",
+      );
+      expect(imageBlock).toBeTruthy();
+      expect(imageBlock.source.media_type).toBe(expectedType);
+      // Data URL prefix is stripped down to the raw base64 payload.
+      expect(imageBlock.source.data).toBe(expectedData);
+    },
+  );
+
+  it("defaults raw to {} when the first block is not a text block", async () => {
+    // Arrange: a non-text leading block -> raw becomes "{}" -> schema error.
+    createMock.mockResolvedValue(reply([{ type: "tool_use" }]));
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("defaults raw to {} when content is empty", async () => {
+    // Arrange: no blocks -> optional chaining -> "{}".
+    createMock.mockResolvedValue(reply([]));
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a schema error on a malformed (missing-field) response", async () => {
+    // Arrange: aiDescription is the wrong type.
+    createMock.mockResolvedValue(
+      textReply(JSON.stringify({ ...classificationResult, aiDescription: 5 })),
+    );
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a SyntaxError when the reply contains no JSON object", async () => {
+    // Arrange
+    createMock.mockResolvedValue(textReply("not json"));
+
+    // Act / Assert
+    await expect(classifyWithAnthropic("x", null)).rejects.toThrow(SyntaxError);
+  });
+
+  it("propagates SDK errors (timeout/exception) to the caller", async () => {
+    // Arrange
+    createMock.mockRejectedValue(new Error("anthropic timeout"));
+
+    // Act / Assert
+    await expect(
+      classifyWithAnthropic("x", "data:image/png;base64,QUJD"),
+    ).rejects.toThrow("anthropic timeout");
+  });
+});

--- a/nexa/src/lib/classify/google-provider.test.ts
+++ b/nexa/src/lib/classify/google-provider.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+
+import { classifyWithGoogle } from "./google-provider";
+
+// `classifyWithGoogle` constructs `new GoogleGenAI(...)` and calls
+// `.models.generateContent()`. Mock the SDK so no network/key is used and we
+// can drive every mime-type, response-parsing, and error branch from the test.
+const generateContentMock = vi.fn();
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    models = { generateContent: generateContentMock };
+  },
+}));
+
+/** Build the Google response shape the provider reads (`response.text`). */
+function reply(text: string | null | undefined) {
+  return { text };
+}
+
+function validJson() {
+  return JSON.stringify(classificationResult);
+}
+
+describe("classifyWithGoogle", () => {
+  beforeEach(() => {
+    generateContentMock.mockReset();
+  });
+
+  it("parses a well-formed response and tags provider + latency", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    const result = await classifyWithGoogle("a pothole", null);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.provider).toBe("google/gemini-2.5-flash");
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  it("includes an inlineData part with the mime type derived from the data URL", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("", "data:image/png;base64,QUJD");
+
+    // Assert
+    const arg = generateContentMock.mock.calls[0][0];
+    const parts = arg.contents[0].parts;
+    const inline = parts.find(
+      (p: Record<string, unknown>) => "inlineData" in p,
+    );
+    expect(inline.inlineData.mimeType).toBe("image/png");
+    // Data URL prefix stripped to raw base64.
+    expect(inline.inlineData.data).toBe("QUJD");
+  });
+
+  it("falls back to image/jpeg when the input has no data-URL mime prefix", async () => {
+    // Arrange: bare base64 -> extractMimeType regex does not match -> default.
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("", "QUJDRA==");
+
+    // Assert
+    const arg = generateContentMock.mock.calls[0][0];
+    const inline = arg.contents[0].parts.find(
+      (p: Record<string, unknown>) => "inlineData" in p,
+    );
+    expect(inline.inlineData.mimeType).toBe("image/jpeg");
+  });
+
+  it("omits the inlineData part and the description for text-only empty input", async () => {
+    // Arrange: no image, whitespace description -> only the text part remains.
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("   ", null);
+
+    // Assert
+    const parts = generateContentMock.mock.calls[0][0].contents[0].parts;
+    expect(parts).toHaveLength(1);
+    expect("text" in parts[0]).toBe(true);
+    expect(parts.some((p: Record<string, unknown>) => "inlineData" in p)).toBe(
+      false,
+    );
+  });
+
+  it("appends the user description to the text part when provided", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("graffiti on the wall", null);
+
+    // Assert
+    const parts = generateContentMock.mock.calls[0][0].contents[0].parts;
+    const textPart = parts.find((p: Record<string, unknown>) => "text" in p);
+    expect(textPart.text).toContain("graffiti on the wall");
+    expect(textPart.text).toContain("USER_DESCRIPTION");
+  });
+
+  it("uses the default prompt and forwards model + timeout config", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("", null);
+
+    // Assert
+    const arg = generateContentMock.mock.calls[0][0];
+    expect(arg.model).toBe("gemini-2.5-flash");
+    expect(typeof arg.config.httpOptions.timeout).toBe("number");
+    const textPart = arg.contents[0].parts.find(
+      (p: Record<string, unknown>) => "text" in p,
+    );
+    expect(textPart.text).toContain("civic issue classifier");
+  });
+
+  it("honors an override prompt", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithGoogle("", null, { prompt: "OVERRIDE_PROMPT_Z" });
+
+    // Assert
+    const textPart =
+      generateContentMock.mock.calls[0][0].contents[0].parts.find(
+        (p: Record<string, unknown>) => "text" in p,
+      );
+    expect(textPart.text).toContain("OVERRIDE_PROMPT_Z");
+    expect(textPart.text).not.toContain("civic issue classifier");
+  });
+
+  it("defaults raw to {} when response.text is null (schema error)", async () => {
+    // Arrange: null text -> "{}" -> schema rejects missing required fields.
+    generateContentMock.mockResolvedValue(reply(null));
+
+    // Act / Assert
+    await expect(classifyWithGoogle("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a schema error on a malformed (invalid severity) response", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(
+      reply(JSON.stringify({ ...classificationResult, severity: "extreme" })),
+    );
+
+    // Act / Assert
+    await expect(classifyWithGoogle("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a SyntaxError when the reply contains no JSON object", async () => {
+    // Arrange
+    generateContentMock.mockResolvedValue(reply("plain prose, no json"));
+
+    // Act / Assert
+    await expect(classifyWithGoogle("x", null)).rejects.toThrow(SyntaxError);
+  });
+
+  it("propagates SDK errors (timeout/exception) to the caller", async () => {
+    // Arrange
+    generateContentMock.mockRejectedValue(new Error("google timeout"));
+
+    // Act / Assert
+    await expect(
+      classifyWithGoogle("x", "data:image/jpeg;base64,QUJD"),
+    ).rejects.toThrow("google timeout");
+  });
+});

--- a/nexa/src/lib/classify/openai-provider.test.ts
+++ b/nexa/src/lib/classify/openai-provider.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { classificationResult } from "@/test/fixtures/classification";
+
+import { classifyWithOpenAI } from "./openai-provider";
+
+// `classifyWithOpenAI` constructs `new OpenAI(...)` and calls
+// `.chat.completions.create()`. Mock the SDK so no network/key is used and we
+// can drive every response-parsing and error branch by controlling the reply.
+const createMock = vi.fn();
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create: createMock } };
+  },
+}));
+
+const DATA_URL = "data:image/jpeg;base64,QUJD";
+
+/** Build the SDK response shape the provider reads. */
+function reply(content: string | null | undefined) {
+  return { choices: [{ message: { content } }] };
+}
+
+/** A well-formed classification JSON the schema accepts. */
+function validJson() {
+  return JSON.stringify(classificationResult);
+}
+
+describe("classifyWithOpenAI", () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it("parses a well-formed response and tags provider + latency", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    const result = await classifyWithOpenAI("a pothole", DATA_URL);
+
+    // Assert
+    expect(result.issueType).toBe(classificationResult.issueType);
+    expect(result.severity).toBe(classificationResult.severity);
+    expect(result.confidence).toBe(classificationResult.confidence);
+    expect(result.provider).toBe("openai/gpt-4o-mini");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes the image_url content part when an image is supplied", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithOpenAI("a pothole", DATA_URL);
+
+    // Assert: the request carries an image_url part with the data URL.
+    const arg = createMock.mock.calls[0][0];
+    const content = arg.messages[0].content;
+    const imagePart = content.find(
+      (p: { type: string }) => p.type === "image_url",
+    );
+    expect(imagePart).toBeTruthy();
+    expect(imagePart.image_url.url).toBe(DATA_URL);
+  });
+
+  it("omits the image part and the description block for text-only empty input", async () => {
+    // Arrange: no image, whitespace-only description -> formatUserDescription "".
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithOpenAI("   ", null);
+
+    // Assert: only the single prompt text part remains.
+    const arg = createMock.mock.calls[0][0];
+    const content = arg.messages[0].content;
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+    expect(content.some((p: { type: string }) => p.type === "image_url")).toBe(
+      false,
+    );
+  });
+
+  it("appends the user description as a fenced data block when provided", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithOpenAI("trash near the curb", null);
+
+    // Assert
+    const serialized = JSON.stringify(createMock.mock.calls[0][0]);
+    expect(serialized).toContain("trash near the curb");
+    expect(serialized).toContain("USER_DESCRIPTION");
+  });
+
+  it("uses the default prompt and forwards model/timeout settings", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithOpenAI("", null);
+
+    // Assert: default prompt text present; second arg carries the timeout.
+    const [body, opts] = createMock.mock.calls[0];
+    expect(body.model).toBe("gpt-4o-mini");
+    expect(JSON.stringify(body)).toContain("civic issue classifier");
+    expect(typeof opts.timeout).toBe("number");
+  });
+
+  it("uses the override prompt when options.prompt is set", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply(validJson()));
+
+    // Act
+    await classifyWithOpenAI("", null, { prompt: "OVERRIDE_PROMPT_X" });
+
+    // Assert
+    const serialized = JSON.stringify(createMock.mock.calls[0][0]);
+    expect(serialized).toContain("OVERRIDE_PROMPT_X");
+    expect(serialized).not.toContain("civic issue classifier");
+  });
+
+  it("defaults raw to {} when message content is null (parses to a thrown schema error)", async () => {
+    // Arrange: null content -> "{}" -> schema rejects missing required fields.
+    createMock.mockResolvedValue(reply(null));
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("defaults raw to {} when the choices array is empty", async () => {
+    // Arrange: no choices -> optional chaining yields "{}".
+    createMock.mockResolvedValue({ choices: [] });
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a schema error on a malformed (invalid enum) response", async () => {
+    // Arrange: issueType is not a valid enum value.
+    createMock.mockResolvedValue(
+      reply(JSON.stringify({ ...classificationResult, issueType: "NOPE" })),
+    );
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("x", null)).rejects.toThrow(
+      /invalid classification response/i,
+    );
+  });
+
+  it("throws a SyntaxError when the reply contains no JSON object", async () => {
+    // Arrange
+    createMock.mockResolvedValue(reply("no json here"));
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("x", null)).rejects.toThrow(SyntaxError);
+  });
+
+  it("propagates SDK errors (timeout/exception) to the caller", async () => {
+    // Arrange: the OpenAI client rejects (e.g. APITimeoutError / network).
+    createMock.mockRejectedValue(new Error("openai timeout"));
+
+    // Act / Assert
+    await expect(classifyWithOpenAI("x", DATA_URL)).rejects.toThrow(
+      "openai timeout",
+    );
+  });
+});


### PR DESCRIPTION
Closes #201.

## What
Adds colocated unit tests for the three concrete LLM provider adapters that previously had **zero direct coverage** (they were only exercised indirectly through mocked consensus tests):

- \`src/lib/classify/openai-provider.test.ts\`
- \`src/lib/classify/anthropic-provider.test.ts\`
- \`src/lib/classify/google-provider.test.ts\`

Each suite mocks the SDK module via \`vi.mock\` (\`openai\` / \`@anthropic-ai/sdk\` / \`@google/genai\`) so **no network calls or API keys** are used, mirroring the pattern in \`observe.test.ts\`. Fixtures are reused from \`src/test/fixtures/classification\`.

## Branches covered per provider
- Well-formed parse with \`provider\` id + \`latencyMs\` tagging
- Default prompt vs \`options.prompt\` override
- Description present vs empty/whitespace (the \`formatUserDescription\` boundary)
- Image present vs text-only request shaping (image_url / image block / inlineData)
- Media/mime-type derivation: Anthropic png/gif/webp/jpeg + non-data-URL default; Google data-URL mime + jpeg fallback
- Empty / missing content -> \`"{}"\` default -> schema rejection
- Malformed responses (bad enum, wrong-typed field) -> traceable schema error (per #129 validation)
- No-JSON reply -> \`SyntaxError\`
- SDK error/timeout rejection propagated to the caller

## Coverage gate
Targets the CI \`src/lib/classify/**\` >= 95% statements/lines floor. Importing these files now **counts** them, so the error/timeout/edge branches are all covered:

| File | Lines |
|------|-------|
| openai-provider.ts | 100% |
| anthropic-provider.ts | 100% |
| google-provider.ts | 100% |
| **src/lib/classify (dir)** | **100% statements / 100% lines** |

\`npm run test:coverage\` **exits 0** (587 tests pass, 36 new). \`npx tsc --noEmit\` and \`npm run format:check\` are clean.