### PR TITLE
fix(submission): word-boundary key matching in prefill (license_plate no longer gets latitude) [#234]

### DIFF
--- a/nexa/src/lib/submission/prefill.test.ts
+++ b/nexa/src/lib/submission/prefill.test.ts
@@ -247,11 +247,55 @@ describe("buildPrefillFields — unknown / underivable field branch", () => {
     expect(f?.hint).toBe("You'll need to fill this in.");
   });
 
-  it("matches the lat branch for any key containing 'lat' (e.g. license_plate)", () => {
-    // Documents a real substring quirk: license_pLATe contains "lat", so it
-    // resolves to the report latitude rather than falling through to unknown.
+  it("does NOT match license_plate to latitude (whole-token matching, #234)", () => {
+    // Regression for the substring quirk: license_pLATe used to contain "lat"
+    // and resolve to the report latitude. With token matching it splits to
+    // ["license","plate"] — neither is a latitude token — so it stays unknown.
     const f = fieldFor("license_plate", { type: "string" }, makeFullReport());
-    expect(f?.value).toBe("37.4419");
+    expect(f?.value).toBeNull();
+    expect(f?.hint).toBe("You'll need to fill this in.");
+  });
+
+  it("leaves the other CARB vehicle fields unfilled (no false token match)", () => {
+    // template/vehicle_make/etc. must not false-match any derivation branch.
+    for (const key of [
+      "template",
+      "vehicle_make",
+      "vehicle_model",
+      "vehicle_color",
+      "contact_name",
+    ]) {
+      const f = fieldFor(key, { type: "string" }, makeFullReport());
+      expect(f?.value).toBeNull();
+      expect(f?.hint).toBe("You'll need to fill this in.");
+    }
+  });
+
+  it("keeps the real CARB form-field keys mapping correctly", () => {
+    // Pin every derivable key from the CARB VEHICLE_EMISSIONS schema.
+    const report = makeFullReport();
+    expect(
+      fieldFor("observation_location", { type: "string" }, report)?.value,
+    ).toBe("100 Main St, Palo Alto, CA");
+    expect(
+      fieldFor("observation_datetime", { type: "datetime" }, report)?.value,
+    ).toBe(new Date(report.createdAt as Date).toLocaleString());
+    // And the keys from the SeeClickFix-style schema.
+    expect(
+      fieldFor("location_address", { type: "string" }, report)?.value,
+    ).toBe("100 Main St, Palo Alto, CA");
+    expect(fieldFor("latitude", { type: "number" }, report)?.value).toBe(
+      "37.4419",
+    );
+    expect(fieldFor("longitude", { type: "number" }, report)?.value).toBe(
+      "-122.143",
+    );
+    expect(fieldFor("contact_email", { type: "string" }, report)?.value).toBe(
+      "reporter@example.com",
+    );
+    expect(fieldFor("description", { type: "string" }, report)?.value).toBe(
+      "Pothole on Main St",
+    );
   });
 });
 

--- a/nexa/src/lib/submission/prefill.ts
+++ b/nexa/src/lib/submission/prefill.ts
@@ -37,13 +37,56 @@ function humanize(key: string): string {
   return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
+// Recognized token sets per derivation branch. We tokenize the key on
+// non-alphanumeric boundaries and match WHOLE tokens, so `license_plate`
+// (license/plate) no longer false-matches the `lat` latitude token the way the
+// old `k.includes("lat")` substring check did (issue #234).
+const PHOTO_TOKENS = new Set(["photo", "image", "attachment"]);
+const DESCRIPTION_TOKENS = new Set([
+  "description",
+  "details",
+  "comment",
+  "comments",
+  "problem",
+  "issue",
+]);
+const ADDRESS_TOKENS = new Set([
+  "address",
+  "location",
+  "intersection",
+  "street",
+]);
+const LATITUDE_TOKENS = new Set(["lat", "latitude"]);
+const LONGITUDE_TOKENS = new Set(["lon", "long", "lng", "longitude"]);
+const EMAIL_TOKENS = new Set(["email"]);
+const DATETIME_TOKENS = new Set([
+  "datetime",
+  "date",
+  "time",
+  "observed",
+  "timestamp",
+]);
+
+// Split a field key into lowercased alphanumeric tokens
+// (e.g. "observation_datetime" -> ["observation", "datetime"]).
+function tokenize(key: string): string[] {
+  return key
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function hasToken(tokens: string[], set: Set<string>): boolean {
+  return tokens.some((t) => set.has(t));
+}
+
 function valueForKey(
   key: string,
   type: string,
   report: PrefillReport,
   embeddedValue?: string | null,
 ): { value: string | null; hint?: string } {
-  const k = key.toLowerCase();
+  const tokens = tokenize(key);
   const description =
     report.description?.trim() || report.aiDescription?.trim();
 
@@ -55,7 +98,7 @@ function valueForKey(
     return { value: embeddedValue };
   }
 
-  if (type === "file" || /photo|image|attachment/.test(k)) {
+  if (type === "file" || hasToken(tokens, PHOTO_TOKENS)) {
     return {
       value: null,
       hint: report.imageUrl
@@ -63,24 +106,24 @@ function valueForKey(
         : "No photo attached.",
     };
   }
-  if (/description|details|comment|problem|issue/.test(k)) {
+  if (hasToken(tokens, DESCRIPTION_TOKENS)) {
     return { value: description ?? null };
   }
-  if (/address|location|intersection|street/.test(k)) {
+  if (hasToken(tokens, ADDRESS_TOKENS)) {
     return { value: report.address ?? null };
   }
-  if (k.includes("lat")) {
+  if (hasToken(tokens, LATITUDE_TOKENS)) {
     return { value: report.latitude != null ? String(report.latitude) : null };
   }
-  if (k.includes("lon") || k.includes("lng")) {
+  if (hasToken(tokens, LONGITUDE_TOKENS)) {
     return {
       value: report.longitude != null ? String(report.longitude) : null,
     };
   }
-  if (k.includes("email")) {
+  if (hasToken(tokens, EMAIL_TOKENS)) {
     return { value: report.contactEmail ?? null };
   }
-  if (/datetime|date|time|observed|observation_date/.test(k)) {
+  if (hasToken(tokens, DATETIME_TOKENS)) {
     return { value: new Date(report.createdAt).toLocaleString() };
   }
 


### PR DESCRIPTION
## Summary

Fixes #234. `valueForKey` in `src/lib/submission/prefill.ts` used loose substring matching (`k.includes("lat")`, `k.includes("lon")`, `k.includes("email")`, and regex `.test(k)` checks). Because `license_plate` contains the substring `lat` (li-cense-p-**lat**-e), it false-matched the latitude branch, and the CARB vehicle-emissions payload filled the license-plate field with the report's latitude.

## Approach

Tokenize the key on non-alphanumeric boundaries (`observation_datetime` -> `["observation", "datetime"]`) and match **whole tokens** against per-branch token sets, instead of substring containment. `license_plate` -> `["license", "plate"]` matches no derivation branch and correctly falls through to the "you'll need to fill this in" hint.

Every real form-field key from `prisma/agencies.ts` keeps working:
- `description` -> description
- `location_address`, `observation_location` -> address (via `location`/`address`/`street`)
- `latitude` -> lat; `longitude`/`lng`/`long`/`lon` -> long
- `photo`/`image_url`/`attachment` -> photo
- `contact_email` -> email
- `observation_datetime` -> datetime

## Tests

- Replaced the test that *documented* the substring quirk with a regression asserting `license_plate` is **not** filled with latitude (value null, fill-it-in hint).
- Added coverage that the other CARB vehicle fields (`template`, `vehicle_make/model/color`, `contact_name`) stay unfilled.
- Added a test pinning every derivable CARB/SeeClickFix schema key to its correct mapping.

## Verification

- `npm run test:coverage` exits 0 — 767 tests pass across 73 files; coverage gate met.
- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` all clean.