### PR TITLE
test: integration tests for the 5 untested API routes [#199]

### DIFF
--- a/nexa/src/app/api/issues/map/route.test.ts
+++ b/nexa/src/app/api/issues/map/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IssueType, ReportStatus } from "@/generated/prisma/enums";
+import { prismaMock } from "@/test/prisma-mock";
+
+// The map is login-gated, so drive the session helper to cover authed/anon.
+vi.mock("@/lib/auth", () => ({ getSession: vi.fn() }));
+import { getSession } from "@/lib/auth";
+
+import { GET } from "./route";
+
+const mockedGetSession = vi.mocked(getSession);
+
+/** Build an IssueGroup row as returned by the route's narrowed `select`. */
+function makeGroupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "group_1",
+    latitude: 37.4419,
+    longitude: -122.143,
+    issueType: IssueType.ROAD_DAMAGE,
+    status: ReportStatus.CONFIRMED,
+    reportCount: 3,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    reports: [] as { id: string }[],
+    ...overrides,
+  };
+}
+
+describe("GET /api/issues/map", () => {
+  beforeEach(() => {
+    mockedGetSession.mockReset();
+    prismaMock.issueGroup.findMany.mockReset();
+  });
+
+  it("returns 401 when the caller is not authenticated", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue(null);
+
+    // Act
+    const response = await GET();
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ success: false, error: "Not authenticated." });
+    expect(prismaMock.issueGroup.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns aggregated pins with the viewer's own report id attached", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });
+    prismaMock.issueGroup.findMany.mockResolvedValue([
+      makeGroupRow({ id: "group_1", reports: [{ id: "my_report" }] }),
+    ] as never);
+
+    // Act
+    const response = await GET();
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.points).toHaveLength(1);
+    expect(body.data.points[0]).toMatchObject({
+      id: "group_1",
+      latitude: 37.4419,
+      longitude: -122.143,
+      status: ReportStatus.CONFIRMED,
+      reportCount: 3,
+      myReportId: "my_report",
+    });
+    // The point carries a human label and a relative-time string.
+    expect(typeof body.data.points[0].issueLabel).toBe("string");
+    expect(typeof body.data.points[0].relativeTime).toBe("string");
+  });
+
+  it("sets myReportId to null when the viewer filed nothing in the group", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });
+    prismaMock.issueGroup.findMany.mockResolvedValue([
+      makeGroupRow({ reports: [] }),
+    ] as never);
+
+    // Act
+    const response = await GET();
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body.data.points[0].myReportId).toBeNull();
+  });
+
+  it("returns an empty points array when there are no issue groups", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });
+    prismaMock.issueGroup.findMany.mockResolvedValue([] as never);
+
+    // Act
+    const response = await GET();
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { points: [] } });
+  });
+});

--- a/nexa/src/app/api/push/unsubscribe/route.test.ts
+++ b/nexa/src/app/api/push/unsubscribe/route.test.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/push/unsubscribe", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const ENDPOINT = "https://push.example.com/sub/abc";
+
+describe("POST /api/push/unsubscribe", () => {
+  beforeEach(() => {
+    prismaMock.pushSubscription.deleteMany.mockReset();
+  });
+
+  it("deletes the stored subscription for the endpoint and returns the envelope", async () => {
+    // Arrange
+    prismaMock.pushSubscription.deleteMany.mockResolvedValue({
+      count: 1,
+    } as never);
+
+    // Act
+    const response = await POST(makeRequest({ endpoint: ENDPOINT }));
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { unsubscribed: true } });
+    expect(
+      prismaMock.pushSubscription.deleteMany,
+    ).toHaveBeenCalledExactlyOnceWith({ where: { endpoint: ENDPOINT } });
+  });
+
+  it("is idempotent: still succeeds when no subscription matched", async () => {
+    // Arrange
+    prismaMock.pushSubscription.deleteMany.mockResolvedValue({
+      count: 0,
+    } as never);
+
+    // Act
+    const response = await POST(makeRequest({ endpoint: ENDPOINT }));
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { unsubscribed: true } });
+  });
+
+  it("rejects a body missing the endpoint with a 400 and never touches the DB", async () => {
+    // Act
+    const response = await POST(makeRequest({}));
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prismaMock.pushSubscription.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the delete throws", async () => {
+    // Arrange
+    prismaMock.pushSubscription.deleteMany.mockRejectedValue(
+      new Error("db down"),
+    );
+
+    // Act
+    const response = await POST(makeRequest({ endpoint: ENDPOINT }));
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to remove push subscription.",
+    });
+  });
+});

--- a/nexa/src/app/api/reports/[id]/submission-fields/route.test.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.test.ts
@@ -1,0 +1,194 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IntakeMethod } from "@/generated/prisma/enums";
+import { makeReport } from "@/test/factories/report";
+import { makeAgency } from "@/test/factories/agency";
+import { prismaMock } from "@/test/prisma-mock";
+
+// Ownership gates on the session; agency resolution is delegated to the
+// jurisdictions lib. Mock both boundaries; use the REAL buildPrefillFields so we
+// assert the actual prefill shape the route emits.
+vi.mock("@/lib/auth", () => ({ getSession: vi.fn() }));
+import { getSession } from "@/lib/auth";
+
+const { resolveAgencyId } = vi.hoisted(() => ({ resolveAgencyId: vi.fn() }));
+vi.mock("@/lib/jurisdictions/agency", () => ({ resolveAgencyId }));
+
+import { GET } from "./route";
+
+const mockedGetSession = vi.mocked(getSession);
+
+function request(): NextRequest {
+  return new NextRequest("http://localhost/api/reports/r1/submission-fields");
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("GET /api/reports/[id]/submission-fields", () => {
+  beforeEach(() => {
+    mockedGetSession.mockReset();
+    resolveAgencyId.mockReset();
+    prismaMock.report.findUnique.mockReset();
+    prismaMock.agency.findUnique.mockReset();
+  });
+
+  it("returns 404 when the report does not exist", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue(null);
+    prismaMock.report.findUnique.mockResolvedValue(null);
+
+    // Act
+    const res = await GET(request(), params("missing"));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ success: false, error: "Report not found." });
+  });
+
+  it("returns 403 when an owned report belongs to another user", async () => {
+    // Arrange
+    mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({ id: "r1", userId: "someone_else" }),
+      agency: null,
+    } as never);
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(403);
+    expect(body).toEqual({
+      success: false,
+      error: "You can only view your own reports.",
+    });
+  });
+
+  it("serves an anonymous (userId-null) report to any caller", async () => {
+    // Arrange: anonymous report, no agency on the report, none resolved either.
+    mockedGetSession.mockResolvedValue(null);
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({ id: "r1", userId: null, agencyId: null }),
+      agency: null,
+    } as never);
+    resolveAgencyId.mockResolvedValue({ agencyId: null, candidates: [] });
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert: no 403/404; route returns the null-agency envelope.
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: { agency: null, fields: [] } });
+  });
+
+  it("returns agency, formUrl and prefilled fields for an owned report with an agency", async () => {
+    // Arrange: report carries its agency directly (no resolution needed).
+    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
+    const agency = makeAgency({
+      id: "agency_1",
+      name: "Palo Alto 311",
+      intakeUrl: "https://www.paloalto.gov/311",
+      intakeMethod: IntakeMethod.WEB_FORM,
+      requiredFields: {
+        location_address: { type: "string", required: true },
+        description: { type: "string", required: true },
+        photo: { type: "file", required: false },
+      },
+    });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({
+        id: "r1",
+        userId: "owner",
+        agencyId: "agency_1",
+        address: "University Ave, Palo Alto, CA",
+        description: "Large pothole on the corner.",
+      }),
+      agency,
+    } as never);
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert: envelope shape + prefilled values from the report.
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.agency).toEqual({
+      name: "Palo Alto 311",
+      intakeUrl: "https://www.paloalto.gov/311",
+      intakeMethod: IntakeMethod.WEB_FORM,
+    });
+    expect(body.data.formUrl).toBe("https://www.paloalto.gov/311");
+
+    const byKey = Object.fromEntries(
+      body.data.fields.map((f: { key: string }) => [f.key, f]),
+    );
+    expect(byKey.location_address).toMatchObject({
+      key: "location_address",
+      label: "Location address",
+      value: "University Ave, Palo Alto, CA",
+      required: true,
+      type: "string",
+    });
+    expect(byKey.description.value).toBe("Large pothole on the corner.");
+    // The agency resolver is not consulted when the report already has an agency.
+    expect(resolveAgencyId).not.toHaveBeenCalled();
+  });
+
+  it("resolves the agency by location when the report has none attached", async () => {
+    // Arrange: no agency on the report; resolver picks one, route loads it.
+    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({ id: "r1", userId: "owner", agencyId: null }),
+      agency: null,
+    } as never);
+    resolveAgencyId.mockResolvedValue({
+      agencyId: "agency_9",
+      candidates: ["agency_9"],
+    });
+    prismaMock.agency.findUnique.mockResolvedValue(
+      makeAgency({
+        id: "agency_9",
+        name: "Resolved Agency",
+        requiredFields: {},
+      }),
+    );
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(resolveAgencyId).toHaveBeenCalledOnce();
+    expect(prismaMock.agency.findUnique).toHaveBeenCalledWith({
+      where: { id: "agency_9" },
+    });
+    expect(body.data.agency.name).toBe("Resolved Agency");
+    expect(body.data.fields).toEqual([]);
+  });
+
+  it("returns 500 when the lookup throws", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
+    prismaMock.report.findUnique.mockRejectedValue(new Error("db down"));
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to build submission fields.",
+    });
+  });
+});

--- a/nexa/src/app/api/reports/agency-candidates/route.test.ts
+++ b/nexa/src/app/api/reports/agency-candidates/route.test.ts
@@ -1,0 +1,183 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IssueType } from "@/generated/prisma/enums";
+
+// The route delegates routing to resolveAgencyCandidates; mock that boundary so
+// no polygon registry or DB runs and we can drive ambiguous/single/empty.
+const { resolveAgencyCandidates } = vi.hoisted(() => ({
+  resolveAgencyCandidates: vi.fn(),
+}));
+vi.mock("@/lib/jurisdictions/agency", () => ({ resolveAgencyCandidates }));
+
+import { POST } from "./route";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/reports/agency-candidates", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  issueType: IssueType.ROAD_DAMAGE,
+  latitude: 37.44,
+  longitude: -122.14,
+};
+
+describe("POST /api/reports/agency-candidates", () => {
+  beforeEach(() => {
+    resolveAgencyCandidates.mockReset();
+  });
+
+  it("returns the ambiguous multi-candidate resolution with a disambiguation question", async () => {
+    // Arrange
+    const resolution = {
+      agencyId: null,
+      candidates: [
+        {
+          id: "agency_web",
+          name: "Menlo Park Web Desk",
+          jurisdiction: "city-menlo-park",
+          intakeMethod: "WEB_FORM",
+        },
+        {
+          id: "agency_api",
+          name: "Menlo Park Open311",
+          jurisdiction: "city-menlo-park",
+          intakeMethod: "API",
+        },
+      ],
+      disambiguation:
+        "More than one office handles this here. Which should we file your report with?",
+    };
+    resolveAgencyCandidates.mockResolvedValue(resolution);
+
+    // Act
+    const res = await POST(post(VALID_BODY));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ success: true, data: resolution });
+    expect(resolveAgencyCandidates).toHaveBeenCalledWith({
+      latitude: 37.44,
+      longitude: -122.14,
+      issueType: IssueType.ROAD_DAMAGE,
+    });
+  });
+
+  it("returns the single confident match with no disambiguation", async () => {
+    // Arrange
+    const resolution = {
+      agencyId: "agency_1",
+      candidates: [
+        {
+          id: "agency_1",
+          name: "Palo Alto 311",
+          jurisdiction: "city-palo-alto",
+          intakeMethod: "API",
+        },
+      ],
+      disambiguation: null,
+    };
+    resolveAgencyCandidates.mockResolvedValue(resolution);
+
+    // Act
+    const res = await POST(post(VALID_BODY));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data.agencyId).toBe("agency_1");
+    expect(body.data.disambiguation).toBeNull();
+    expect(body.data.candidates).toHaveLength(1);
+  });
+
+  it("returns the empty resolution when no agency covers the location", async () => {
+    // Arrange
+    resolveAgencyCandidates.mockResolvedValue({
+      agencyId: null,
+      candidates: [],
+      disambiguation: null,
+    });
+
+    // Act
+    const res = await POST(post(VALID_BODY));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      data: { agencyId: null, candidates: [], disambiguation: null },
+    });
+  });
+
+  it("passes issueType through as null when omitted from the body", async () => {
+    // Arrange
+    resolveAgencyCandidates.mockResolvedValue({
+      agencyId: null,
+      candidates: [],
+      disambiguation: null,
+    });
+
+    // Act
+    await POST(post({ latitude: 37.44, longitude: -122.14 }));
+
+    // Assert
+    expect(resolveAgencyCandidates).toHaveBeenCalledWith({
+      latitude: 37.44,
+      longitude: -122.14,
+      issueType: null,
+    });
+  });
+
+  it("returns 400 for an out-of-range coordinate and never resolves", async () => {
+    // Act
+    const res = await POST(
+      post({ issueType: IssueType.ROAD_DAMAGE, latitude: 200, longitude: 0 }),
+    );
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(resolveAgencyCandidates).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unknown issueType enum value", async () => {
+    // Act
+    const res = await POST(
+      post({
+        issueType: "NOT_A_REAL_TYPE",
+        latitude: 37.44,
+        longitude: -122.14,
+      }),
+    );
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(resolveAgencyCandidates).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the resolver throws", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    resolveAgencyCandidates.mockRejectedValue(new Error("registry boom"));
+
+    // Act
+    const res = await POST(post(VALID_BODY));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to resolve agency candidates.",
+    });
+  });
+});

--- a/nexa/src/app/api/reports/send-follow-up-reminders/route.test.ts
+++ b/nexa/src/app/api/reports/send-follow-up-reminders/route.test.ts
@@ -1,0 +1,234 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Boundaries the route depends on: the eligible-report query and the email
+// sender. Mock both so no DB or Brevo network runs.
+const {
+  findStaleUnresolvedReportsForFollowUp,
+  sendReportFollowUpReminderEmail,
+} = vi.hoisted(() => ({
+  findStaleUnresolvedReportsForFollowUp: vi.fn(),
+  sendReportFollowUpReminderEmail: vi.fn(),
+}));
+vi.mock("@/lib/reports/follow-up-reminders", () => ({
+  findStaleUnresolvedReportsForFollowUp,
+}));
+vi.mock("@/lib/email", () => ({ sendReportFollowUpReminderEmail }));
+
+import { POST } from "./route";
+
+const SECRET = "test-secret";
+
+function post(
+  opts: { secret?: string; bearer?: string; query?: string } = {},
+): NextRequest {
+  const headers: Record<string, string> = {};
+  if (opts.secret) headers["x-follow-up-reminder-secret"] = opts.secret;
+  if (opts.bearer) headers["authorization"] = `Bearer ${opts.bearer}`;
+  return new NextRequest(
+    `http://localhost/api/reports/send-follow-up-reminders${opts.query ?? ""}`,
+    { method: "POST", headers },
+  );
+}
+
+function makeCandidate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "report_1",
+    issueType: "ROAD_DAMAGE",
+    status: "CONFIRMED",
+    description: "Pothole",
+    aiDescription: null,
+    address: "University Ave",
+    externalTrackingId: null,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+    user: { email: "u@x.com", name: "U" },
+    ...overrides,
+  };
+}
+
+describe("POST /api/reports/send-follow-up-reminders", () => {
+  beforeEach(() => {
+    findStaleUnresolvedReportsForFollowUp.mockReset();
+    sendReportFollowUpReminderEmail.mockReset();
+    vi.stubEnv("FOLLOW_UP_REMINDER_SECRET", SECRET);
+    vi.stubEnv("BREVO_API_KEY", "brevo-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 500 when FOLLOW_UP_REMINDER_SECRET is not configured", async () => {
+    // Arrange
+    vi.stubEnv("FOLLOW_UP_REMINDER_SECRET", "");
+
+    // Act
+    const res = await POST(post({ secret: SECRET }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("FOLLOW_UP_REMINDER_SECRET is not configured");
+    expect(findStaleUnresolvedReportsForFollowUp).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the secret is missing or wrong", async () => {
+    // Act
+    const res = await POST(post({ secret: "wrong" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ success: false, error: "Not authorized." });
+    expect(findStaleUnresolvedReportsForFollowUp).not.toHaveBeenCalled();
+  });
+
+  it("authorizes via the bearer token as well as the header secret", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([]);
+
+    // Act: dryRun defaults to true, so no Brevo key is required.
+    const res = await POST(post({ bearer: SECRET }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data.dryRun).toBe(true);
+  });
+
+  it("dry-runs by default: counts eligible reports as skipped and sends nothing", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([
+      makeCandidate({ id: "report_1" }),
+      makeCandidate({ id: "report_2" }),
+    ]);
+
+    // Act
+    const res = await POST(post({ secret: SECRET }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toMatchObject({
+      staleDays: 14,
+      dryRun: true,
+      eligibleReports: 2,
+      sent: 0,
+      skipped: 2,
+      failures: [],
+    });
+    expect(sendReportFollowUpReminderEmail).not.toHaveBeenCalled();
+  });
+
+  it("honours a custom positive ?days override", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([]);
+
+    // Act
+    const res = await POST(post({ secret: SECRET, query: "?days=30" }));
+    const body = await res.json();
+
+    // Assert
+    expect(body.data.staleDays).toBe(30);
+    expect(findStaleUnresolvedReportsForFollowUp).toHaveBeenCalledWith({
+      staleDays: 30,
+    });
+  });
+
+  it("falls back to the default stale window for a non-positive ?days", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([]);
+
+    // Act
+    const res = await POST(post({ secret: SECRET, query: "?days=0" }));
+    const body = await res.json();
+
+    // Assert
+    expect(body.data.staleDays).toBe(14);
+  });
+
+  it("returns 500 when dryRun=false but BREVO_API_KEY is unset", async () => {
+    // Arrange
+    vi.stubEnv("BREVO_API_KEY", "");
+
+    // Act
+    const res = await POST(post({ secret: SECRET, query: "?dryRun=false" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body.error).toContain("BREVO_API_KEY is not configured");
+    expect(findStaleUnresolvedReportsForFollowUp).not.toHaveBeenCalled();
+  });
+
+  it("sends one reminder per eligible report when dryRun=false", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([
+      makeCandidate({ id: "report_1" }),
+      makeCandidate({ id: "report_2" }),
+    ]);
+    sendReportFollowUpReminderEmail.mockResolvedValue(undefined);
+
+    // Act
+    const res = await POST(post({ secret: SECRET, query: "?dryRun=false" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toMatchObject({
+      dryRun: false,
+      eligibleReports: 2,
+      sent: 2,
+      skipped: 0,
+      failures: [],
+    });
+    expect(sendReportFollowUpReminderEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips a candidate with no user and records per-report failures", async () => {
+    // Arrange
+    findStaleUnresolvedReportsForFollowUp.mockResolvedValue([
+      makeCandidate({ id: "no_user", user: null }),
+      makeCandidate({ id: "ok" }),
+      makeCandidate({ id: "boom" }),
+    ]);
+    sendReportFollowUpReminderEmail.mockImplementation(
+      async (_user: unknown, report: { id: string }) => {
+        if (report.id === "boom") throw new Error("brevo 500");
+      },
+    );
+
+    // Act
+    const res = await POST(post({ secret: SECRET, query: "?dryRun=false" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data.sent).toBe(1);
+    expect(body.data.skipped).toBe(1);
+    expect(body.data.failures).toEqual([
+      { reportId: "boom", error: "brevo 500" },
+    ]);
+  });
+
+  it("returns 500 when the eligible-report lookup throws", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    findStaleUnresolvedReportsForFollowUp.mockRejectedValue(
+      new Error("db down"),
+    );
+
+    // Act
+    const res = await POST(post({ secret: SECRET }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to look up eligible reports.",
+    });
+  });
+});


### PR DESCRIPTION
Closes #199.

Adds colocated integration tests (Prisma deep-mocked, external HTTP/email mocked, offline + deterministic) for the five API routes that previously had no `*.test.ts`:

| Route | Cases |
| --- | --- |
| `reports/[id]/submission-fields` | 404 missing, 403 wrong-owner, anonymous-report access, agency-on-report vs location-resolved agency + prefill field shape, 500 |
| `reports/agency-candidates` | ambiguous multi-candidate + disambiguation question, single confident match, empty/no-agency, `issueType` null passthrough, 400 coord/enum validation, 500 |
| `push/unsubscribe` | idempotent delete + envelope, 400 missing endpoint, 500 |
| `issues/map` | 401 auth gate, aggregated pins with viewer report id, `myReportId` null, empty |
| `reports/send-follow-up-reminders` | header/bearer auth, missing-secret 500, wrong-secret 401, dry-run default, `?days` override + fallback, missing-Brevo-key 500, send/skip/per-report-failure accounting, lookup-error 500 |

All assertions reflect the real current behavior (envelope shapes, status codes, auth/ownership). Reuses the existing test toolkit (`prismaMock`, `makeReport`, `makeAgency`) — no parallel mocking utility introduced. The submission-fields happy path exercises the real `buildPrefillFields`.

**31 new tests.** Verified locally:
- `npm run test:coverage` exits 0 — 64 files / 642 tests pass; coverage stays above every floor (statements 87.25, branches 78.01, functions 86.84, lines 89.35).
- `npx tsc --noEmit` clean.
- `npm run format:check` clean.