### PR TITLE
test: unit tests for prefill + follow-up modules [#200]

### DIFF
--- a/nexa/src/lib/email/templates/follow-up-reminder.test.ts
+++ b/nexa/src/lib/email/templates/follow-up-reminder.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formatFullDateTime } from "@/lib/utils";
+
+import { followUpReminderTemplate } from "./follow-up-reminder";
+
+const CREATED = new Date("2026-05-01T09:00:00.000Z");
+const UPDATED = new Date("2026-05-20T09:00:00.000Z");
+
+function build(
+  overrides: Partial<Parameters<typeof followUpReminderTemplate>[0]> = {},
+) {
+  return followUpReminderTemplate({
+    name: "Ada",
+    reportId: "report_123",
+    issueType: "ROAD_DAMAGE",
+    address: "100 Main St",
+    createdAt: CREATED,
+    updatedAt: UPDATED,
+    externalTrackingId: "TRK-9",
+    summary: "Deep pothole",
+    ...overrides,
+  });
+}
+
+describe("followUpReminderTemplate — subject", () => {
+  it("names the human-readable issue label", () => {
+    expect(build().subject).toBe(
+      "Follow-up recommended for your Road Damage report",
+    );
+  });
+
+  it("falls back to a generic phrase for a null issue type", () => {
+    expect(build({ issueType: null }).subject).toBe(
+      "Follow-up recommended for your an infrastructure issue report",
+    );
+  });
+
+  it("passes through an unknown issue type verbatim", () => {
+    expect(build({ issueType: "MYSTERY" }).subject).toContain("MYSTERY");
+  });
+});
+
+describe("followUpReminderTemplate — body content", () => {
+  it("greets the named recipient and includes the reference id", () => {
+    const { html } = build();
+    expect(html).toContain("Check in on your report, Ada");
+    expect(html).toContain("report_123");
+  });
+
+  it("defaults the greeting to 'there' when the name is empty", () => {
+    expect(build({ name: "" }).html).toContain(
+      "Check in on your report, there",
+    );
+  });
+
+  it("renders the formatted submitted and last-updated dates", () => {
+    const { html } = build();
+    expect(html).toContain(formatFullDateTime(CREATED));
+    expect(html).toContain(formatFullDateTime(UPDATED));
+  });
+
+  it("includes the optional address, tracking id, and summary rows when present", () => {
+    const { html } = build();
+    expect(html).toContain("100 Main St");
+    expect(html).toContain("TRK-9");
+    expect(html).toContain("Deep pothole");
+  });
+
+  it("omits the optional rows when their values are null", () => {
+    const { html } = build({
+      address: null,
+      externalTrackingId: null,
+      summary: null,
+    });
+    expect(html).not.toContain(">Location<");
+    expect(html).not.toContain(">Tracking ID<");
+    expect(html).not.toContain(">Summary<");
+  });
+
+  it("always carries the app-side-tracking-only disclaimer", () => {
+    expect(build().html).toContain("app-side tracking only");
+  });
+});
+
+describe("followUpReminderTemplate — escaping & app url", () => {
+  it("HTML-escapes user-controlled values to prevent injection", () => {
+    const { html } = build({
+      name: "<script>x</script>",
+      address: 'A & B "lane"',
+    });
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("A &amp; B &quot;lane&quot;");
+  });
+
+  describe("app url resolution", () => {
+    const original = process.env.NEXT_PUBLIC_APP_URL;
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+    });
+    afterEach(() => {
+      if (original === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+      else process.env.NEXT_PUBLIC_APP_URL = original;
+    });
+
+    it("falls back to localhost when NEXT_PUBLIC_APP_URL is unset", () => {
+      expect(build().html).toContain("http://localhost:3000/dashboard");
+    });
+
+    it("uses the configured app url when set", () => {
+      process.env.NEXT_PUBLIC_APP_URL = "https://nexa.example.gov";
+      expect(build().html).toContain("https://nexa.example.gov/dashboard");
+    });
+  });
+});

--- a/nexa/src/lib/reports/follow-up-reminders.test.ts
+++ b/nexa/src/lib/reports/follow-up-reminders.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+import { FOLLOW_UP_REMINDER_STALE_DAYS } from "./follow-up";
+import {
+  findStaleUnresolvedReportsForFollowUp,
+  type StaleReportReminderCandidate,
+} from "./follow-up-reminders";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const STALE_MS = FOLLOW_UP_REMINDER_STALE_DAYS * MS_PER_DAY;
+
+// Fixed "now" so the cutoff and per-report ages are fully deterministic.
+const NOW = new Date("2026-06-09T12:00:00.000Z");
+
+let seq = 0;
+
+// The module selects a narrow projection, so the resolved rows are
+// `StaleReportReminderCandidate[]`, not full `Report[]`. The deep mock's
+// signature is the full row type; cast at the boundary to drive it with the
+// real (narrower) query shape.
+function mockReturns(rows: StaleReportReminderCandidate[]): void {
+  prismaMock.report.findMany.mockResolvedValue(
+    rows as unknown as Awaited<ReturnType<typeof prismaMock.report.findMany>>,
+  );
+}
+
+// A query-result row shaped like the `select` in the module. Defaults are an
+// unresolved report whose updatedAt sits exactly on the stale cutoff.
+function makeCandidate(
+  overrides: Partial<StaleReportReminderCandidate> = {},
+): StaleReportReminderCandidate {
+  seq += 1;
+  const updatedAt = new Date(NOW.getTime() - STALE_MS);
+  return {
+    id: `report_${seq}`,
+    issueType: "ROAD_DAMAGE",
+    status: "CONFIRMED",
+    description: "Pothole",
+    aiDescription: null,
+    address: "100 Main St",
+    externalTrackingId: null,
+    createdAt: updatedAt,
+    updatedAt,
+    user: { email: "reporter@example.com", name: "Reporter" },
+    ...overrides,
+  };
+}
+
+describe("findStaleUnresolvedReportsForFollowUp", () => {
+  describe("Prisma query construction", () => {
+    it("excludes resolved/closed, requires a user with an email, and gates on the cutoff", async () => {
+      prismaMock.report.findMany.mockResolvedValue([]);
+
+      await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+
+      const args = prismaMock.report.findMany.mock.calls[0][0];
+      expect(args?.where).toMatchObject({
+        status: { notIn: ["RESOLVED", "CLOSED"] },
+        userId: { not: null },
+        user: { is: { email: { not: "" } } },
+      });
+      expect(args?.orderBy).toEqual({ updatedAt: "asc" });
+    });
+
+    it("computes the cutoff as now minus the default stale window", async () => {
+      prismaMock.report.findMany.mockResolvedValue([]);
+
+      await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+
+      const where = prismaMock.report.findMany.mock.calls[0][0]?.where as {
+        updatedAt: { lte: Date };
+      };
+      expect(where.updatedAt.lte.getTime()).toBe(NOW.getTime() - STALE_MS);
+    });
+
+    it("honors a custom staleDays window in the cutoff", async () => {
+      prismaMock.report.findMany.mockResolvedValue([]);
+
+      await findStaleUnresolvedReportsForFollowUp({ now: NOW, staleDays: 30 });
+
+      const where = prismaMock.report.findMany.mock.calls[0][0]?.where as {
+        updatedAt: { lte: Date };
+      };
+      expect(where.updatedAt.lte.getTime()).toBe(
+        NOW.getTime() - 30 * MS_PER_DAY,
+      );
+    });
+
+    it("falls back to the current clock when `now` is omitted", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      try {
+        prismaMock.report.findMany.mockResolvedValue([]);
+        await findStaleUnresolvedReportsForFollowUp();
+        const where = prismaMock.report.findMany.mock.calls[0][0]?.where as {
+          updatedAt: { lte: Date };
+        };
+        expect(where.updatedAt.lte.getTime()).toBe(NOW.getTime() - STALE_MS);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("post-query eligibility filter", () => {
+    it("keeps a report whose updatedAt is exactly on the cutoff (>= stale is inclusive)", async () => {
+      const onEdge = makeCandidate({
+        id: "report_on_edge",
+        updatedAt: new Date(NOW.getTime() - STALE_MS),
+      });
+      mockReturns([onEdge]);
+
+      const result = await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+      expect(result.map((r) => r.id)).toEqual(["report_on_edge"]);
+    });
+
+    it("drops a borderline row the DB returned but that is not yet stale", async () => {
+      // 1ms short of the full stale window → ageDays floors below the threshold,
+      // so the in-memory eligibility check must reject it even though the (less
+      // precise, day-granular) DB cutoff let it through.
+      const notQuiteStale = makeCandidate({
+        id: "report_borderline",
+        updatedAt: new Date(NOW.getTime() - STALE_MS + 1),
+      });
+      mockReturns([notQuiteStale]);
+
+      const result = await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+      expect(result).toEqual([]);
+    });
+
+    it("returns all rows when every candidate is genuinely stale", async () => {
+      const a = makeCandidate({
+        id: "a",
+        updatedAt: new Date(NOW.getTime() - STALE_MS - MS_PER_DAY),
+      });
+      const b = makeCandidate({
+        id: "b",
+        updatedAt: new Date(NOW.getTime() - STALE_MS - 10 * MS_PER_DAY),
+      });
+      mockReturns([a, b]);
+
+      const result = await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+      expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+    });
+
+    it("returns an empty array when the query yields nothing", async () => {
+      prismaMock.report.findMany.mockResolvedValue([]);
+      const result = await findStaleUnresolvedReportsForFollowUp({ now: NOW });
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/nexa/src/lib/reports/follow-up.test.ts
+++ b/nexa/src/lib/reports/follow-up.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FOLLOW_UP_REMINDER_STALE_DAYS,
+  getReportFollowUpState,
+  isReportEligibleForFollowUpReminder,
+  type FollowUpReportLike,
+} from "./follow-up";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// A fixed "now" well clear of the epoch so day-arithmetic can't accidentally
+// land on 0 and mask a sign error.
+const NOW = new Date("2026-06-09T12:00:00.000Z");
+
+// Helper: a report whose last activity is `days` (+ optional ms) before NOW.
+function reportAgedDays(
+  days: number,
+  extraMs = 0,
+  overrides: Partial<FollowUpReportLike> = {},
+): FollowUpReportLike {
+  const lastActivity = new Date(NOW.getTime() - days * MS_PER_DAY - extraMs);
+  return {
+    status: "CONFIRMED",
+    createdAt: lastActivity,
+    updatedAt: lastActivity,
+    ...overrides,
+  };
+}
+
+describe("getReportFollowUpState", () => {
+  describe("activity timestamp selection", () => {
+    it("prefers updatedAt over createdAt when present", () => {
+      const createdAt = new Date(NOW.getTime() - 30 * MS_PER_DAY);
+      const updatedAt = new Date(NOW.getTime() - 2 * MS_PER_DAY);
+      const state = getReportFollowUpState(
+        { status: "CONFIRMED", createdAt, updatedAt },
+        NOW,
+      );
+      expect(state.lastActivityAt).toBe(updatedAt);
+      expect(state.ageDays).toBe(2);
+    });
+
+    it("falls back to createdAt when updatedAt is null", () => {
+      const createdAt = new Date(NOW.getTime() - 5 * MS_PER_DAY);
+      const state = getReportFollowUpState(
+        { status: "CONFIRMED", createdAt, updatedAt: null },
+        NOW,
+      );
+      expect(state.lastActivityAt).toBe(createdAt);
+      expect(state.ageDays).toBe(5);
+    });
+
+    it("falls back to createdAt when updatedAt is undefined", () => {
+      const createdAt = new Date(NOW.getTime() - 5 * MS_PER_DAY);
+      const state = getReportFollowUpState(
+        { status: "CONFIRMED", createdAt },
+        NOW,
+      );
+      expect(state.lastActivityAt).toBe(createdAt);
+    });
+  });
+
+  describe("ageDays computation", () => {
+    it("floors a partial day", () => {
+      const state = getReportFollowUpState(
+        reportAgedDays(3, MS_PER_DAY / 2),
+        NOW,
+      );
+      expect(state.ageDays).toBe(3);
+    });
+
+    it("clamps a future last-activity timestamp to 0 (never negative)", () => {
+      const future = new Date(NOW.getTime() + 10 * MS_PER_DAY);
+      const state = getReportFollowUpState(
+        { status: "CONFIRMED", createdAt: future, updatedAt: future },
+        NOW,
+      );
+      expect(state.ageDays).toBe(0);
+    });
+  });
+
+  describe("resolved/closed reports", () => {
+    it.each(["RESOLVED", "CLOSED"])(
+      "labels a %s report as Resolved and never stale",
+      (status) => {
+        const state = getReportFollowUpState(
+          reportAgedDays(60, 0, { status }),
+          NOW,
+        );
+        expect(state.isUnresolved).toBe(false);
+        expect(state.isStale).toBe(false);
+        expect(state.label).toBe("Resolved");
+        expect(state.description).toContain("resolved or closed");
+      },
+    );
+  });
+
+  describe("unresolved reports + stale window", () => {
+    it("labels a fresh unresolved report Awaiting response", () => {
+      const state = getReportFollowUpState(reportAgedDays(1), NOW);
+      expect(state.isUnresolved).toBe(true);
+      expect(state.isStale).toBe(false);
+      expect(state.label).toBe("Awaiting response");
+      expect(state.description).toContain("app-side tracking only");
+    });
+
+    it("is NOT stale one day before the staleDays threshold", () => {
+      const state = getReportFollowUpState(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS - 1),
+        NOW,
+      );
+      expect(state.isStale).toBe(false);
+      expect(state.label).toBe("Awaiting response");
+    });
+
+    it("becomes stale exactly AT the staleDays threshold (>= is inclusive)", () => {
+      const state = getReportFollowUpState(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS),
+        NOW,
+      );
+      expect(state.isStale).toBe(true);
+      expect(state.label).toBe("Follow-up recommended");
+      expect(state.description).toContain("app-side tracking only");
+    });
+
+    it("is stale well past the threshold", () => {
+      const state = getReportFollowUpState(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS + 30),
+        NOW,
+      );
+      expect(state.isStale).toBe(true);
+      expect(state.label).toBe("Follow-up recommended");
+    });
+  });
+
+  describe("custom staleDays override", () => {
+    it("honors a tighter window", () => {
+      const report = reportAgedDays(5);
+      expect(getReportFollowUpState(report, NOW, 7).isStale).toBe(false);
+      expect(getReportFollowUpState(report, NOW, 5).isStale).toBe(true);
+    });
+  });
+
+  describe("default now (real clock) via fake timers", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("uses the current time when `now` is omitted", () => {
+      const state = getReportFollowUpState(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS),
+      );
+      expect(state.isStale).toBe(true);
+    });
+
+    it("advancing the clock past the window flips a report to stale", () => {
+      const report = reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS - 1);
+      expect(getReportFollowUpState(report).isStale).toBe(false);
+
+      // Advance just over one more day so the report crosses the threshold.
+      vi.setSystemTime(new Date(NOW.getTime() + MS_PER_DAY + 1));
+      expect(getReportFollowUpState(report).isStale).toBe(true);
+    });
+  });
+});
+
+describe("isReportEligibleForFollowUpReminder", () => {
+  it("is true exactly when the report is stale (delegates to getReportFollowUpState)", () => {
+    expect(
+      isReportEligibleForFollowUpReminder(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS),
+        NOW,
+      ),
+    ).toBe(true);
+    expect(
+      isReportEligibleForFollowUpReminder(
+        reportAgedDays(FOLLOW_UP_REMINDER_STALE_DAYS - 1),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for a resolved report no matter how old", () => {
+    expect(
+      isReportEligibleForFollowUpReminder(
+        reportAgedDays(365, 0, { status: "RESOLVED" }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("respects a custom staleDays threshold", () => {
+    const report = reportAgedDays(10);
+    expect(isReportEligibleForFollowUpReminder(report, NOW, 14)).toBe(false);
+    expect(isReportEligibleForFollowUpReminder(report, NOW, 10)).toBe(true);
+  });
+});

--- a/nexa/src/lib/submission/prefill.test.ts
+++ b/nexa/src/lib/submission/prefill.test.ts
@@ -68,4 +68,251 @@ describe("buildPrefillFields — embedded field values (issue #193)", () => {
     const loc = fields.find((f) => f.key === "observation_location");
     expect(loc?.value).toBe("1 Main St");
   });
+
+  it("ignores a non-string embedded value (number) and derives instead", () => {
+    const fields = buildPrefillFields(
+      makeBareReport({ address: "2 Oak Ave" }),
+      {
+        // Only string `.value` is authoritative; a number must be ignored.
+        service_address: { type: "string", value: 42 },
+      },
+    );
+
+    const addr = fields.find((f) => f.key === "service_address");
+    expect(addr?.value).toBe("2 Oak Ave");
+  });
+});
+
+// A populated report so each derivation branch has something to surface.
+function makeFullReport(overrides: Partial<PrefillReport> = {}): PrefillReport {
+  return {
+    description: "Pothole on Main St",
+    aiDescription: "AI: deep pothole",
+    address: "100 Main St, Palo Alto, CA",
+    latitude: 37.4419,
+    longitude: -122.143,
+    imageUrl: "https://example.com/photo.jpg",
+    createdAt: new Date("2026-06-09T12:00:00Z"),
+    contactEmail: "reporter@example.com",
+    ...overrides,
+  };
+}
+
+// Convenience: derive a single field from a one-key schema.
+function fieldFor(
+  key: string,
+  spec: Record<string, unknown>,
+  report: PrefillReport,
+) {
+  return buildPrefillFields(report, { [key]: spec }).find((f) => f.key === key);
+}
+
+describe("buildPrefillFields — valueForKey derivation branches", () => {
+  it("derives the description from report.description", () => {
+    const f = fieldFor("description", { type: "string" }, makeFullReport());
+    expect(f?.value).toBe("Pothole on Main St");
+  });
+
+  it("matches the details/comment/problem/issue synonyms for description", () => {
+    for (const key of ["details", "comment", "problem_description", "issue"]) {
+      const f = fieldFor(key, { type: "string" }, makeFullReport());
+      expect(f?.value).toBe("Pothole on Main St");
+    }
+  });
+
+  it("falls back to aiDescription when description is blank/whitespace", () => {
+    const f = fieldFor(
+      "description",
+      { type: "string" },
+      makeFullReport({ description: "   " }),
+    );
+    expect(f?.value).toBe("AI: deep pothole");
+  });
+
+  it("yields a null description when neither description is present", () => {
+    const f = fieldFor("description", { type: "string" }, makeBareReport());
+    expect(f?.value).toBeNull();
+  });
+
+  it("derives the address from report.address (and its synonyms)", () => {
+    for (const key of ["address", "location", "intersection", "cross_street"]) {
+      const f = fieldFor(key, { type: "string" }, makeFullReport());
+      expect(f?.value).toBe("100 Main St, Palo Alto, CA");
+    }
+  });
+
+  it("yields a null address when the report has none", () => {
+    const f = fieldFor("address", { type: "string" }, makeBareReport());
+    expect(f?.value).toBeNull();
+  });
+
+  it("stringifies the latitude for a lat field", () => {
+    const f = fieldFor("latitude", { type: "number" }, makeFullReport());
+    expect(f?.value).toBe("37.4419");
+  });
+
+  it("yields null latitude when the report has none", () => {
+    const f = fieldFor("latitude", { type: "number" }, makeBareReport());
+    expect(f?.value).toBeNull();
+  });
+
+  it("treats latitude 0 as present, not missing", () => {
+    const f = fieldFor(
+      "latitude",
+      { type: "number" },
+      makeBareReport({ latitude: 0 }),
+    );
+    expect(f?.value).toBe("0");
+  });
+
+  it("stringifies the longitude for both lon and lng spellings", () => {
+    for (const key of ["longitude", "lng"]) {
+      const f = fieldFor(key, { type: "number" }, makeFullReport());
+      expect(f?.value).toBe("-122.143");
+    }
+  });
+
+  it("yields null longitude when the report has none", () => {
+    const f = fieldFor("longitude", { type: "number" }, makeBareReport());
+    expect(f?.value).toBeNull();
+  });
+
+  it("treats longitude 0 as present, not missing", () => {
+    const f = fieldFor(
+      "lng",
+      { type: "number" },
+      makeBareReport({ longitude: 0 }),
+    );
+    expect(f?.value).toBe("0");
+  });
+
+  it("derives the contact email from report.contactEmail", () => {
+    const f = fieldFor("contact_email", { type: "string" }, makeFullReport());
+    expect(f?.value).toBe("reporter@example.com");
+  });
+
+  it("yields null email when the report has none", () => {
+    const f = fieldFor("email", { type: "string" }, makeBareReport());
+    expect(f?.value).toBeNull();
+  });
+
+  it("formats the createdAt for a datetime field (date/time synonyms)", () => {
+    const createdAt = new Date("2026-06-09T12:00:00Z");
+    const expected = createdAt.toLocaleString();
+    for (const key of ["datetime", "date", "observation_date", "observed_at"]) {
+      const f = fieldFor(
+        "incident_" + key,
+        { type: "string" },
+        makeFullReport({ createdAt }),
+      );
+      expect(f?.value).toBe(expected);
+    }
+  });
+
+  it("accepts an ISO string createdAt and formats it", () => {
+    const f = fieldFor(
+      "observation_date",
+      { type: "string" },
+      makeFullReport({ createdAt: "2026-06-09T12:00:00Z" }),
+    );
+    expect(f?.value).toBe(new Date("2026-06-09T12:00:00Z").toLocaleString());
+  });
+});
+
+describe("buildPrefillFields — file/photo branch", () => {
+  it("never prefills a value for a file-typed field but hints to attach", () => {
+    const f = fieldFor("evidence", { type: "file" }, makeFullReport());
+    expect(f?.value).toBeNull();
+    expect(f?.hint).toBe("Attach the photo you uploaded to Nexa.");
+  });
+
+  it("matches photo/image/attachment keys regardless of declared type", () => {
+    for (const key of ["photo", "image_url", "attachment"]) {
+      const f = fieldFor(key, { type: "string" }, makeFullReport());
+      expect(f?.value).toBeNull();
+      expect(f?.hint).toBe("Attach the photo you uploaded to Nexa.");
+    }
+  });
+
+  it("hints that no photo is attached when the report has no imageUrl", () => {
+    const f = fieldFor("photo", { type: "file" }, makeBareReport());
+    expect(f?.hint).toBe("No photo attached.");
+  });
+});
+
+describe("buildPrefillFields — unknown / underivable field branch", () => {
+  it("returns a null value and a fill-it-in hint for unknown keys", () => {
+    const f = fieldFor("vehicle_make", { type: "string" }, makeFullReport());
+    expect(f?.value).toBeNull();
+    expect(f?.hint).toBe("You'll need to fill this in.");
+  });
+
+  it("matches the lat branch for any key containing 'lat' (e.g. license_plate)", () => {
+    // Documents a real substring quirk: license_pLATe contains "lat", so it
+    // resolves to the report latitude rather than falling through to unknown.
+    const f = fieldFor("license_plate", { type: "string" }, makeFullReport());
+    expect(f?.value).toBe("37.4419");
+  });
+});
+
+describe("buildPrefillFields — schema parsing, labels, ordering", () => {
+  it("returns an empty list for a null/non-object schema", () => {
+    expect(buildPrefillFields(makeFullReport(), null)).toEqual([]);
+    expect(buildPrefillFields(makeFullReport(), undefined)).toEqual([]);
+    expect(buildPrefillFields(makeFullReport(), "not-an-object")).toEqual([]);
+    expect(buildPrefillFields(makeFullReport(), 7)).toEqual([]);
+  });
+
+  it("defaults the type to 'string' when the spec omits or mistypes it", () => {
+    const fields = buildPrefillFields(makeFullReport(), {
+      foo: {},
+      bar: { type: 99 },
+    });
+    expect(fields.every((f) => f.type === "string")).toBe(true);
+  });
+
+  it("tolerates a null/non-object field spec", () => {
+    const fields = buildPrefillFields(makeFullReport(), {
+      description: null,
+    });
+    const f = fields.find((field) => field.key === "description");
+    // null spec → defaults (type string, not required) → derives description.
+    expect(f?.required).toBe(false);
+    expect(f?.value).toBe("Pothole on Main St");
+  });
+
+  it("humanizes keys: underscores/dashes to spaces, first letter capitalized", () => {
+    const fields = buildPrefillFields(makeFullReport(), {
+      location_address: { type: "string" },
+      "cross-street": { type: "string" },
+    });
+    expect(fields.find((f) => f.key === "location_address")?.label).toBe(
+      "Location address",
+    );
+    expect(fields.find((f) => f.key === "cross-street")?.label).toBe(
+      "Cross street",
+    );
+  });
+
+  it("marks required only when the spec sets required === true", () => {
+    const fields = buildPrefillFields(makeFullReport(), {
+      a: { type: "string", required: true },
+      b: { type: "string", required: false },
+      c: { type: "string", required: "yes" },
+    });
+    expect(fields.find((f) => f.key === "a")?.required).toBe(true);
+    expect(fields.find((f) => f.key === "b")?.required).toBe(false);
+    // Only a strict boolean true counts as required.
+    expect(fields.find((f) => f.key === "c")?.required).toBe(false);
+  });
+
+  it("sorts required fields ahead of optional ones", () => {
+    const fields = buildPrefillFields(makeFullReport(), {
+      optional_one: { type: "string" },
+      required_one: { type: "string", required: true },
+      optional_two: { type: "string" },
+      required_two: { type: "string", required: true },
+    });
+    expect(fields.map((f) => f.required)).toEqual([true, true, false, false]);
+  });
 });


### PR DESCRIPTION
Closes #200.

Adds colocated unit tests for the previously-untested mapping/branching logic in the submission-assist and reminder paths.

## Modules covered
- `src/lib/submission/prefill.ts` — extended the existing `prefill.test.ts`. Every `valueForKey` branch: description (+ details/comment/problem/issue synonyms, aiDescription fallback, null), address (+ location/intersection/street synonyms, null), latitude/longitude (incl. `0` not treated as missing, `lng` spelling, null), email, datetime (date/time/observation synonyms, ISO-string `createdAt`), file/photo (file type + photo/image/attachment keys, photo-present vs absent hint), and the underivable/unknown branch. Plus the embedded `.value` extraction (#193 — non-string/empty fallthrough), `buildPrefillFields` schema parsing (null/non-object schema, type defaulting, null spec), `humanize` labels, strict-`true` required gating, and required-first ordering.
- `src/lib/reports/follow-up.ts` — `getReportFollowUpState`: `updatedAt`-over-`createdAt` selection (+ null/undefined fallback), `ageDays` flooring and future-clamp-to-0, Resolved/Closed labelling, and the `>= staleDays` window boundary (one day before / exactly at / well past). `isReportEligibleForFollowUpReminder` delegation and custom `staleDays`.
- `src/lib/reports/follow-up-reminders.ts` — Prisma `where`/`orderBy` construction, cutoff arithmetic (default + custom `staleDays` + omitted `now`), and the post-query eligibility filter on the day-granular window edge (driven via the shared prisma deep-mock).
- `src/lib/email/templates/follow-up-reminder.ts` — message building: subject issue-label/fallback, body content, optional address/tracking-id/summary row inclusion vs omission, HTML escaping of user input, and `NEXT_PUBLIC_APP_URL` resolution.

## Determinism
All time-dependent assertions use Vitest fake timers (`vi.useFakeTimers`/`setSystemTime`); a fixed `now` is passed where the API allows it.

## Reuse
Builds on `src/test` helpers (`prismaMock`) and follows the house colocated-`*.test.ts` style mirrored from `dedup.test.ts`.

## Verification
- `npm run test:coverage` exits 0 (676 tests pass). The four target modules reach 100% line / branch / function coverage.
- `npx tsc --noEmit` clean.
- `npm run format:check` clean.