### PR TITLE
test: EXIF GPS extraction + location-source precedence + agency routing [#218]

### DIFF
--- a/nexa/src/lib/classify/preprocess.test.ts
+++ b/nexa/src/lib/classify/preprocess.test.ts
@@ -230,4 +230,51 @@ describe("preprocessImage — EXIF GPS", () => {
     expect(result.exifGps).toBeNull();
     expect(result.dataUrl.startsWith("data:image/jpeg;base64,")).toBe(true);
   });
+
+  it("rejects a latitude with no longitude (lat-without-lon guard)", async () => {
+    // Arrange: some photos carry a GPSLatitude but no GPSLongitude. A half pair
+    // is not a usable point, so the guard must drop it rather than emit a
+    // coordinate with an undefined lon.
+    gpsMock.mockResolvedValue({ latitude: 37.4419 });
+
+    // Act
+    const result = await preprocessImage("Zm9v");
+
+    // Assert
+    expect(result.exifGps).toBeNull();
+  });
+
+  it("rejects a longitude with no latitude (lon-without-lat guard)", async () => {
+    // Arrange: the mirror of the above — lon present, lat missing.
+    gpsMock.mockResolvedValue({ longitude: -122.143 });
+
+    // Act
+    const result = await preprocessImage("Zm9v");
+
+    // Assert
+    expect(result.exifGps).toBeNull();
+  });
+
+  it("rejects a half pair where the other coordinate is explicitly null", async () => {
+    // Arrange: exifr can hand back an explicit null for a missing half.
+    gpsMock.mockResolvedValue({ latitude: 37.4419, longitude: null });
+
+    // Act
+    const result = await preprocessImage("Zm9v");
+
+    // Assert: null fails the `typeof === "number"` half of the guard.
+    expect(result.exifGps).toBeNull();
+  });
+
+  it("accepts a valid pair that sits on a real jurisdiction point", async () => {
+    // Arrange: a Palo Alto coordinate (the same point the agency-routing tests
+    // resolve) survives the guard intact — both halves finite numbers.
+    gpsMock.mockResolvedValue({ latitude: 37.4419, longitude: -122.143 });
+
+    // Act
+    const result = await preprocessImage("Zm9v");
+
+    // Assert
+    expect(result.exifGps).toEqual({ latitude: 37.4419, longitude: -122.143 });
+  });
 });

--- a/nexa/src/lib/jurisdictions/resolve-agency.test.ts
+++ b/nexa/src/lib/jurisdictions/resolve-agency.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import { prismaMock } from "@/test/prisma-mock";
+
+import { resolveAgencyId } from "./agency";
+import { resolveJurisdiction } from "./resolve";
+
+// End-to-end location → agency routing (issue #218 scope (c)). These tests prove
+// the coordinates a report carries (from a GPS share, an address pick, or photo
+// EXIF — the source is irrelevant once we hold a lat/lon) drive the polygon
+// router and the agency lookup to the EXPECTED agency.
+//
+// `resolveJurisdiction` is a pure function over the committed boundaries.json, so
+// it runs for real and offline. `resolveAgencyId` then hits prisma.agency, which
+// the shared deep-mock (`@/test/prisma-mock`) intercepts — we stub the rows the
+// seeded DB would return and assert both the QUERY (correct jurisdiction filter)
+// and the RESULT (the one confident agency id).
+//
+// Coordinates are reused from resolve.test.ts so the two suites stay in lockstep:
+//   PALO_ALTO -> city-palo-alto
+//   EAST_PALO_ALTO -> city-east-palo-alto
+const PALO_ALTO = { latitude: 37.4419, longitude: -122.143 } as const;
+const EAST_PALO_ALTO = { latitude: 37.4688, longitude: -122.1411 } as const;
+
+type AgencyRow = Awaited<ReturnType<typeof prismaMock.agency.findMany>>;
+
+describe("location → agency routing", () => {
+  it("a Palo Alto coordinate resolves to the Palo Alto jurisdiction", () => {
+    // Act
+    const match = resolveJurisdiction(
+      PALO_ALTO.latitude,
+      PALO_ALTO.longitude,
+      "ROAD_DAMAGE",
+    );
+
+    // Assert
+    expect(match?.jurisdiction.id).toBe("city-palo-alto");
+  });
+
+  it("a Palo Alto coordinate routes to the Palo Alto agency", async () => {
+    // Arrange: the seeded DB has exactly one Palo Alto agency covering the issue.
+    prismaMock.agency.findMany.mockResolvedValue([
+      { id: "agency-palo-alto" },
+    ] as AgencyRow);
+
+    // Act
+    const result = await resolveAgencyId({
+      ...PALO_ALTO,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert: the lookup was scoped to the resolved jurisdiction + issue type...
+    expect(prismaMock.agency.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          jurisdiction: "city-palo-alto",
+          issueTypes: { has: "ROAD_DAMAGE" },
+        },
+      }),
+    );
+    // ...and the single covering agency became the confident match.
+    expect(result.agencyId).toBe("agency-palo-alto");
+    expect(result.candidates).toEqual(["agency-palo-alto"]);
+  });
+
+  it("an East Palo Alto coordinate resolves to the East Palo Alto jurisdiction", () => {
+    // Act
+    const match = resolveJurisdiction(
+      EAST_PALO_ALTO.latitude,
+      EAST_PALO_ALTO.longitude,
+      "ROAD_DAMAGE",
+    );
+
+    // Assert
+    expect(match?.jurisdiction.id).toBe("city-east-palo-alto");
+  });
+
+  it("an East Palo Alto coordinate routes to the East Palo Alto agency", async () => {
+    // Arrange
+    prismaMock.agency.findMany.mockResolvedValue([
+      { id: "agency-east-palo-alto" },
+    ] as AgencyRow);
+
+    // Act
+    const result = await resolveAgencyId({
+      ...EAST_PALO_ALTO,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert: routed to the EPA jurisdiction, not Palo Alto's.
+    expect(prismaMock.agency.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          jurisdiction: "city-east-palo-alto",
+          issueTypes: { has: "ROAD_DAMAGE" },
+        },
+      }),
+    );
+    expect(result.agencyId).toBe("agency-east-palo-alto");
+  });
+
+  it("the two neighboring points route to DIFFERENT agencies", async () => {
+    // Arrange: Palo Alto and East Palo Alto are adjacent but distinct cities.
+    // The same issue type must not collapse them onto one agency.
+    prismaMock.agency.findMany
+      .mockResolvedValueOnce([{ id: "agency-palo-alto" }] as AgencyRow)
+      .mockResolvedValueOnce([{ id: "agency-east-palo-alto" }] as AgencyRow);
+
+    // Act
+    const pa = await resolveAgencyId({
+      ...PALO_ALTO,
+      issueType: "ROAD_DAMAGE",
+    });
+    const epa = await resolveAgencyId({
+      ...EAST_PALO_ALTO,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert
+    expect(pa.agencyId).toBe("agency-palo-alto");
+    expect(epa.agencyId).toBe("agency-east-palo-alto");
+    expect(pa.agencyId).not.toBe(epa.agencyId);
+  });
+
+  it("returns no agency for a point outside every jurisdiction", async () => {
+    // Arrange: middle of the ocean — no polygon matches, so prisma is never hit.
+    // Act
+    const result = await resolveAgencyId({
+      latitude: 0,
+      longitude: 0,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert
+    expect(result).toEqual({ agencyId: null, candidates: [] });
+    expect(prismaMock.agency.findMany).not.toHaveBeenCalled();
+  });
+
+  it("surfaces both candidates without auto-assigning when the match is ambiguous", async () => {
+    // Arrange: a real spot inside Palo Alto, but two agencies cover the issue.
+    prismaMock.agency.findMany.mockResolvedValue([
+      { id: "agency-palo-alto-web" },
+      { id: "agency-palo-alto-api" },
+    ] as AgencyRow);
+
+    // Act
+    const result = await resolveAgencyId({
+      ...PALO_ALTO,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert: ambiguity is left for a later disambiguation step — no auto-pick.
+    expect(result.agencyId).toBeNull();
+    expect(result.candidates).toEqual([
+      "agency-palo-alto-web",
+      "agency-palo-alto-api",
+    ]);
+  });
+
+  it("returns no agency when coordinates are missing even with an issue type", async () => {
+    // Act: a free-text address that never resolved to a point.
+    const result = await resolveAgencyId({
+      latitude: null,
+      longitude: null,
+      issueType: "ROAD_DAMAGE",
+    });
+
+    // Assert: short-circuits before any polygon/DB work.
+    expect(result).toEqual({ agencyId: null, candidates: [] });
+    expect(prismaMock.agency.findMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #218.

Tests proving location is handled correctly across sources (GPS share vs photo metadata vs address).

## What's covered
**(a) EXIF GPS extraction in `preprocess.ts`** — extends `preprocess.test.ts`. The existing suite already covered valid GPS, missing GPS, non-finite and non-numeric coords, and the exifr-throws path. Added the **lat-without-lon guard** explicitly: latitude present with no longitude, the mirror (lon without lat), a half-pair where the other coordinate is an explicit `null`, and a valid pair on a real Palo Alto point.

**(b) Source precedence in `use-geolocation.ts`** (user GPS / address > photo EXIF > none) — already fully covered in `use-geolocation.test.tsx` from the EXIF-wiring work (#216): `applyExifFallback` no-ops when `source==='user'`, applies when `source` is `null`, and a later pin drag overrides the source back to `user`. Left as-is to avoid duplication.

**(c) Coords drive routing to the EXPECTED agency** — new `resolve-agency.test.ts`. `resolveJurisdiction` runs for real against the committed boundaries; `resolveAgencyId` hits the shared prisma deep-mock. A Palo Alto coordinate routes to the Palo Alto agency, an East Palo Alto coordinate to the EPA agency, the two adjacent cities stay on distinct agencies, and out-of-bounds / missing-coords / ambiguous-coverage cases resolve to no confident agency (prisma untouched where it should be). Coordinates are reused from `resolve.test.ts`.

## Verification
- New/extended tests: **8** new agency-routing + **4** new preprocess EXIF guard cases.
- `npm run test:coverage` exits **0** (jurisdictions 96.07% S / 97.61% L, classify 100%; global lines 89.19%).
- `npx tsc --noEmit` clean; `npm run format:check` clean.
- Full suite: 669 passed.