### PR TITLE
feat(data): seed East Palo Alto agencies + expand verified coverage triples [#195][#198]

### DIFF
--- a/nexa/eval/coverage.ts
+++ b/nexa/eval/coverage.ts
@@ -1,0 +1,136 @@
+/**
+ * Agency coverage audit (O2.KR2).
+ *
+ *   npx tsx eval/coverage.ts
+ *   npm run eval:coverage
+ *   npm run eval:coverage -- --strict   # exit non-zero when below the target
+ *
+ * WHAT IT MEASURES (O2.KR2): the number of DISTINCT
+ * `(jurisdiction, issueType, intakeMethod)` triples the seeded agencies cover.
+ * The OKR target is >=30 such triples across >=2 jurisdictions, each with a
+ * known submission method. This script is the single source of truth for that
+ * count — it enumerates every triple straight from the same `AGENCIES` array
+ * that `prisma/seed.ts` writes to the DB and `eval/readiness.ts` routes against,
+ * so there is no parallel data structure to drift.
+ *
+ * FULLY OFFLINE: it only imports the static seed array. No network, DB, or LLM.
+ *
+ * HONESTY POLICY: this script reports the REAL verified count. As of the East
+ * Palo Alto + verified-coverage expansion (issues #195/#198) the seeded data
+ * yields 16 distinct triples — short of the 30 target. The remaining gap is NOT
+ * closed by inventing agencies or fields; reaching 30 requires onboarding more
+ * source-verified intake channels (see the "STILL NEEDED" section printed below
+ * and the agency-research comments on issues #23 / #98). By default the script
+ * exits 0 (it is a documentation/visibility tool, not a hard CI gate, precisely
+ * because faking the number to pass a gate is forbidden). Pass `--strict` to
+ * make it exit non-zero below the target once the verified data genuinely
+ * reaches 30.
+ */
+import { AGENCIES } from "../prisma/agencies";
+
+/** O2.KR2 target: >=30 distinct (jurisdiction, issueType, intakeMethod) triples. */
+const TARGET_TRIPLES = 30;
+
+interface Triple {
+  jurisdiction: string;
+  issueType: string;
+  intakeMethod: string;
+}
+
+function enumerateTriples(): Triple[] {
+  const seen = new Set<string>();
+  const triples: Triple[] = [];
+  for (const agency of AGENCIES) {
+    for (const issueType of agency.issueTypes) {
+      const key = `${agency.jurisdiction}|${issueType}|${agency.intakeMethod}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      triples.push({
+        jurisdiction: agency.jurisdiction,
+        issueType,
+        intakeMethod: agency.intakeMethod,
+      });
+    }
+  }
+  return triples;
+}
+
+/**
+ * Counts distinct (jurisdiction, issueType, intakeMethod) triples and the
+ * supporting jurisdiction / intake-method breakdowns. Exported so unit tests can
+ * assert the count without re-implementing the enumeration.
+ */
+export function countTriples(): {
+  total: number;
+  triples: Triple[];
+  jurisdictions: string[];
+  intakeMethods: string[];
+} {
+  const triples = enumerateTriples();
+  const jurisdictions = Array.from(
+    new Set(triples.map((t) => t.jurisdiction)),
+  ).sort();
+  const intakeMethods = Array.from(
+    new Set(triples.map((t) => t.intakeMethod)),
+  ).sort();
+  return { total: triples.length, triples, jurisdictions, intakeMethods };
+}
+
+function main(): void {
+  const strict = process.argv.slice(2).includes("--strict");
+  const { total, triples, jurisdictions, intakeMethods } = countTriples();
+
+  console.log("\n=== Agency coverage audit (O2.KR2) ===");
+  console.log(
+    `Distinct (jurisdiction × issueType × intakeMethod) triples: ${total}  (target >=${TARGET_TRIPLES})`,
+  );
+  console.log(
+    `Jurisdictions covered: ${jurisdictions.length} — ${jurisdictions.join(", ")}`,
+  );
+  console.log(`Intake methods present: ${intakeMethods.join(", ")}`);
+
+  console.log("\nTriples:");
+  for (const t of triples
+    .slice()
+    .sort((a, b) =>
+      `${a.jurisdiction}|${a.issueType}|${a.intakeMethod}`.localeCompare(
+        `${b.jurisdiction}|${b.issueType}|${b.intakeMethod}`,
+      ),
+    )) {
+    console.log(`  ${t.jurisdiction} | ${t.issueType} | ${t.intakeMethod}`);
+  }
+
+  const meetsTarget = total >= TARGET_TRIPLES;
+  if (meetsTarget) {
+    console.log(
+      `\nPASS: ${total}/${TARGET_TRIPLES} verified triples across ${jurisdictions.length} jurisdictions (O2.KR2 met).`,
+    );
+  } else {
+    const gap = TARGET_TRIPLES - total;
+    console.log(
+      `\nBELOW TARGET: ${total}/${TARGET_TRIPLES} verified triples — short by ${gap}.`,
+    );
+    console.log(
+      "This is the HONEST count: no agencies or fields were invented to hit 30.\n" +
+        "STILL NEEDED (source-verified data only — see issue #23 / #98 research):\n" +
+        "  - Onboard additional SeeClickFix Open311 cities (Milpitas, Morgan Hill,\n" +
+        "    Gilroy) once their boundaries are seeded — each adds verified API\n" +
+        "    triples for ROAD_DAMAGE / ILLEGAL_DUMPING. These are NOT yet seeded\n" +
+        "    jurisdictions (no boundary polygon), so they cannot be counted here.\n" +
+        "  - Verify Palo Alto 311 / Mountain View dumping / SCC service catalogs\n" +
+        "    (those agency pages returned HTTP 403 or are JS SPAs and could not be\n" +
+        "    field-verified). Promoting them adds no NEW triples but raises\n" +
+        "    confidence on existing ones.\n" +
+        "  - A second VERIFIED VEHICLE_EMISSIONS modality (e.g. a CARB web-form\n" +
+        "    URL, or BAAQMD as a seeded special-district) would add emissions\n" +
+        "    triples beyond the single PHONE channel currently verified.",
+    );
+  }
+
+  if (strict && !meetsTarget) process.exitCode = 1;
+}
+
+// Only run the report when executed directly (not when imported by tests).
+if (process.argv[1] && process.argv[1].endsWith("coverage.ts")) {
+  main();
+}

--- a/nexa/eval/dataset/readiness-cases.json
+++ b/nexa/eval/dataset/readiness-cases.json
@@ -238,5 +238,45 @@
       "vehicleColor": "dark",
       "observationDatetime": "2026-06-09T17:45:00-07:00"
     }
+  },
+  {
+    "id": "road-epa-13",
+    "issueType": "ROAD_DAMAGE",
+    "note": "East Palo Alto road damage -> EPA Public Works (WEB_FORM, issue #195). Before this jurisdiction was seeded, EPA reports resolved to no_agency and could not be submitted.",
+    "report": {
+      "description": "Crumbling asphalt and a wide pothole at the intersection.",
+      "aiDescription": "Damaged road surface with pothole in East Palo Alto.",
+      "latitude": 37.4625,
+      "longitude": -122.15081,
+      "address": "University Ave & Bay Rd, East Palo Alto, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/road-epa-13.jpg",
+      "contactEmail": "reporter13@example.com",
+      "contactName": "Robin Ortiz",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "dump-epa-14",
+    "issueType": "ILLEGAL_DUMPING",
+    "note": "East Palo Alto illegal dumping -> EPA Clean City (EMAIL intake, issue #195). Exercises the EMAIL channel (cleancity@cityofepa.org) added in this PR.",
+    "report": {
+      "description": "Couch and bags of household trash dumped at the curb.",
+      "aiDescription": "Illegally dumped furniture and refuse in East Palo Alto.",
+      "latitude": 37.45857,
+      "longitude": -122.13351,
+      "address": "Pulgas Ave & Weeks St, East Palo Alto, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/dump-epa-14.jpg",
+      "contactEmail": null,
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
   }
 ]

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -22,7 +22,8 @@
     "eval:two-stage": "tsx eval/run.ts --mode=two-stage",
     "eval:routing": "tsx eval/routing.ts",
     "eval:validate-boundaries": "tsx eval/validate-boundaries.ts",
-    "eval:readiness": "tsx eval/readiness.ts"
+    "eval:readiness": "tsx eval/readiness.ts",
+    "eval:coverage": "tsx eval/coverage.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/nexa/prisma/agencies.ts
+++ b/nexa/prisma/agencies.ts
@@ -132,6 +132,63 @@ export const AGENCIES: AgencySeed[] = [
     },
   },
   {
+    // ─── East Palo Alto — Public Works (issue #195) ──────────────────────────
+    // VERIFIED per the issue #23 agency-research comment ("East Palo Alto hole
+    // RESOLVED", source-verified 2026-06-09). Before this row the EPA polygon
+    // (boundaries.json: jurisdictionId='city-east-palo-alto') routed reports but
+    // had ZERO seeded agencies, so every East Palo Alto report resolved to
+    // no_agency and could not be submitted (issue #195).
+    //
+    // Verified facts:
+    //   - EPA Public Works handles ROAD_DAMAGE.
+    //   - Intake is the city contact web form (cityofepa.org/contact) with a
+    //     verified staff email fallback (maintenance@cityofepa.org; the research
+    //     also lists engineering@cityofepa.org). We model the web form as the
+    //     primary intake (intakeMethod=WEB_FORM) and carry the verified email in
+    //     intakeEmail as the fallback channel.
+    //   - EPA exposes NO machine API — the research explicitly CORRECTS an
+    //     earlier "EPA uses SeeClickFix" claim (SeeClickFix is Menlo Park's
+    //     provider, not EPA's), so this stays WEB_FORM, never API.
+    //
+    // The exact form-path / per-field validation was NOT deep-verified, so
+    // requiredFields stays minimal (only the fields any city contact form needs)
+    // — we do not invent field-level constraints.
+    name: "East Palo Alto Public Works",
+    jurisdiction: "city-east-palo-alto",
+    issueTypes: ["ROAD_DAMAGE"],
+    intakeMethod: "WEB_FORM",
+    intakeUrl: "https://www.cityofepa.org/contact",
+    intakeEmail: "maintenance@cityofepa.org",
+    requiredFields: {
+      description: { type: "string", required: true },
+      location_address: { type: "string", required: true },
+      contact_email: { type: "string", required: false },
+    },
+  },
+  {
+    // ─── East Palo Alto — Clean City (issue #195) ────────────────────────────
+    // VERIFIED per the issue #23 agency-research comment (source-verified
+    // 2026-06-09): EPA Clean City handles ILLEGAL_DUMPING. The verified intake
+    // channels are the Clean City email (cleancity@cityofepa.org) and the city
+    // phone line (650) 853-3100 — the research lists NO web form for this
+    // program, so intakeMethod=EMAIL (the published address) and the verified
+    // hotline is carried in requiredFields.contact_phone.value so the readiness
+    // harness and prefill copy-over surface it as a fallback channel.
+    name: "East Palo Alto Clean City",
+    jurisdiction: "city-east-palo-alto",
+    issueTypes: ["ILLEGAL_DUMPING"],
+    intakeMethod: "EMAIL",
+    intakeUrl: null,
+    intakeEmail: "cleancity@cityofepa.org",
+    requiredFields: {
+      // Verified East Palo Alto Clean City hotline (issue #23 research).
+      contact_phone: { type: "string", value: "(650) 853-3100" },
+      description: { type: "string", required: true },
+      location_address: { type: "string", required: true },
+      contact_email: { type: "string", required: false },
+    },
+  },
+  {
     name: "Mountain View Public Works",
     jurisdiction: "city-mountain-view",
     issueTypes: ["ROAD_DAMAGE", "STREETLIGHT_OUTAGE", "ILLEGAL_DUMPING"],

--- a/nexa/src/lib/jurisdictions/agency-coverage.test.ts
+++ b/nexa/src/lib/jurisdictions/agency-coverage.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENCIES } from "../../../prisma/agencies";
+import { countTriples } from "../../../eval/coverage";
+
+// These tests lock the seeded agency data and the O2.KR2 coverage count so the
+// verified East Palo Alto rows (issue #195) and the distinct-triple total
+// (issue #198) can never silently regress.
+
+describe("seeded agency coverage (issues #195 / #198)", () => {
+  it("seeds the verified East Palo Alto Public Works (ROAD_DAMAGE, web form)", () => {
+    const epaRoads = AGENCIES.find(
+      (a) => a.name === "East Palo Alto Public Works",
+    );
+    expect(epaRoads).toBeDefined();
+    expect(epaRoads?.jurisdiction).toBe("city-east-palo-alto");
+    expect(epaRoads?.issueTypes).toEqual(["ROAD_DAMAGE"]);
+    expect(epaRoads?.intakeMethod).toBe("WEB_FORM");
+    // Verified intake URL + staff-email fallback (issue #23 research).
+    expect(epaRoads?.intakeUrl).toContain("cityofepa.org");
+    expect(epaRoads?.intakeEmail).toBe("maintenance@cityofepa.org");
+  });
+
+  it("seeds the verified East Palo Alto Clean City (ILLEGAL_DUMPING, email + hotline)", () => {
+    const epaDump = AGENCIES.find(
+      (a) => a.name === "East Palo Alto Clean City",
+    );
+    expect(epaDump).toBeDefined();
+    expect(epaDump?.jurisdiction).toBe("city-east-palo-alto");
+    expect(epaDump?.issueTypes).toEqual(["ILLEGAL_DUMPING"]);
+    expect(epaDump?.intakeMethod).toBe("EMAIL");
+    expect(epaDump?.intakeEmail).toBe("cleancity@cityofepa.org");
+    // The verified (650) 853-3100 hotline is carried as an embedded field value.
+    const fields = epaDump?.requiredFields as {
+      contact_phone?: { value?: string };
+    };
+    expect(fields?.contact_phone?.value).toBe("(650) 853-3100");
+  });
+
+  it("now covers East Palo Alto so it no longer resolves to no_agency (issue #195)", () => {
+    const epaAgencies = AGENCIES.filter(
+      (a) => a.jurisdiction === "city-east-palo-alto",
+    );
+    // At least the two P0 categories (road damage + illegal dumping) are covered.
+    expect(epaAgencies.length).toBeGreaterThanOrEqual(2);
+    const covered = new Set(epaAgencies.flatMap((a) => a.issueTypes));
+    expect(covered.has("ROAD_DAMAGE")).toBe(true);
+    expect(covered.has("ILLEGAL_DUMPING")).toBe(true);
+  });
+
+  it("counts the distinct (jurisdiction × issueType × intakeMethod) triples (O2.KR2)", () => {
+    const { total, jurisdictions, intakeMethods } = countTriples();
+
+    // HONEST count: the verified seed yields 16 distinct triples — short of the
+    // 30 target. This assertion is the regression lock; raise it (never lower
+    // it) only when MORE source-verified triples are added. We do NOT fabricate
+    // agencies/fields to hit 30 (see eval/coverage.ts "STILL NEEDED").
+    expect(total).toBe(16);
+
+    // Across >=2 jurisdictions, with all four intake methods represented.
+    expect(jurisdictions.length).toBeGreaterThanOrEqual(2);
+    expect(jurisdictions).toContain("city-east-palo-alto");
+    expect(intakeMethods).toEqual(["API", "EMAIL", "PHONE", "WEB_FORM"]);
+  });
+});

--- a/nexa/src/lib/jurisdictions/registry.test.ts
+++ b/nexa/src/lib/jurisdictions/registry.test.ts
@@ -14,9 +14,22 @@ describe("getPortal", () => {
     expect(portal?.url).toContain("paloalto.gov");
   });
 
-  it("returns null when the matched jurisdiction's default endpoint is null", () => {
-    // Arrange / Act: East Palo Alto has an unverified (null) default portal.
+  it("returns the verified East Palo Alto road-damage portal (issue #195)", () => {
+    // Arrange / Act: EPA now has an issue-type-specific ROAD_DAMAGE intake.
     const portal = getPortal("city-east-palo-alto", "ROAD_DAMAGE");
+
+    // Assert: resolves to the verified EPA Public Works contact form.
+    expect(portal).toEqual(
+      JURISDICTIONS["city-east-palo-alto"].endpoints.ROAD_DAMAGE,
+    );
+    expect(portal?.url).toContain("cityofepa.org");
+  });
+
+  it("falls back to null for an East Palo Alto issue type with no verified intake", () => {
+    // Arrange / Act: EPA's `default` is null, so an issue type without a
+    // specific entry (e.g. STREETLIGHT_OUTAGE) still resolves to null and the
+    // caller falls through to the LLM lookup.
+    const portal = getPortal("city-east-palo-alto", "STREETLIGHT_OUTAGE");
 
     // Assert
     expect(portal).toBeNull();

--- a/nexa/src/lib/jurisdictions/registry.ts
+++ b/nexa/src/lib/jurisdictions/registry.ts
@@ -64,8 +64,30 @@ export const JURISDICTIONS: Record<JurisdictionId, Jurisdiction> = {
   "city-east-palo-alto": {
     id: "city-east-palo-alto",
     displayName: "East Palo Alto",
+    // Issue-type-specific intake (issues #195/#198): East Palo Alto splits its
+    // intake by program, so we route per issue type rather than via a single
+    // `default`. These mirror the seeded agencies in prisma/agencies.ts.
     endpoints: {
-      // URL not yet verified — let the LLM lookup handle it for now.
+      // EPA Public Works handles road damage via the city contact web form
+      // (verified per issue #23 agency-research comment, 2026-06-09).
+      ROAD_DAMAGE: {
+        url: "https://www.cityofepa.org/contact",
+        reason:
+          "East Palo Alto Public Works handles road maintenance; the city contact form is the verified intake (maintenance@cityofepa.org is the staff fallback).",
+        confidence: "medium",
+      },
+      // EPA Clean City handles illegal dumping; its verified channel is email
+      // (cleancity@cityofepa.org) plus the city line (650) 853-3100. There is no
+      // verified web form, so we surface the general city contact page as the
+      // best web entry point and keep confidence medium.
+      ILLEGAL_DUMPING: {
+        url: "https://www.cityofepa.org/contact",
+        reason:
+          "East Palo Alto Clean City handles illegal dumping via cleancity@cityofepa.org / (650) 853-3100; the city contact page is the web entry point.",
+        confidence: "medium",
+      },
+      // Other issue types (e.g. streetlights) have no verified EPA intake yet —
+      // leave the default null so callers fall through to the LLM lookup.
       default: null,
     },
   },

--- a/nexa/src/lib/jurisdictions/resolve.test.ts
+++ b/nexa/src/lib/jurisdictions/resolve.test.ts
@@ -65,10 +65,16 @@ describe("resolveJurisdiction", () => {
     expect(result?.portal?.url).toContain("paloalto.gov");
   });
 
-  it("returns a null portal when the matched jurisdiction has no verified endpoint", () => {
-    // Arrange: East Palo Alto matches a polygon but its registry portal is null.
+  it("returns a null portal when the matched jurisdiction has no verified endpoint for the issue type", () => {
+    // Arrange: East Palo Alto matches a polygon and now has verified
+    // ROAD_DAMAGE / ILLEGAL_DUMPING intakes (issue #195), but no STREETLIGHT
+    // intake — that issue type falls through to its null `default`.
     // Act
-    const result = resolveJurisdiction(37.4688, -122.1411, "ROAD_DAMAGE");
+    const result = resolveJurisdiction(
+      37.4688,
+      -122.1411,
+      "STREETLIGHT_OUTAGE",
+    );
 
     // Assert
     expect(result?.jurisdiction.id).toBe("city-east-palo-alto");


### PR DESCRIPTION
Implements #195 and #198 together — both expand the agency seed for the Nexa app using ONLY source-verified intake data from the agency-research comments on #23 / #98. **Nothing was invented**; every field traces to that verified research, and confidence flags / caveats are preserved.

## Agencies added (with sources)

Sources: agency-research comments on #23 and #98 (source-verified 2026-06-09).

| Agency | Jurisdiction | Issue type(s) | Intake | Verified contact |
|---|---|---|---|---|
| East Palo Alto Public Works | `city-east-palo-alto` | ROAD_DAMAGE | WEB_FORM | cityofepa.org/contact + maintenance@cityofepa.org (fallback) |
| East Palo Alto Clean City | `city-east-palo-alto` | ILLEGAL_DUMPING | EMAIL | cleancity@cityofepa.org + hotline (650) 853-3100 |

- **#195**: the EPA polygon already existed in `boundaries.json` and routing-cases reference it 16×, but there were **zero** seeded EPA agencies, so every EPA report resolved to `no_agency` and could not be submitted. These two verified rows fix that for the P0 categories (ROAD_DAMAGE + ILLEGAL_DUMPING). `registry.ts` also gains issue-type-specific EPA routing.
- **EPA exposes no machine API.** The research explicitly corrects an earlier "EPA uses SeeClickFix" claim (SeeClickFix is Menlo Park's provider), so these stay WEB_FORM/EMAIL — never API.
- Reuses the existing `AgencySeed` shape in `prisma/agencies.ts` (single source of truth feeding both `seed.ts` and the readiness harness). No parallel data structure.

## Triple count vs 30 (O2.KR2)

Added `eval/coverage.ts` (`npm run eval:coverage`) — it enumerates the distinct `(jurisdiction × issueType × intakeMethod)` triples from the same `AGENCIES` array and prints the count.

**Result: 16 distinct verified triples across 5 jurisdictions** (up from 14 / 4). All four intake methods are present (API, WEB_FORM, EMAIL, PHONE — EPA adds the EMAIL channel).

**This is short of the 30 target by 14, and that is the honest count.** Per the rules, no agencies/fields were fabricated to hit 30. The script (and `agency-coverage.test.ts`) document the real number and exactly what verified data is still needed:
- Onboard more SeeClickFix Open311 cities (Milpitas, Morgan Hill, Gilroy) — but they are **not seeded jurisdictions** (no boundary polygon) so they cannot be counted yet.
- Field-verify the Palo Alto 311 / Mountain View dumping / SCC service catalogs that returned HTTP 403 or are JS SPAs (raises confidence on existing triples; adds none).
- A second **verified** VEHICLE_EMISSIONS modality (a CARB web-form URL, or BAAQMD as a seeded special-district) would add emissions triples beyond the single verified PHONE channel.

## Tests / gates (all green locally)

- `npm run test:coverage` — **exits 0**, 596 tests pass; `src/lib/jurisdictions` at 94.1% statements / 97.6% lines (above the 90% per-dir floor). New `agency-coverage.test.ts` locks the EPA rows + the triple count; existing `registry.test.ts` / `resolve.test.ts` updated for EPA's new endpoint.
- `npx tsc --noEmit` clean · `npm run lint` (0 errors) · `npm run format:check` clean.
- `npm run eval:readiness` 92.9% (PASS; EPA road + dumping cases added, EMAIL channel exercised) · `npm run eval:routing` 100% · `npm run eval:validate-boundaries` PASS.

Closes #195. Advances #198 (honest 16/30; gap documented).