### PR TITLE
test(e2e): record end-to-end workflow video [#220]

### DIFF
--- a/nexa/e2e/README.md
+++ b/nexa/e2e/README.md
@@ -1,0 +1,60 @@
+# End-to-end tests (Playwright)
+
+These specs run against the Playwright `webServer` (`next dev`, booted with a
+fixed test env from `playwright.config.ts`). All network calls the browser makes
+are intercepted with `page.route`, so the suite is deterministic and offline —
+no real LLM, geocoding, agency routing, Open311 submission, or database.
+
+Run the whole suite:
+
+```bash
+npm run test:e2e
+```
+
+## Specs
+
+| Spec                            | What it covers                                          |
+| ------------------------------- | ------------------------------------------------------- |
+| `smoke.spec.ts`                 | Homepage loads, title + hero CTA render.                |
+| `anonymous-report.spec.ts`      | Guest report loop + classification-failure error path.  |
+| `authenticated-journey.spec.ts` | Proxy auth gating + register/login flow.                |
+| `full-workflow.spec.ts`         | **Dedicated end-to-end video walkthrough** (see below). |
+
+## Video walkthrough (`full-workflow.spec.ts`, #220)
+
+`full-workflow.spec.ts` walks the complete guest workflow end to end:
+
+> home → "Report an Issue" → `/report` → describe (text + stubbed photo +
+> stubbed address/location) → Analyze Issue (classify) → review → Submit Report
+> → confirmation / submission step.
+
+It runs under the dedicated `full-workflow-video` Playwright **project** in
+`playwright.config.ts`, which sets `use.video: "on"` — so a webm is **always**
+recorded for this spec, pass or fail. The rest of the suite keeps the default
+`video: "retain-on-failure"`, so the existing CI e2e behaviour is unchanged.
+
+### Where the video lands
+
+After `npm run test:e2e`, the recording is written under `test-results/`:
+
+```
+test-results/full-workflow-records-the-full-guest-report-workflow-end-to-end-full-workflow-video/video.webm
+```
+
+(One folder per test; the folder name is derived from the spec name, the test
+title, and the project name `full-workflow-video`.) To find it regardless of the
+exact slug:
+
+```bash
+find test-results -name video.webm
+```
+
+### How to view it
+
+- macOS: `open <path-to>/video.webm`
+- Any OS: open the file in a browser (Chrome/Firefox play `.webm`), or
+- `npx playwright show-report` — the HTML report (generated in CI) embeds the
+  video alongside the trace.
+
+> Note: `test-results/` is a Playwright output directory and is git-ignored; the
+> video is an artifact produced by running the suite, not a committed file.

--- a/nexa/e2e/full-workflow.spec.ts
+++ b/nexa/e2e/full-workflow.spec.ts
@@ -1,0 +1,235 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Dedicated end-to-end WALKTHROUGH for #220. The point of this spec is the
+// VIDEO it records — the `full-workflow-video` project in playwright.config.ts
+// runs it with `video: "on"`, so a runnable `npm run test:e2e` always emits a
+// webm of the complete guest report loop:
+//
+//   home -> "Report an Issue" -> /report
+//        -> describe (text + stubbed photo + stubbed address/location)
+//        -> Analyze Issue (classify) -> review classification
+//        -> Submit Report -> confirmation / submission step.
+//
+// Every network call the browser makes is intercepted with `page.route`, so the
+// run is fully deterministic and offline: no real LLM consensus, no
+// Google/Nominatim geocoding, no agency routing, no Open311 submission, no
+// database. We assert only on rendered screen state (text/roles/urls), never on
+// internal server logic. Selectors mirror the proven ones in
+// anonymous-report.spec.ts so this walkthrough stays in lock-step with the UI.
+//
+// The artifact lands at:
+//   test-results/full-workflow-*/video.webm
+// (one folder per test; the project name "full-workflow-video" is encoded in
+// the path). See e2e/README.md for how to view it.
+
+// --- Deterministic stub payloads -------------------------------------------
+
+const CLASSIFY_RESULT = {
+  success: true,
+  data: {
+    winner: {
+      issueType: "ROAD_DAMAGE",
+      aiDescription:
+        "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+      severity: "high",
+      confidence: 0.95,
+    },
+    allResults: [
+      {
+        provider: "stub-model",
+        latencyMs: 12,
+        issueType: "ROAD_DAMAGE",
+        aiDescription:
+          "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+        severity: "high",
+        confidence: 0.95,
+      },
+    ],
+    consensus: true,
+    method: "unanimous",
+  },
+};
+
+// The created report row echoed back by POST /api/reports. The confirmation
+// screen renders this id, so we assert on it as the terminal state.
+const CREATED_REPORT = {
+  success: true,
+  data: {
+    id: "rep_e2e_video_0001",
+    issueType: "ROAD_DAMAGE",
+    description: null,
+    aiDescription:
+      "A large pothole in the roadway poses a hazard to vehicles and cyclists.",
+    createdAt: "2026-06-09T12:00:00.000Z",
+  },
+};
+
+const ADDRESS_SUGGESTIONS = {
+  success: true,
+  data: {
+    suggestions: [
+      {
+        displayName: "123 Main St, Springfield",
+        latitude: 37.422,
+        longitude: -122.084,
+      },
+    ],
+  },
+};
+
+/**
+ * Register every client-side route stub the report flow touches. Routes are
+ * matched by URL so minor UI changes (selectors/text) never break the network
+ * layer. Mirrors anonymous-report.spec.ts, plus an explicit stub for the
+ * agency-candidates lookup the page fires on classify success — so the review
+ * step renders without any external routing call.
+ */
+async function stubReportRoutes(page: Page) {
+  // Guest session check — the report page calls this on mount.
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      status: 401,
+      json: { success: false, error: "Not authenticated" },
+    }),
+  );
+
+  // LLM classification consensus — stubbed winner + single provider result.
+  await page.route("**/api/reports/classify", (route) =>
+    route.fulfill({ json: CLASSIFY_RESULT }),
+  );
+
+  // Official-form lookup fires after a successful classify. Return a benign
+  // "not found" so the review step renders without an external Places/Nominatim
+  // call. The exact body is non-load-bearing for this happy path.
+  await page.route("**/api/reports/form-link", (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        data: {
+          status: "not_found",
+          cityName: null,
+          message: "No official form found.",
+          reason: "Stubbed for e2e.",
+        },
+      },
+    }),
+  );
+
+  // Agency routing also fires on classify success. Collapse it to a single,
+  // unambiguous candidate so the review step never asks the user to disambiguate
+  // and the offline run stays deterministic.
+  await page.route("**/api/reports/agency-candidates", (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        data: {
+          candidates: [
+            {
+              id: "agency_e2e_stub",
+              name: "City Public Works",
+              jurisdiction: "Springfield",
+            },
+          ],
+          ambiguous: false,
+        },
+      },
+    }),
+  );
+
+  // Address suggestions (Google -> Nominatim fallback on the server) collapsed
+  // to one deterministic result so selecting it sets coordinates offline.
+  await page.route("**/api/location/suggest**", (route) =>
+    route.fulfill({ json: ADDRESS_SUGGESTIONS }),
+  );
+
+  // Report creation — the row whose id the confirmation page shows.
+  await page.route("**/api/reports", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ json: CREATED_REPORT });
+    }
+    return route.continue();
+  });
+
+  // The confirmation screen's SubmissionAssistant POSTs here on mount. Report a
+  // successful automated filing so it lands in a stable "submitted" state.
+  await page.route("**/api/reports/*/submit", (route) =>
+    route.fulfill({
+      json: {
+        success: true,
+        data: {
+          reportId: CREATED_REPORT.data.id,
+          status: "SUBMITTED",
+          submitted: true,
+          externalTrackingId: "TRK-STUB-1",
+        },
+      },
+    }),
+  );
+}
+
+test("records the full guest report workflow end to end", async ({ page }) => {
+  await stubReportRoutes(page);
+
+  // --- Home -> /report -------------------------------------------------------
+  // Enter via the homepage CTA so the video opens on the real landing page and
+  // exercises the actual navigation a first-time visitor takes.
+  await page.goto("/");
+  await page
+    .getByRole("link", { name: /report an issue/i })
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/report$/);
+
+  // --- Describe step ---------------------------------------------------------
+  // The mic toggle also carries a "...description" aria-label, so target the
+  // textbox by its exact accessible name rather than a substring match.
+  const description = page.getByRole("textbox", { name: "Description" });
+  await description.fill(
+    "Large pothole on Main St near the crosswalk, deep enough to damage a tire.",
+  );
+
+  // Stubbed photo: attach a tiny in-memory PNG to the hidden file input so the
+  // capture includes an image without reading from disk. The page wires the
+  // file input's change handler through use-image-upload; a valid PNG keeps that
+  // pipeline happy while staying fully offline.
+  const onePngPixel = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  await page.setInputFiles("#photo-input", {
+    name: "pothole.png",
+    mimeType: "image/png",
+    buffer: onePngPixel,
+  });
+
+  // Type a partial address to trigger the (stubbed) suggestion dropdown, then
+  // pick the suggestion — selecting it sets latitude/longitude offline. A
+  // language <select> in the nav is also a combobox, so scope to the address
+  // input by its accessible name ("Location").
+  const addressInput = page.getByRole("combobox", { name: "Location" });
+  await addressInput.fill("123 Main");
+  const suggestion = page.getByRole("option", { name: /123 Main St/i });
+  await expect(suggestion).toBeVisible();
+  await suggestion.click();
+
+  // GPS coordinates from the selected suggestion now render on the describe step.
+  await expect(page.getByText(/GPS:\s*37\.422/)).toBeVisible();
+
+  // Trigger classification (stubbed) -> advances to the review step.
+  await page.getByRole("button", { name: /analyze issue/i }).click();
+
+  // --- Review step -----------------------------------------------------------
+  // The classified issue type + AI description are rendered for the user to confirm.
+  await expect(page.getByText(/road damage/i).first()).toBeVisible();
+  await expect(page.getByText(/large pothole in the roadway/i)).toBeVisible();
+
+  // Confirm and submit (stubbed POST /api/reports).
+  await page.getByRole("button", { name: /^submit report$/i }).click();
+
+  // --- Confirmed / submission step (terminal state) --------------------------
+  // Acceptance: the confirmation screen shows the created report id, and the
+  // SubmissionAssistant (stubbed /submit) has run. This is the final frame of
+  // the recorded walkthrough.
+  await expect(page.getByText(/report submitted!/i)).toBeVisible();
+  await expect(page.getByText(CREATED_REPORT.data.id)).toBeVisible();
+});

--- a/nexa/playwright.config.ts
+++ b/nexa/playwright.config.ts
@@ -27,8 +27,21 @@ export default defineConfig({
   },
   projects: [
     {
+      // Default project: every spec EXCEPT the dedicated video walkthrough.
+      // Leaves the existing CI e2e behaviour untouched (video only retained on
+      // failure, per `use.video` above).
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      testIgnore: /full-workflow\.spec\.ts/,
+    },
+    {
+      // Dedicated project for the end-to-end walkthrough (#220). `video: "on"`
+      // ALWAYS records a webm for this spec — pass or fail — and that recording
+      // is the deliverable. Scoped to this single file so the rest of the suite
+      // (and its CI expectations) keep the default `retain-on-failure`.
+      name: "full-workflow-video",
+      testMatch: /full-workflow\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"], video: "on" },
     },
   ],
   webServer: {


### PR DESCRIPTION
Closes #220.

## What

Adds a dedicated Playwright e2e spec whose **video recording is the deliverable**: a webm of the complete guest report workflow, recorded end to end.

- **`nexa/e2e/full-workflow.spec.ts`** — walks the full guest loop: home → "Report an Issue" → `/report` → describe (text + stubbed photo + stubbed address/location, with GPS asserted) → Analyze Issue (classify) → review (issue type + AI description) → Submit Report → confirmation/submission step (asserts on the created report id). Every browser network call (`/api/auth/me`, `/api/reports/classify`, `/api/reports/form-link`, `/api/reports/agency-candidates`, `/api/location/suggest`, `POST /api/reports`, `/api/reports/*/submit`) is stubbed via `page.route`, so the run is deterministic and fully offline — no LLM, geocoding, agency routing, Open311, or DB.
- **`nexa/playwright.config.ts`** — adds a dedicated `full-workflow-video` project with `use.video: "on"` that matches only this spec, so a webm is **always** recorded (pass or fail). The default `chromium` project ignores the file via `testIgnore` and keeps `video: "retain-on-failure"`, so the existing CI e2e job's behaviour and expectations are unchanged.
- **`nexa/e2e/README.md`** — documents all e2e specs, where the video lands, and how to view it.

No app code changed.

## Video artifact

After `npm run test:e2e`, the recording is written under the git-ignored `test-results/`:

```
nexa/test-results/full-workflow-records-the--9757f--report-workflow-end-to-end-full-workflow-video/video.webm
```

Find it regardless of slug: `find test-results -name video.webm`. View with `open <path>/video.webm`, a browser, or `npx playwright show-report`.

## Verification (local, in worktree)

- `npm run test:e2e` → **8 passed**, including the `full-workflow-video` spec.
- Video produced: `test-results/.../full-workflow-video/video.webm` (~85 KB webm). Verified via `find test-results -name video.webm`.
- `tsc --noEmit` → clean (after `prisma generate`).
- `npm run test:coverage` → exits **0** (e2e excluded from coverage).

Do not merge yet.