### PR TITLE
test: deterministic window tests for dedup + rate-limit [#207]

### DIFF
--- a/nexa/src/lib/rate-limit.test.ts
+++ b/nexa/src/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __resetRateLimitStore,
@@ -69,6 +69,109 @@ describe("clientIpFromHeaders", () => {
       clientIpFromHeaders(new Headers({ "x-real-ip": "198.51.100.5" })),
     ).toBe("198.51.100.5");
     expect(clientIpFromHeaders(new Headers())).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic fixed-window boundary tests (#207). These exercise the
+// PRODUCTION clock path: rateLimit is called WITHOUT an injected `now`, so it
+// reads Date.now(). Vitest fake timers freeze and advance that clock, so the
+// window edges are deterministic with no injected time and no real sleeps.
+// ---------------------------------------------------------------------------
+describe("rateLimit — fixed-window boundary under fake timers (#207)", () => {
+  const WINDOW_MS = 60_000;
+  const START = new Date("2026-06-09T12:00:00.000Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+  });
+
+  afterEach(() => {
+    // __resetRateLimitStore runs via the outer afterEach; restore the clock.
+    vi.useRealTimers();
+  });
+
+  it("counts requests within the window and blocks past the limit", () => {
+    const opts = { limit: 3, windowMs: WINDOW_MS };
+
+    // Three requests inside the same (frozen) window are allowed.
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+    expect(rateLimit("ip", opts).remaining).toBe(0);
+
+    // Advance but stay strictly inside the window: still blocked.
+    vi.advanceTimersByTime(WINDOW_MS - 1);
+    const blocked = rateLimit("ip", opts);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSeconds).toBe(1); // ~1ms left → ceil to 1.
+  });
+
+  it("does NOT reset one millisecond before the window expires", () => {
+    const opts = { limit: 1, windowMs: WINDOW_MS };
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+
+    // resetAt = START + WINDOW_MS; one tick before that the window is alive.
+    vi.advanceTimersByTime(WINDOW_MS - 1);
+    expect(rateLimit("ip", opts).allowed).toBe(false);
+  });
+
+  it("resets exactly at the window edge (now >= resetAt is inclusive)", () => {
+    const opts = { limit: 1, windowMs: WINDOW_MS };
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+
+    // Advance precisely to resetAt: the counter restarts and the request passes.
+    vi.advanceTimersByTime(WINDOW_MS);
+    const afterReset = rateLimit("ip", opts);
+    expect(afterReset.allowed).toBe(true);
+    expect(afterReset.remaining).toBe(0); // fresh window, one request spent.
+  });
+
+  it("starts a fresh window after expiry rather than carrying the count over", () => {
+    const opts = { limit: 2, windowMs: WINDOW_MS };
+    rateLimit("ip", opts); // 1
+    expect(rateLimit("ip", opts).remaining).toBe(0); // 2 — at the limit
+    expect(rateLimit("ip", opts).allowed).toBe(false); // blocked in window 1
+
+    // Roll past the window: full budget is available again.
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+    expect(rateLimit("ip", opts).allowed).toBe(true);
+    expect(rateLimit("ip", opts).allowed).toBe(false);
+  });
+
+  it("isolates keys: one IP exhausting its budget does not leak into another", () => {
+    const opts = { limit: 1, windowMs: WINDOW_MS };
+
+    // ip_a spends and exhausts its budget.
+    expect(rateLimit("ip_a", opts).allowed).toBe(true);
+    expect(rateLimit("ip_a", opts).allowed).toBe(false);
+
+    // ip_b is untouched — full budget despite ip_a being blocked.
+    expect(rateLimit("ip_b", opts).allowed).toBe(true);
+    expect(rateLimit("ip_b", opts).allowed).toBe(false);
+
+    // Their windows expire independently; advancing time resets both cleanly.
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(rateLimit("ip_a", opts).allowed).toBe(true);
+    expect(rateLimit("ip_b", opts).allowed).toBe(true);
+  });
+
+  it("keeps each key's window edge independent when stamped at different times", () => {
+    const opts = { limit: 1, windowMs: WINDOW_MS };
+
+    // ip_a's window opens at START.
+    expect(rateLimit("ip_a", opts).allowed).toBe(true);
+
+    // Half a window later ip_b opens its own window.
+    vi.advanceTimersByTime(WINDOW_MS / 2);
+    expect(rateLimit("ip_b", opts).allowed).toBe(true);
+
+    // At START + WINDOW_MS, ip_a resets but ip_b (opened later) is still capped.
+    vi.advanceTimersByTime(WINDOW_MS / 2);
+    expect(rateLimit("ip_a", opts).allowed).toBe(true);
+    expect(rateLimit("ip_b", opts).allowed).toBe(false);
   });
 });
 

--- a/nexa/src/lib/reports/dedup.test.ts
+++ b/nexa/src/lib/reports/dedup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { makeReport } from "@/test/factories/report";
 import { prismaMock } from "@/test/prisma-mock";
@@ -11,6 +11,11 @@ const LAT = 37.4419;
 const LON = -122.143;
 const NEAR_LON = -122.1428; // ~17m east at this latitude — inside 50m.
 const FAR_LON = -122.142; // ~88m east — outside 50m.
+
+// Defaults from src/lib/config.ts (env unset in the test runner).
+const WINDOW_HOURS = 24;
+const WINDOW_MS = WINDOW_HOURS * 60 * 60 * 1000;
+const RADIUS_METERS = 50;
 
 describe("findDuplicateReport", () => {
   it("returns null when the report has no issue type", async () => {
@@ -131,5 +136,233 @@ describe("findDuplicateReport", () => {
     });
 
     expect(match?.reportId).toBe("report_nearer");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic time-window (stale-window cutoff) and radius-boundary tests
+// (#207). Time is frozen with vitest fake timers so the `since` cutoff derived
+// from `Date.now()` inside findDuplicateReport is fully deterministic — no real
+// clock, no sleeps.
+//
+// findDuplicateReport delegates the createdAt >= since filter to Prisma, which
+// is deep-mocked here. To genuinely exercise the boundary we drive the mock as
+// the real database would: it returns only candidates whose createdAt satisfies
+// the `where.createdAt.gte` the function actually computed. A report stamped
+// just INSIDE the window survives the filter (→ duplicate); one stamped just
+// OUTSIDE is filtered out (→ not a duplicate).
+// ---------------------------------------------------------------------------
+describe("findDuplicateReport — stale-window boundary (#207)", () => {
+  // A fixed, arbitrary "now" well clear of the epoch so subtraction can't
+  // accidentally land on 0 and mask a sign error.
+  const NOW = new Date("2026-06-09T12:00:00.000Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Drive the Prisma mock the way the real DB would: only return candidates
+   * whose createdAt is >= the `since` cutoff the function passed in `where`.
+   * Returns the call args so tests can also assert the cutoff directly.
+   */
+  function mockFilteredByWindow(
+    allCandidates: ReturnType<typeof makeReport>[],
+  ) {
+    prismaMock.report.findMany.mockImplementation((async (args: {
+      where?: { createdAt?: { gte?: Date } };
+    }) => {
+      const since = args.where?.createdAt?.gte;
+      if (!since) return allCandidates;
+      return allCandidates.filter(
+        (c) => c.createdAt.getTime() >= since.getTime(),
+      );
+    }) as typeof prismaMock.report.findMany);
+  }
+
+  it("computes the look-back cutoff as now minus the 24h window", async () => {
+    prismaMock.report.findMany.mockResolvedValue([]);
+
+    await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    const where = prismaMock.report.findMany.mock.calls[0][0]?.where as {
+      createdAt: { gte: Date };
+    };
+    expect(where.createdAt.gte.getTime()).toBe(NOW - WINDOW_MS);
+  });
+
+  it("flags a report created just INSIDE the stale window as a duplicate", async () => {
+    // 1ms newer than the cutoff → must survive the createdAt filter.
+    const justInside = makeReport({
+      id: "report_just_inside",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+      createdAt: new Date(NOW - WINDOW_MS + 1),
+    });
+    mockFilteredByWindow([justInside]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match?.reportId).toBe("report_just_inside");
+  });
+
+  it("treats a report exactly ON the cutoff as in-window (gte is inclusive)", async () => {
+    const exactlyOnEdge = makeReport({
+      id: "report_on_edge",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+      createdAt: new Date(NOW - WINDOW_MS),
+    });
+    mockFilteredByWindow([exactlyOnEdge]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match?.reportId).toBe("report_on_edge");
+  });
+
+  it("does NOT flag a report created just OUTSIDE the stale window", async () => {
+    // 1ms older than the cutoff → the DB filter excludes it, so no duplicate.
+    const justOutside = makeReport({
+      id: "report_just_outside",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+      createdAt: new Date(NOW - WINDOW_MS - 1),
+    });
+    mockFilteredByWindow([justOutside]);
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match).toBeNull();
+  });
+
+  it("advancing past the window edge turns a once-duplicate into a non-duplicate", async () => {
+    // A report stamped exactly at the original NOW.
+    const report = makeReport({
+      id: "report_aging",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: NEAR_LON,
+      createdAt: new Date(NOW),
+    });
+    mockFilteredByWindow([report]);
+
+    // At NOW it is in-window → duplicate.
+    expect(
+      (
+        await findDuplicateReport({
+          userId: "user_1",
+          issueType: "ROAD_DAMAGE",
+          latitude: LAT,
+          longitude: LON,
+        })
+      )?.reportId,
+    ).toBe("report_aging");
+
+    // Advance just past the window: the same report is now stale.
+    vi.setSystemTime(NOW + WINDOW_MS + 1);
+    expect(
+      await findDuplicateReport({
+        userId: "user_1",
+        issueType: "ROAD_DAMAGE",
+        latitude: LAT,
+        longitude: LON,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("findDuplicateReport — radius boundary (#207)", () => {
+  // The haversine refinement is the load-bearing boundary; time is irrelevant
+  // here, but we freeze it anyway for total determinism.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    prismaMock.report.findMany.mockImplementation(
+      (async () => candidates) as typeof prismaMock.report.findMany,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Mutable holder the mock above reads from, set per-test.
+  let candidates: ReturnType<typeof makeReport>[] = [];
+
+  // Longitude offset (degrees) for a target distance in metres, due east, at
+  // LAT — mirrors the METERS_PER_DEGREE_LAT model the prefilter uses so the
+  // crafted points sit predictably either side of the 50m radius.
+  function lonOffsetForMeters(meters: number): number {
+    const metersPerDegLon = 111_320 * Math.cos((LAT * Math.PI) / 180);
+    return meters / metersPerDegLon;
+  }
+
+  it("flags a candidate just INSIDE the radius", async () => {
+    candidates = [
+      makeReport({
+        id: "report_inside_radius",
+        issueType: "ROAD_DAMAGE",
+        latitude: LAT,
+        longitude: LON + lonOffsetForMeters(RADIUS_METERS - 1),
+      }),
+    ];
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match?.reportId).toBe("report_inside_radius");
+    expect(match?.distanceMeters).toBeLessThanOrEqual(RADIUS_METERS);
+  });
+
+  it("does NOT flag a candidate just OUTSIDE the radius", async () => {
+    candidates = [
+      makeReport({
+        id: "report_outside_radius",
+        issueType: "ROAD_DAMAGE",
+        latitude: LAT,
+        longitude: LON + lonOffsetForMeters(RADIUS_METERS + 2),
+      }),
+    ];
+
+    const match = await findDuplicateReport({
+      userId: "user_1",
+      issueType: "ROAD_DAMAGE",
+      latitude: LAT,
+      longitude: LON,
+    });
+
+    expect(match).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #207.

Adds deterministic, fake-timer-driven tests for the time-sensitive branches the audit flagged as undercovered. No production code changed — tests only. Extends the existing colocated test files (no second time-mocking helper, reuses `src/test` prisma-mock + report factory).

## dedup (`src/lib/reports/dedup.test.ts`)
The look-back cutoff (`since = now - 24h`) is computed from `Date.now()` and delegated to Prisma's `createdAt.gte` filter. Tests freeze the clock with `vi.setSystemTime` and drive the Prisma mock to filter exactly as the real DB would:
- asserts the computed cutoff equals `now - window`
- a report just **inside** the stale window (cutoff + 1ms) IS flagged duplicate
- a report exactly **on** the cutoff is in-window (`gte` is inclusive)
- a report just **outside** (cutoff − 1ms) is NOT a duplicate
- advancing past the window edge turns a once-duplicate into a non-duplicate
- radius boundary: candidate just inside 50m flagged, just outside not (haversine refinement)

## rate-limit (`src/lib/rate-limit.test.ts`)
Exercises the **production clock path** — `rateLimit` is called without an injected `now`, so it reads `Date.now()`, driven by fake timers:
- counts within the window then blocks past the limit
- no reset 1ms before expiry; inclusive reset exactly at the window edge (`now >= resetAt`)
- a fresh budget after expiry rather than carrying the count over
- per-key isolation: one IP exhausting its budget does not leak into another
- independent window edges when keys open windows at different times

## Verification
- `npm run test:coverage` exits 0 — 568 tests pass (13 new); coverage gate green
- `npx tsc --noEmit` clean
- `npm run format:check` clean