### PR TITLE
docs(ops): DB backup/PITR/RTO-RPO + error-tracking strategy (env-gated Sentry hook) [#208]

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -109,5 +109,16 @@ S3_SECRET_ACCESS_KEY=
 # The stored imageUrl is `${S3_PUBLIC_BASE_URL}/${key}`.
 S3_PUBLIC_BASE_URL=
 
+# --- Error tracking / APM (Sentry, issue #208) ---
+# Optional. When unset, server-side error tracking is a NO-OP: errors are still
+# surfaced via the existing `[…][ALERT]` console logs and the /api/health DB
+# probe, and the app runs unchanged (ready-to-activate). Set this to forward
+# uncaught server errors to Sentry IN ADDITION to those logs — see src/
+# instrumentation.ts and docs/ops.md. Activating it also requires installing the
+# optional @sentry/nextjs package (the hook degrades gracefully if it is absent).
+# The DSN is a public, non-secret project identifier from your Sentry project's
+# Settings → Client Keys (DSN).
+SENTRY_DSN=
+
 # --- App ---
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/nexa/VERCEL_SETUP.md
+++ b/nexa/VERCEL_SETUP.md
@@ -125,3 +125,23 @@ The Vercel dashboard's **Deployments** tab → any prior green deployment →
 "Promote to Production" is a one-click rollback. Database migrations are
 **not** auto-rolled-back — keep them additive (no `DROP COLUMN` etc.) during
 the demo period.
+
+> An app rollback does **not** roll back the database. To recover from data
+> loss/corruption, see the Neon backup / point-in-time-restore procedure in the
+> [operations runbook](docs/ops.md).
+
+---
+
+## 6. Backups, disaster recovery, and observability
+
+Database backup / point-in-time restore (with RTO/RPO targets and a recovery
+runbook) and the error-tracking / APM strategy live in
+[`docs/ops.md`](docs/ops.md). Key points:
+
+- **Backups/PITR:** Neon instant restore (PITR) within the project's history
+  window; recommended targets RPO ≈ 0, RTO ≤ 30 min, history window ≥ 7 days
+  (requires a paid plan — the Free plan is fixed at 6 hours), plus periodic
+  off-platform `pg_dump` backups.
+- **Observability:** the existing `[…][ALERT]` logs and `/api/health` DB probe
+  are the baseline; an env-gated Sentry hook (`src/instrumentation.ts`, set
+  `SENTRY_DSN`) forwards server errors to an aggregator when configured.

--- a/nexa/docs/ops.md
+++ b/nexa/docs/ops.md
@@ -1,0 +1,164 @@
+# Operations runbook: backups, disaster recovery, and observability
+
+This runbook covers the **DevOps** concerns for a production Nexa deployment:
+database backup / point-in-time restore (PITR) with explicit RTO/RPO targets and
+a recovery procedure, plus the error-tracking / APM strategy. It complements the
+deploy steps in [`VERCEL_SETUP.md`](../VERCEL_SETUP.md) — read that first for how
+the app and the Neon database are provisioned.
+
+---
+
+## 1. Database backup, PITR, and disaster recovery (Neon Postgres)
+
+The production database is **Neon Postgres** (see `VERCEL_SETUP.md` §1). Neon's
+storage is built on a copy-on-write branching architecture that retains a log of
+data changes, which is what powers its restore capabilities.
+
+### 1.1 What Neon actually gives you
+
+| Capability                 | What it is                                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Instant restore (PITR)** | Roll a branch back to any point in time within the project's **history window** (a retained change log). |
+| **Restore branch**         | Create a _new_ branch at a past timestamp for inspection/recovery without touching the live branch.      |
+| **Manual `pg_dump`**       | Standard logical backups you run yourself (`pg_dump` → `pg_restore`); portable, off-Neon copies.         |
+
+**History window (retention) by plan** — this is the maximum age you can restore
+back to, and it is a project-wide setting under **Settings → Instant restore** in
+the Neon Console:
+
+| Neon plan | Default history window | Maximum         |
+| --------- | ---------------------- | --------------- |
+| Free      | 6 hours                | 6 hours (fixed) |
+| Launch    | 1 day                  | up to 7 days    |
+| Scale     | 1 day                  | up to 30 days   |
+
+A longer history window increases storage cost, since Neon must keep more change
+data. Verify the current value (and your plan) in the Neon Console before relying
+on a target below.
+
+> Accuracy note: instant restore covers data that is _within_ the history window.
+> It is **not** a substitute for off-platform backups if you need to recover from
+> an event older than the window, or to migrate off Neon. For business
+> continuity / compliance, also take periodic `pg_dump` backups (§1.4).
+
+### 1.2 Recommended targets (RTO / RPO)
+
+For the demo's traffic and data-loss tolerance:
+
+| Metric                             | Target                               | Backed by                                                                                              |
+| ---------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| **RPO** (max acceptable data loss) | ≈ 0 (continuous)                     | Neon instant restore retains a continuous change log within the window.                                |
+| **RTO** (max time to recover)      | ≤ 30 minutes                         | Instant restore / restore-branch promotion is near-immediate; the budget covers triage + verification. |
+| **History window**                 | ≥ 7 days (Launch plan or higher)     | Configure under Settings → Instant restore once off the Free plan.                                     |
+| **Off-platform backup**            | weekly `pg_dump`, retained ≥ 30 days | Manual or GitHub-Actions-scheduled `pg_dump` to durable storage (§1.4).                                |
+
+The Free plan's fixed 6-hour window does **not** meet the ≥ 7-day target — treat
+upgrading to a paid plan (and raising the history window) as a prerequisite for a
+production launch.
+
+### 1.3 Recovery procedure (instant restore / PITR)
+
+When data is corrupted or wrongly deleted **within the history window**:
+
+1. **Stop the bleeding.** If a bad deploy is the cause, roll the app back first
+   via Vercel → Deployments → promote the last green deployment
+   (`VERCEL_SETUP.md` §5). Note: app rollback does **not** roll back the database.
+2. **Pick the restore timestamp** — just before the incident. Cross-reference the
+   `[…][ALERT]` logs and `/api/health` (§2) to bound when things went wrong.
+3. **Restore in the Neon Console**:
+   - _Lower-risk path (recommended):_ create a **restore branch** at the target
+     timestamp, point a throwaway connection string at it, and verify the data
+     looks right (e.g. the `Report`/`User` tables) **before** cutting over.
+   - _Direct path:_ use **instant restore** to roll the primary branch back to the
+     target timestamp. This reverts the live branch — confirm the timestamp first.
+4. **Re-point the app** if you restored onto a new branch: update `DATABASE_URL`
+   in Vercel (Settings → Environment Variables) to the restored branch's pooled
+   connection string, then redeploy.
+5. **Verify** using `VERCEL_SETUP.md` §4 (hit `/api/health`, file a test report,
+   confirm a row lands in `Report`).
+6. **Re-apply migrations if needed.** Migrations are additive (`VERCEL_SETUP.md`
+   §5), so a restored older snapshot may be missing recent schema. Run
+   `npx prisma migrate deploy` against the restored branch.
+
+### 1.4 Off-platform backup (`pg_dump`)
+
+For recovery beyond the history window, or an exportable copy:
+
+```bash
+cd nexa
+# Full logical dump (custom format → compact, parallel-restorable):
+DATABASE_URL="<Neon pooled connection string>" \
+  pg_dump "$DATABASE_URL" --format=custom --file="nexa-$(date +%F).dump"
+
+# Restore into a fresh/empty database:
+pg_restore --clean --if-exists --no-owner \
+  --dbname="<target connection string>" "nexa-2026-01-01.dump"
+```
+
+Automate it (recommended for a real launch): a scheduled **GitHub Actions** job
+that runs the dump and uploads to durable object storage (e.g. S3 / R2 — the same
+credentials already documented for image storage in `.env.example`), with a
+retention policy of ≥ 30 days. Keep dumps encrypted and access-restricted; they
+contain user PII.
+
+---
+
+## 2. Error tracking / APM
+
+### 2.1 Current baseline (already in the codebase)
+
+Two production signals exist today and remain the **source of truth**:
+
+- **`[…][ALERT]` console logs** — recognizable prefixes that an external log
+  monitor can alert on. The status-polling cron logs `[poll-status][ALERT]` for
+  per-report failures, push-notify failures, an unhealthy run
+  (`errorCount/checked` over threshold), and crashes
+  (`src/app/api/cron/poll-status/route.ts`).
+- **`/api/health` DB probe** — a liveness + readiness endpoint that runs a
+  bounded `SELECT 1` and returns `503 db_unreachable` when the database is down,
+  logging `[health] DB probe failed` (`src/app/api/health/route.ts`). Point an
+  uptime monitor (Vercel / UptimeRobot) at it.
+
+Set up alerting on top of these: a Vercel Log Drain (or your log platform) with an
+alert rule matching the `[ALERT]` substring, and an uptime monitor on
+`/api/health`.
+
+### 2.2 Recommended aggregator: Sentry (env-gated, code-complete)
+
+The baseline above has no aggregation, deduplication, or notification thresholds.
+The recommended next step is **Sentry for Next.js** (`@sentry/nextjs`), which
+hooks Next's native instrumentation to capture uncaught server errors, group them,
+and notify.
+
+A **minimal, env-gated hook is already wired** in `src/instrumentation.ts`,
+mirroring the no-op-when-unset convention used for push / email / S3:
+
+- It is a **NO-OP unless `SENTRY_DSN` is set** — the app runs unchanged out of the
+  box, and the `[…][ALERT]` logs remain the baseline.
+- When `SENTRY_DSN` is set, Next's `register()` initializes Sentry and
+  `onRequestError()` forwards uncaught server errors to Sentry **in addition to**
+  the existing logs.
+- `@sentry/nextjs` is an **optional dependency**, imported dynamically only when a
+  DSN is present. If the DSN is set but the package is not installed, the hook
+  logs `[instrumentation][ALERT]` and degrades to console logging rather than
+  failing the build. This keeps the default install lean.
+
+`SENTRY_DSN` is read through `src/lib/config.ts` (`getSentryDsn`) and documented
+in `.env.example`.
+
+### 2.3 Activating Sentry
+
+1. Create a Sentry project (platform: **Next.js**) and copy its **DSN** from
+   Settings → Client Keys (DSN). The DSN is a public, non-secret identifier.
+2. Install the SDK:
+   ```bash
+   cd nexa
+   npm install @sentry/nextjs
+   ```
+3. Set `SENTRY_DSN` in Vercel (Settings → Environment Variables) for Production
+   (and Preview if desired), then redeploy. The hook in `src/instrumentation.ts`
+   activates automatically — no further wiring required.
+4. _(Optional)_ tune `tracesSampleRate` in `src/instrumentation.ts` (currently `0`,
+   i.e. error-only, no performance tracing) and add client-side capture via
+   `instrumentation-client.ts` if you want browser errors too.
+5. Configure alert rules / notification thresholds in the Sentry dashboard.

--- a/nexa/src/instrumentation.test.ts
+++ b/nexa/src/instrumentation.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// instrumentation.ts reads SENTRY_DSN through config.ts, whose getters are lazy
+// + memoized per module instance. Reset the module registry between cases so a
+// changed SENTRY_DSN takes effect on a fresh import.
+const ORIGINAL_SENTRY_DSN = process.env.SENTRY_DSN;
+
+async function loadInstrumentation() {
+  vi.resetModules();
+  return import("./instrumentation");
+}
+
+beforeEach(() => {
+  delete process.env.SENTRY_DSN;
+});
+
+afterEach(() => {
+  if (ORIGINAL_SENTRY_DSN === undefined) delete process.env.SENTRY_DSN;
+  else process.env.SENTRY_DSN = ORIGINAL_SENTRY_DSN;
+  vi.restoreAllMocks();
+});
+
+describe("instrumentation (error-tracking hook)", () => {
+  it("register is a no-op and does not throw when SENTRY_DSN is unset", async () => {
+    const { register } = await loadInstrumentation();
+    await expect(register()).resolves.toBeUndefined();
+  });
+
+  it("onRequestError is a no-op and does not throw when SENTRY_DSN is unset", async () => {
+    const { onRequestError } = await loadInstrumentation();
+    await expect(
+      // The shape of the args is irrelevant when the hook short-circuits.
+      onRequestError(
+        new Error("boom") as { digest: string } & Error,
+        { path: "/", method: "GET", headers: {} },
+        {
+          routerKind: "App Router",
+          routePath: "/",
+          routeType: "route",
+          revalidateReason: undefined,
+        } as Parameters<typeof onRequestError>[2],
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/nexa/src/instrumentation.ts
+++ b/nexa/src/instrumentation.ts
@@ -1,0 +1,91 @@
+/**
+ * Next.js instrumentation entry point (issue #208).
+ *
+ * Wires server-side error tracking behind the same env-gating convention used
+ * for push / email / S3: it is a NO-OP unless `SENTRY_DSN` is set, so the app
+ * runs unchanged out of the box and activates the moment the DSN is provided.
+ *
+ * This deliberately does NOT replace the existing observability baseline — the
+ * `[…][ALERT]` console logs (e.g. `[poll-status][ALERT]`) and the `/api/health`
+ * DB probe remain the source of truth. When a DSN is set, `onRequestError`
+ * forwards uncaught server errors to Sentry IN ADDITION to those logs.
+ *
+ * To keep the install lean, `@sentry/nextjs` is imported dynamically and only
+ * when a DSN is present; when the package is absent the hook degrades to the
+ * existing console logging without throwing. See `docs/ops.md` for the full
+ * integration guide.
+ */
+import type { Instrumentation } from "next";
+
+import { getSentryDsn } from "@/lib/config";
+
+const ALERT_PREFIX = "[instrumentation][ALERT]";
+
+/**
+ * Minimal structural type for the bits of `@sentry/nextjs` we touch. Declared
+ * locally so the project does not need the package installed to typecheck — the
+ * SDK is an OPTIONAL dependency, loaded only when `SENTRY_DSN` is set.
+ */
+interface SentryModule {
+  init(options: {
+    dsn: string;
+    tracesSampleRate?: number;
+    environment?: string;
+  }): void;
+  captureRequestError(
+    ...args: Parameters<Instrumentation.onRequestError>
+  ): void;
+}
+
+/**
+ * Lazily load and initialize the Sentry Next.js SDK. Returns the loaded module,
+ * or `null` when no DSN is set or the optional `@sentry/nextjs` package is not
+ * installed (so error tracking is purely additive and never a hard dependency).
+ */
+async function loadSentry(): Promise<SentryModule | null> {
+  const dsn = getSentryDsn();
+  if (!dsn) return null;
+  try {
+    // Optional dependency: the dynamic specifier is built at runtime so the
+    // bundler does not try to resolve the package unless it is installed.
+    const moduleName = "@sentry/nextjs";
+    const Sentry = (await import(moduleName).catch(
+      () => null,
+    )) as SentryModule | null;
+    if (!Sentry) {
+      console.error(
+        `${ALERT_PREFIX} SENTRY_DSN is set but @sentry/nextjs is not installed — see docs/ops.md`,
+      );
+      return null;
+    }
+    Sentry.init({
+      dsn,
+      tracesSampleRate: 0,
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    });
+    return Sentry;
+  } catch (error) {
+    // Never let observability setup take down the server.
+    console.error(`${ALERT_PREFIX} Sentry init failed:`, error);
+    return null;
+  }
+}
+
+/**
+ * Called once per server instance. No-op unless `SENTRY_DSN` is set.
+ */
+export async function register(): Promise<void> {
+  await loadSentry();
+}
+
+/**
+ * Forward uncaught server errors to Sentry when configured. The existing
+ * `[…][ALERT]` console logging remains the baseline signal; this is additive.
+ */
+export const onRequestError: Instrumentation.onRequestError = async (
+  ...args
+) => {
+  const Sentry = await loadSentry();
+  if (!Sentry) return;
+  Sentry.captureRequestError(...args);
+};

--- a/nexa/src/lib/config.test.ts
+++ b/nexa/src/lib/config.test.ts
@@ -47,3 +47,33 @@ describe("getAdminEmails", () => {
     expect(getAdminEmails()).toBe(getAdminEmails());
   });
 });
+
+const ORIGINAL_SENTRY_DSN = process.env.SENTRY_DSN;
+
+async function loadGetSentryDsn() {
+  vi.resetModules();
+  const mod = await import("./config");
+  return mod.getSentryDsn;
+}
+
+describe("getSentryDsn", () => {
+  beforeEach(() => {
+    delete process.env.SENTRY_DSN;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_SENTRY_DSN === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = ORIGINAL_SENTRY_DSN;
+  });
+
+  it("returns undefined when SENTRY_DSN is unset (error tracking is a no-op)", async () => {
+    const getSentryDsn = await loadGetSentryDsn();
+    expect(getSentryDsn()).toBeUndefined();
+  });
+
+  it("returns a trimmed DSN when set", async () => {
+    process.env.SENTRY_DSN = "  https://abc@o0.ingest.sentry.io/1  ";
+    const getSentryDsn = await loadGetSentryDsn();
+    expect(getSentryDsn()).toBe("https://abc@o0.ingest.sentry.io/1");
+  });
+});

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -103,6 +103,15 @@ export const getAdminEmails = cached(() => {
   );
 });
 
+/**
+ * Sentry DSN for server-side error tracking (see `src/instrumentation.ts`).
+ * Optional and env-gated: when unset the error-tracking hook is a NO-OP — server
+ * errors are still surfaced via the existing `[…][ALERT]` console logs, and the
+ * app runs unchanged. Set it (in Vercel) to forward errors to Sentry in addition
+ * to those logs. The DSN is a public, non-secret identifier.
+ */
+export const getSentryDsn = cached(() => optionalEnv("SENTRY_DSN"));
+
 /** OpenAI API key (GPT classification + stage-1 observation). */
 export const getOpenAiKey = cached(() => optionalEnv("OPENAI_API_KEY"));
 


### PR DESCRIPTION
Closes #208.

## What

Adds production observability + disaster-recovery documentation and a minimal, env-gated error-tracking hook.

### Docs
- **`docs/ops.md`** — new operations runbook:
  - **Neon backup / PITR / DR:** the real instant-restore (history-window) capability and per-plan retention (Free 6h fixed; Launch ≤7d; Scale ≤30d), an off-platform `pg_dump` backup path, recommended **RTO ≤ 30 min / RPO ≈ 0 / history window ≥ 7 days** targets, and a step-by-step recovery procedure.
  - **Error tracking / APM:** documents the existing `[poll-status][ALERT]` logs + `/api/health` DB probe as the current baseline, recommends Sentry as the aggregator, and gives an activation guide.
- **`VERCEL_SETUP.md`** — new §6 linking the runbook + a DB-recovery note on the rollback section.

### Code (minimal, env-gated)
- **`src/instrumentation.ts`** — Next-native `register()` / `onRequestError`. **No-op unless `SENTRY_DSN` is set** (mirrors the push/email/S3 env-gating). `@sentry/nextjs` is an **optional dynamic import**, so the default install stays lean and the build never requires it. When the DSN is set, server errors are forwarded to Sentry **in addition to** the `[…][ALERT]` logs.
- **`src/lib/config.ts`** — `getSentryDsn` getter (reuses the existing optional-env pattern).
- **`.env.example`** — documents `SENTRY_DSN`.
- Tests: `getSentryDsn` getter + instrumentation no-op behavior.

## Verification
- `npm run format:check` — clean
- `npx tsc --noEmit` — exit 0 (after `prisma generate`)
- `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unrelated)
- `npm run test:coverage` — exits 0, **692 passed**

No AI attribution. No hard dependency added.