### PR TITLE
feat(report): populate location from photo EXIF GPS when no shared location [#216]

### DIFF
--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -106,14 +106,38 @@ export default function ReportPage() {
       },
       {
         onSuccess: (data) => {
+          // Precedence: explicit user GPS / address pick > photo EXIF > none.
+          // The server extracts EXIF GPS during preprocessing and reports it via
+          // `preprocess.exifGpsUsed` + `locationUsed`. When the user shared no
+          // location, fold those coords into the report (reverse-geocoded to an
+          // address by the hook). `applyExifFallback` no-ops if the user already
+          // has a location, so the explicit pick always wins and the result
+          // stays overridable. `lat`/`lng` below read the (possibly updated)
+          // coords so routing runs on whatever location we settled on.
+          let lat = geo.latitude;
+          let lng = geo.longitude;
+          if (
+            lat === null &&
+            lng === null &&
+            data.preprocess?.exifGpsUsed &&
+            typeof data.locationUsed?.latitude === "number" &&
+            typeof data.locationUsed?.longitude === "number"
+          ) {
+            geo.applyExifFallback(
+              data.locationUsed.latitude,
+              data.locationUsed.longitude,
+            );
+            lat = data.locationUsed.latitude;
+            lng = data.locationUsed.longitude;
+          }
           void formLookup.lookup(data.winner.issueType, {
             address: geo.address,
-            latitude: geo.latitude,
-            longitude: geo.longitude,
+            latitude: lat,
+            longitude: lng,
           });
           void agencyCandidates.lookup(data.winner.issueType, {
-            latitude: geo.latitude,
-            longitude: geo.longitude,
+            latitude: lat,
+            longitude: lng,
           });
           setStep("review");
           posthog?.capture("report_classified", {
@@ -221,6 +245,7 @@ export default function ReportPage() {
             latitude={geo.latitude}
             longitude={geo.longitude}
             accuracy={geo.accuracy}
+            locationSource={geo.source}
             locationLoading={geo.loading}
             locationSuggesting={addressLookup.suggesting}
             addressSuggestions={addressLookup.suggestions.map(

--- a/nexa/src/components/report/describe-step.test.tsx
+++ b/nexa/src/components/report/describe-step.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "@/test";
 
 import { DescribeStep } from "./describe-step";
+import type { LocationSource } from "@/hooks/use-geolocation";
 
 // The real LocationMap pulls in Leaflet (touches `window` at import). Replace it
 // with a marker we can assert on so "map renders only when lat+lon set" is
@@ -42,6 +43,7 @@ function baseProps() {
     latitude: null as number | null,
     longitude: null as number | null,
     accuracy: null as number | null,
+    locationSource: null as LocationSource,
     locationLoading: false,
     locationSuggesting: false,
     addressSuggestions: [] as string[],
@@ -287,6 +289,37 @@ describe("DescribeStep", () => {
 
     // Assert
     expect(screen.getByTestId("location-map")).toBeInTheDocument();
+  });
+
+  it("shows the photo-EXIF source hint only when locationSource is exif", () => {
+    // Arrange / Act: a user-sourced location shows no "from photo" hint.
+    const { rerender } = renderWithProviders(
+      <DescribeStep
+        {...baseProps()}
+        latitude={40.5}
+        longitude={-74.2}
+        locationSource="user"
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("From photo")).not.toBeInTheDocument();
+
+    // Act: an EXIF-sourced location surfaces the hint + override guidance.
+    rerender(
+      <DescribeStep
+        {...baseProps()}
+        latitude={40.5}
+        longitude={-74.2}
+        locationSource="exif"
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("From photo")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Location set from the photo's GPS data/),
+    ).toBeInTheDocument();
   });
 
   it("disables the classify button when canSubmit is false", () => {

--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ErrorBanner } from "@/components/error-banner";
 import { useSpeechRecognition } from "@/hooks/use-speech-recognition";
+import type { LocationSource } from "@/hooks/use-geolocation";
 import { useI18n } from "@/i18n/provider";
 
 // Leaflet touches `window` at module load, so render the map only on the client.
@@ -26,6 +27,7 @@ interface DescribeStepProps {
   latitude: number | null;
   longitude: number | null;
   accuracy: number | null;
+  locationSource: LocationSource;
   locationLoading: boolean;
   locationSuggesting: boolean;
   addressSuggestions: string[];
@@ -50,6 +52,7 @@ export function DescribeStep({
   latitude,
   longitude,
   accuracy,
+  locationSource,
   locationLoading,
   locationSuggesting,
   addressSuggestions,
@@ -346,10 +349,20 @@ export function DescribeStep({
                   ±{Math.round(accuracy)}m
                 </span>
               )}
+              {locationSource === "exif" && (
+                <span className="rounded-full bg-ep-green-light px-2 py-0.5 text-ep-green dark:bg-green-950 dark:text-green-300">
+                  {t("report.locationFromPhoto")}
+                </span>
+              )}
               <span className="text-muted-foreground/70">
                 {t("report.dragPin")}
               </span>
             </div>
+            {locationSource === "exif" && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {t("report.locationFromPhotoHint")}
+              </p>
+            )}
             <LocationMap
               latitude={latitude}
               longitude={longitude}

--- a/nexa/src/hooks/use-geolocation.test.tsx
+++ b/nexa/src/hooks/use-geolocation.test.tsx
@@ -195,6 +195,116 @@ describe("useGeolocation", () => {
     expect(result.current.longitude).toBe(20);
   });
 
+  it("starts with a null location source", () => {
+    // Arrange / Act
+    const { result } = renderHook(() => useGeolocation());
+
+    // Assert
+    expect(result.current.source).toBeNull();
+  });
+
+  it("detect() marks the source as user", async () => {
+    // Arrange
+    const getCurrentPosition = installGeolocation();
+    getCurrentPosition.mockImplementation((success) => {
+      success(makePosition(37.44, -122.16, 12));
+    });
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act
+    act(() => {
+      result.current.detect();
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.source).toBe("user"));
+  });
+
+  it("setCoordinates() marks the source as user and clears it on null coords", () => {
+    // Arrange
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act: an explicit pick (e.g. address suggestion) sets user provenance.
+    act(() => {
+      result.current.setCoordinates(10, 20);
+    });
+    // Assert
+    expect(result.current.source).toBe("user");
+
+    // Act: clearing coords (free-text address with no resolved point) resets it.
+    act(() => {
+      result.current.setCoordinates(null, null);
+    });
+    // Assert
+    expect(result.current.source).toBeNull();
+  });
+
+  it("applyExifFallback() populates coords + address and tags the source as exif", async () => {
+    // Arrange
+    mockReverseGeocode.mockResolvedValue("EXIF Address");
+    const { result } = renderHook(() => useGeolocation());
+
+    // Act: no prior location, so the photo's EXIF GPS fills in.
+    let applied: boolean | undefined;
+    act(() => {
+      applied = result.current.applyExifFallback(40.5, -74.2);
+    });
+
+    // Assert
+    expect(applied).toBe(true);
+    expect(result.current.latitude).toBe(40.5);
+    expect(result.current.longitude).toBe(-74.2);
+    expect(result.current.source).toBe("exif");
+    expect(mockReverseGeocode).toHaveBeenCalledWith(40.5, -74.2);
+    await waitFor(() => expect(result.current.address).toBe("EXIF Address"));
+  });
+
+  it("applyExifFallback() does NOT override an existing user location (precedence)", () => {
+    // Arrange: user has already shared a location.
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.setCoordinates(1, 2);
+    });
+    mockReverseGeocode.mockClear();
+
+    // Act: EXIF arrives afterward — must defer to the explicit user pick.
+    let applied: boolean | undefined;
+    act(() => {
+      applied = result.current.applyExifFallback(40.5, -74.2);
+    });
+
+    // Assert: coords + source unchanged, no reverse-geocode triggered.
+    expect(applied).toBe(false);
+    expect(result.current.latitude).toBe(1);
+    expect(result.current.longitude).toBe(2);
+    expect(result.current.source).toBe("user");
+    expect(mockReverseGeocode).not.toHaveBeenCalled();
+  });
+
+  it("a user pin drag after an EXIF fallback overrides the source back to user", async () => {
+    // Arrange: EXIF fallback populated the location first.
+    mockReverseGeocode.mockResolvedValue("EXIF Address");
+    const { result } = renderHook(() => useGeolocation());
+    act(() => {
+      result.current.applyExifFallback(40.5, -74.2);
+    });
+    expect(result.current.source).toBe("exif");
+
+    // Act: the user corrects it by dragging the pin (still overridable).
+    mockReverseGeocode.mockResolvedValue("Corrected Address");
+    act(() => {
+      result.current.movePin(5, 6);
+    });
+
+    // Assert
+    expect(result.current.latitude).toBe(5);
+    expect(result.current.longitude).toBe(6);
+    expect(result.current.source).toBe("user");
+    await waitFor(() =>
+      expect(result.current.address).toBe("Corrected Address"),
+    );
+  });
+
   it("movePin() sets coords and refreshes the address", async () => {
     // Arrange
     mockReverseGeocode.mockResolvedValue("Pinned Address");
@@ -231,6 +341,7 @@ describe("useGeolocation", () => {
     expect(result.current.longitude).toBeNull();
     expect(result.current.accuracy).toBeNull();
     expect(result.current.address).toBe("");
+    expect(result.current.source).toBeNull();
     expect(result.current.error).toBeNull();
   });
 

--- a/nexa/src/hooks/use-geolocation.ts
+++ b/nexa/src/hooks/use-geolocation.ts
@@ -7,11 +7,19 @@ import {
   GEOLOCATION_CACHE_AGE_MS,
 } from "@/lib/constants";
 
+/**
+ * Where the current report coordinates came from. Drives both the UI hint and
+ * the fallback precedence: a `"user"` source (GPS share, address pick, or pin
+ * drag) always outranks photo `"exif"`, and `null` means no location yet.
+ */
+export type LocationSource = "user" | "exif" | null;
+
 export function useGeolocation() {
   const [address, setAddress] = useState("");
   const [latitude, setLatitude] = useState<number | null>(null);
   const [longitude, setLongitude] = useState<number | null>(null);
   const [accuracy, setAccuracy] = useState<number | null>(null);
+  const [source, setSource] = useState<LocationSource>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,10 +27,14 @@ export function useGeolocation() {
   // the result of a more recent one.
   const geocodeSeq = useRef(0);
 
+  // Keep coords + their provenance in lockstep so callers never have to set both
+  // by hand. Any explicit user action (detect, address pick, pin drag) passes
+  // `"user"`; clearing coords resets the source to null.
   const setCoordinates = useCallback(
-    (lat: number | null, lng: number | null) => {
+    (lat: number | null, lng: number | null, src: LocationSource = "user") => {
       setLatitude(lat);
       setLongitude(lng);
+      setSource(lat === null || lng === null ? null : src);
     },
     [],
   );
@@ -76,6 +88,34 @@ export function useGeolocation() {
     );
   }, [setCoordinates, refreshAddress]);
 
+  /**
+   * Photo EXIF GPS fallback. Populates the report location from coordinates
+   * extracted from the uploaded image — but only when the user has NOT already
+   * supplied one. This encodes the precedence (user GPS / address pick > photo
+   * EXIF): if `source` is already set we no-op, so an explicit pick is never
+   * clobbered, and the result stays fully overridable afterward. Returns true
+   * when the fallback was applied so callers can react if needed.
+   */
+  const applyExifFallback = useCallback(
+    (lat: number, lng: number): boolean => {
+      // Read the live source from the setter to avoid a stale closure: this is
+      // called from a classify callback that may run with an older `source`.
+      let applied = false;
+      setSource((current) => {
+        if (current !== null) return current;
+        applied = true;
+        return "exif";
+      });
+      if (!applied) return false;
+      setLatitude(lat);
+      setLongitude(lng);
+      setAccuracy(null);
+      void refreshAddress(lat, lng);
+      return true;
+    },
+    [refreshAddress],
+  );
+
   /** Pin drag → update coords + reverse-geocode to keep address in sync. */
   const movePin = useCallback(
     (lat: number, lng: number) => {
@@ -99,9 +139,11 @@ export function useGeolocation() {
     latitude,
     longitude,
     accuracy,
+    source,
     loading,
     error,
     setCoordinates,
+    applyExifFallback,
     movePin,
     detect,
     reset,

--- a/nexa/src/hooks/use-report-submission.ts
+++ b/nexa/src/hooks/use-report-submission.ts
@@ -4,19 +4,19 @@ import { useCallback, useState } from "react";
 import { queueReport } from "@/lib/offline-queue";
 import { uploadImageViaPresign } from "@/lib/upload-image";
 import type { ApiResponse } from "@/lib/api/response";
-import type {
-  ClassificationResult,
-  ComparisonResult,
-} from "@/lib/classify/types";
+import type { ClassificationResult } from "@/lib/classify/types";
+import type { ExtendedComparisonResult } from "@/lib/classify/consensus";
 
-// The classify route returns the canonical `ComparisonResult` (extended on the
-// server with diagnostic fields this hook does not read). Re-export under the
-// existing names so consumers of this hook keep their import paths.
+// The classify route returns `ExtendedComparisonResult` — the base comparison
+// plus diagnostics. Two of those extra fields drive the EXIF-location fallback:
+// `locationUsed` carries the coordinates folded into the prompt (which may be
+// the photo's EXIF GPS), and `preprocess.exifGpsUsed` flags when that happened.
+// Re-export under the existing names so consumers keep their import paths.
 export type {
   ClassificationResult,
   ProviderResult,
 } from "@/lib/classify/types";
-export type ComparisonResponse = ComparisonResult;
+export type ComparisonResponse = ExtendedComparisonResult;
 
 export interface CreatedReport {
   id: string;

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -133,6 +133,9 @@ const enMessages = {
   "report.addressSuggestions": "Address suggestions",
   "report.gpsAccuracy": "Location accuracy: {meters} meters",
   "report.dragPin": "Drag the pin to correct",
+  "report.locationFromPhoto": "From photo",
+  "report.locationFromPhotoHint":
+    "Location set from the photo's GPS data. Detect your location or edit the address to change it.",
   "report.mapAdjustLabel":
     "Map showing detected location. Drag the pin or use the keyboard control to adjust.",
   "report.mapPinKeyboardLabel": "Adjust location pin",
@@ -393,6 +396,9 @@ export const messages = {
     "report.addressSuggestions": "Sugerencias de direcciones",
     "report.gpsAccuracy": "Precisión de ubicación: {meters} metros",
     "report.dragPin": "Arrastra el pin para corregir",
+    "report.locationFromPhoto": "De la foto",
+    "report.locationFromPhotoHint":
+      "Ubicación tomada de los datos GPS de la foto. Detecta tu ubicación o edita la dirección para cambiarla.",
     "report.mapAdjustLabel":
       "Mapa que muestra la ubicación detectada. Arrastra el pin o usa el control de teclado para ajustar.",
     "report.mapPinKeyboardLabel": "Ajustar el pin de ubicación",
@@ -638,6 +644,9 @@ export const messages = {
     "report.addressSuggestions": "地址建议",
     "report.gpsAccuracy": "位置精度：{meters} 米",
     "report.dragPin": "拖动图钉以校正",
+    "report.locationFromPhoto": "来自照片",
+    "report.locationFromPhotoHint":
+      "位置取自照片的 GPS 数据。检测您的位置或编辑地址即可更改。",
     "report.mapAdjustLabel":
       "地图显示检测到的位置。拖动图钉或使用键盘控件进行调整。",
     "report.mapPinKeyboardLabel": "调整位置图钉",
@@ -890,6 +899,9 @@ export const messages = {
     "report.addressSuggestions": "Suggestions d'adresses",
     "report.gpsAccuracy": "Précision de localisation : {meters} mètres",
     "report.dragPin": "Déplacez l'épingle pour corriger",
+    "report.locationFromPhoto": "Depuis la photo",
+    "report.locationFromPhotoHint":
+      "Position définie à partir des données GPS de la photo. Détectez votre position ou modifiez l'adresse pour la changer.",
     "report.mapAdjustLabel":
       "Carte montrant la position détectée. Déplacez l'épingle ou utilisez la commande clavier pour ajuster.",
     "report.mapPinKeyboardLabel": "Ajuster l'épingle de position",


### PR DESCRIPTION
## Summary
Closes #216. When a user uploads a GPS-tagged photo but has **not** shared a device location or picked an address, the report location now falls back to the photo's EXIF GPS (reverse-geocoded to an address). The resulting coords drive agency routing exactly as before.

The server side already did the heavy lifting: `preprocessImage` extracts `exifGps`, and `classifyWithConsensus` merges it into `locationUsed` and flags `preprocess.exifGpsUsed`. The classify route already returned this. The gap was purely client-side — those fields were typed away and never consumed. This PR wires them through with no parallel geocoding/coordinate path.

## Precedence
**explicit user GPS / address pick > photo EXIF > none.**
- `useGeolocation` now tracks a `source: "user" | "exif" | null`. Every explicit action (detect, address-suggestion pick, pin drag) sets `"user"`.
- New `applyExifFallback(lat, lng)` populates coords + reverse-geocodes the address **only when no location is set** (`source === null`); otherwise it no-ops. So an explicit pick always wins, and the EXIF location stays fully overridable afterward (a later detect/drag flips the source back to `"user"`).
- The report page applies the fallback in the classify `onSuccess` handler when `geo.{latitude,longitude}` are absent and the response reports `preprocess.exifGpsUsed` with `locationUsed` coords, then uses those coords for form-link + agency-candidate lookups.

## UX
The describe step shows a "From photo" badge plus override guidance when the location came from EXIF. New i18n keys added for all four locales (en/es/zh/fr).

## Tests
- `use-geolocation.test.tsx`: source tracking, `applyExifFallback` populates coords/address/source, precedence no-op over an existing user location, and user override after EXIF.
- `describe-step.test.tsx`: the "from photo" hint renders only for `locationSource === "exif"`.

## Checks
- `npm run test:coverage` exits 0 (562 tests; global floors met — branches 76.84% ≥ 75, lines 88.56% ≥ 87; classify dir still 100%).
- `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run format:check` all clean.