### PR TITLE
docs(eval): K2 time-to-submit measurement procedure + K1 classification-eval verification strategy [#206][#209]

### DIFF
--- a/nexa/docs/metrics/time-to-submit.md
+++ b/nexa/docs/metrics/time-to-submit.md
@@ -13,6 +13,23 @@ O1.KR2 / K2 service-level objectives.
 - **Stage event:** `report_classified` fires when classification completes, so
   the capture → classify and classify → submit sub-stages remain queryable.
 
+These event names and property keys are the ones actually emitted by the app —
+see `src/app/report/page.tsx` (`posthog?.capture("report_classified", …)` and
+`posthog?.capture("report_submitted", { … time_to_submit_ms … })`). The clock
+(`flowStartedAt`) is started by `markCaptureStart()` on the first photo or first
+description keystroke. The event payloads are:
+
+| Event               | Properties                                                                  |
+| ------------------- | --------------------------------------------------------------------------- |
+| `report_submitted`  | `report_id`, `issue_type`, `time_to_submit_ms`, `has_image`, `has_location` |
+| `report_classified` | `issue_type`, `severity`, `has_image`, `has_location`                       |
+
+PostHog is initialised in `src/components/posthog-provider.tsx` against host
+`NEXT_PUBLIC_POSTHOG_HOST` (default `https://us.i.posthog.com`) with project key
+`NEXT_PUBLIC_POSTHOG_KEY`. Instrumentation is a no-op when the key is unset, so
+readings can only be collected from an environment that has the key configured
+(production / preview).
+
 ## Targets (SLO)
 
 | Statistic | Target                |
@@ -20,19 +37,77 @@ O1.KR2 / K2 service-level objectives.
 | Median    | <= 60 s (60 000 ms)   |
 | p90       | <= 180 s (180 000 ms) |
 
+## Reading median / p90 from PostHog
+
+There are two equivalent ways to read the percentiles. Both operate on the
+`report_submitted` event's `time_to_submit_ms` property.
+
+### Option A — HogQL via the Query API (scriptable, reproducible)
+
+PostHog exposes a SQL-like Query API. The query below returns count, median, and
+p90 of `time_to_submit_ms` over the last 30 days. `quantile(0.9)` is p90;
+`median(x)` is `quantile(0.5)`.
+
+```sql
+SELECT
+  count()                                   AS n,
+  median(toFloat(properties.time_to_submit_ms))      AS median_ms,
+  quantile(0.9)(toFloat(properties.time_to_submit_ms)) AS p90_ms
+FROM events
+WHERE event = 'report_submitted'
+  AND timestamp > now() - INTERVAL 30 DAY
+  AND properties.time_to_submit_ms IS NOT NULL
+```
+
+Run it against the Query API (substitute your project id, region host, and a
+**personal API key** with `query:read` scope — do NOT use the public
+`NEXT_PUBLIC_POSTHOG_KEY`, and never commit the personal key):
+
+```bash
+curl -s "https://us.posthog.com/api/projects/<PROJECT_ID>/query/" \
+  -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "query": {
+          "kind": "HogQLQuery",
+          "query": "SELECT count() AS n, median(toFloat(properties.time_to_submit_ms)) AS median_ms, quantile(0.9)(toFloat(properties.time_to_submit_ms)) AS p90_ms FROM events WHERE event = '\''report_submitted'\'' AND timestamp > now() - INTERVAL 30 DAY AND properties.time_to_submit_ms IS NOT NULL"
+        }
+      }'
+```
+
+The response `results` row is `[n, median_ms, p90_ms]`. Divide the millisecond
+values by 1000 to compare against the 60 s / 180 s targets. (The API host is the
+**app** host — `us.posthog.com` / `eu.posthog.com` — not the ingestion host
+`us.i.posthog.com` used by the browser SDK.)
+
+### Option B — saved insight in the PostHog UI
+
+1. New insight → **Trends**.
+2. Series: event `report_submitted`.
+3. Change the aggregation (the "Total count" dropdown on the series) to
+   **Property value → P50** of `time_to_submit_ms`; add a second series with
+   **P90** of the same property.
+4. Set the date range (e.g. last 30 days) and save the insight to a dashboard.
+5. Optionally add a goal/marker line at 60 000 and 180 000 ms for the SLO.
+
+Read the P50 and P90 values straight off the chart for the snapshot table.
+
 ## PostHog dashboard
 
 > Manual step (out of code scope): create a saved PostHog insight/dashboard
-> computing median and p90 of `time_to_submit_ms` from `report_submitted`, with
-> the 60s/180s SLO lines marked, then paste the link below.
+> computing median and p90 of `time_to_submit_ms` from `report_submitted` (see
+> Option B above), with the 60s/180s SLO lines marked, then paste the link below.
 
 - Dashboard link: _TODO — paste the committed PostHog dashboard URL here._
 
 ## Snapshot
 
-> Fill from real data — at least one midpoint reading from the >= 10 P0 test
-> reports. Add a new row each time the snapshot is refreshed (e.g. in the
-> weekly CI eval summary).
+> **Remaining manual / ops action.** Populating this table requires the live
+> PostHog instance plus a real sample (>= 10 P0 test reports submitted end-to-end
+> so the percentiles are meaningful). That is a human/ops step — do **not**
+> fabricate values. Run Option A or read Option B, then add a dated row below.
+> Add a new row each time the snapshot is refreshed (e.g. in the weekly eval
+> summary). Fill the "met?" columns from the values vs the SLO targets.
 
 | Date (UTC) | n      | Median (ms) | p90 (ms) | Median <= 60s? | p90 <= 180s? | Notes  |
 | ---------- | ------ | ----------- | -------- | -------------- | ------------ | ------ |

--- a/nexa/eval/results/SUMMARY.md
+++ b/nexa/eval/results/SUMMARY.md
@@ -231,3 +231,76 @@ npm ci
 npx prisma generate   # readiness imports the generated Prisma client
 npm run eval:readiness # exits 0 at >=90%, non-zero below
 ```
+
+---
+
+## Continuous-verification strategy for the classification eval (K1) — issue #209
+
+K1 is _"eval-set pass rate, weekly, ≥70%"_. The classification eval that serves
+K1 (`npm run eval` → `eval/run.ts`) is **intentionally not run in CI**, so this
+section documents how it is verified on a cadence instead.
+
+### Why classification is out of CI
+
+`eval/run.ts` calls `classifyWithConsensus`, which makes live calls to three
+paid VLM providers (OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5`, Google
+`gemini-2.5-flash`). Running it in CI would (a) require committing/secret-loading
+paid API keys, and (b) break pull requests from forks, which never get repo
+secrets. The CI `eval` job therefore gates only the **offline** evals — routing
+(`eval:routing`, O2.KR1 ≥85%), boundary validation (`eval:validate-boundaries`),
+and submission-readiness (`eval:readiness`, K3 ≥90%) — none of which touch an LLM
+or the network. See `.github/workflows/ci.yml` (the `eval` job comments make the
+exclusion explicit).
+
+These offline evals **complement** the classification eval rather than replace
+it: routing/readiness verify that _once an issue is classified_ the report is
+routed to a real agency and every required intake field is populated, while the
+classification eval verifies the upstream step — that the VLM consensus actually
+assigns the correct `IssueType` to a real photo. K1 specifically covers the
+classification step, which only the LLM eval can measure.
+
+### Cadence, owner, threshold, results location
+
+| Aspect              | Value                                                                 |
+| ------------------- | --------------------------------------------------------------------- |
+| Cadence             | Weekly (out of CI; manual run or a scheduled/gated job with secrets)  |
+| Owner               | Eval maintainer (`@sarahhashash`) — reassign as the team rotates       |
+| Threshold (K1)      | Weekly eval pass rate **≥70%**; classification accuracy floor **≥80%** (O1.KR1) |
+| Results location    | This file — append a dated row to the table below each run            |
+| Baseline of record  | **92.1%** overall accuracy (70/76), 2026-05-22 (see Headline, top)    |
+
+### How / when to run it
+
+Run weekly from a machine that has the three API keys (a maintainer's laptop or a
+scheduled out-of-CI job, e.g. a scheduled cloud agent, that injects the keys as
+secrets — keys must never enter the public CI workflow):
+
+```bash
+cd nexa
+cp .env.example .env.local   # fill in OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY
+npm run eval:fetch:download  # refresh/pre-cache the dataset (offline-friendly)
+npm run eval                 # both modes over the full dataset; ~$0.70/run
+```
+
+`eval/run.ts` prints overall accuracy, per-class accuracy, the confusion matrix,
+and the baseline-vs-two-stage flip diff, and writes
+`eval/results/{baseline,two-stage}.json` (gitignored). Read the overall accuracy
+off stdout, then record it in the table below.
+
+> Note: unlike `eval:routing` / `eval:readiness`, `eval/run.ts` does **not** yet
+> exit non-zero below a threshold — it is a reporter, not a gate. The weekly
+> check is therefore a human read of the printed accuracy against the ≥70% /
+> ≥80% thresholds. If/when the eval is wired into a scheduled job with secrets,
+> add an accuracy gate there (mirroring the `TARGET_ACCURACY` pattern in
+> `eval/routing.ts`) so the run fails the cadence below target.
+
+### Weekly K1 log
+
+> Append one row per weekly run. Do not fabricate — only record accuracy actually
+> printed by `npm run eval`. The 2026-05-22 baseline row is the run captured in
+> the Headline section above.
+
+| Date (UTC) | Overall accuracy | n     | Pass (≥70% / ≥80%)? | Run by | Notes              |
+| ---------- | ---------------- | ----- | ------------------- | ------ | ------------------ |
+| 2026-05-22 | 92.1%            | 76    | PASS                | team   | Baseline (Headline) |
+| _TODO_     | _TODO_           | _TODO_| _TODO_              | _TODO_ | _TODO_             |


### PR DESCRIPTION
Closes #206 #209

Documentation-only. Completes the two eval/measurement docs against the actual instrumentation, eval harness, and CI workflow (no fabricated numbers).

## #206 — K2 time-to-submit measurement procedure
`nexa/docs/metrics/time-to-submit.md`:
- Documents the **exact** PostHog read procedure for median/p90 of `time_to_submit_ms`:
  - Option A: HogQL via the Query API (`median()` / `quantile(0.9)`) with a ready-to-run `curl`, noting the personal-API-key requirement and the app-host vs ingestion-host distinction.
  - Option B: a saved Trends insight (P50/P90 of the property) in the UI.
- Lists the **real** event names + payload keys as emitted by `src/app/report/page.tsx` (`report_submitted` → `report_id`, `issue_type`, `time_to_submit_ms`, `has_image`, `has_location`; `report_classified`), and the PostHog config from `src/components/posthog-provider.tsx`.
- Restates the 60s / 180s SLO and keeps the dated snapshot table.
- Marks snapshot population (live PostHog + ≥10 test reports) as the **remaining manual/ops step** — no measured values invented.

## #209 — K1 classification-eval continuous-verification strategy
`nexa/eval/results/SUMMARY.md` (new section):
- Explains why the classification eval (`eval/run.ts` → `npm run eval`) is **not** in CI (paid VLM keys; would break fork PRs) and that CI gates only the offline evals (`eval:routing`, `eval:validate-boundaries`, `eval:readiness`).
- Shows how it **complements** the gated offline routing/readiness evals (those verify routing+intake once classified; the LLM eval verifies the classification step K1 measures).
- States the weekly **K1 ≥70% pass / ≥80% accuracy** thresholds, cadence, owner, and results location; documents the run procedure; notes `run.ts` is a reporter (no gate) and where to add one if wired into a scheduled secrets-bearing job.
- Adds a weekly K1 log table seeded with the existing 2026-05-22 92.1% baseline row.

## Verification
- `npm run format:check` — clean.
- `npm run test:coverage` — exits 0 (Statements 87.7%, Lines 89.67%); no tests touched.
- No script added, so no `tsc` change required.