### PR TITLE
feat(devops): warn at startup when soft-required env vars are missing [#242]

### DIFF
--- a/nexa/src/app/api/health/route.test.ts
+++ b/nexa/src/app/api/health/route.test.ts
@@ -13,7 +13,7 @@ describe("GET /api/health", () => {
     vi.restoreAllMocks();
   });
 
-  it("responds 200 with status ok when the DB probe succeeds", async () => {
+  it("responds 200 with status ok plus a secret-free features map when the DB probe succeeds", async () => {
     // Arrange: SELECT 1 resolves.
     prismaMock.$queryRaw.mockResolvedValue([{ "?column?": 1 }]);
 
@@ -22,10 +22,27 @@ describe("GET /api/health", () => {
 
     // Assert
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      success: true,
-      data: { status: "ok", database: "ok" },
+    const body = (await response.json()) as {
+      success: boolean;
+      data: {
+        status: string;
+        database: string;
+        features: Record<string, boolean>;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe("ok");
+    expect(body.data.database).toBe("ok");
+    // The features map reports the soft-required gates (issue #242) as booleans
+    // only — it must never leak a key value.
+    expect(body.data.features).toEqual({
+      telemetry: expect.any(Boolean),
+      emailSubmission: expect.any(Boolean),
+      aiClassification: expect.any(Boolean),
+      addressAutocomplete: expect.any(Boolean),
+      statusPollingCron: expect.any(Boolean),
     });
+    expect(JSON.stringify(body.data.features)).not.toMatch(/sk-|key|secret/i);
   });
 
   it("responds 503 when the DB probe throws", async () => {

--- a/nexa/src/app/api/health/route.ts
+++ b/nexa/src/app/api/health/route.ts
@@ -1,4 +1,5 @@
 import { errorResponse, successResponse } from "@/lib/api/response";
+import { getConfiguredFeatures } from "@/lib/config";
 import { prisma } from "@/lib/prisma";
 
 // GET /api/health
@@ -8,9 +9,12 @@ import { prisma } from "@/lib/prisma";
 // `SELECT 1`, so an external monitor (e.g. Vercel/UptimeRobot) can distinguish a
 // healthy app from one whose DB is unreachable.
 //
-// Returns 200 `{ success: true, data: { status: "ok", database: "ok" } }` when
-// the DB responds, and 503 `{ success: false, error, code: "db_unreachable" }`
-// when it does not.
+// Returns 200 `{ success: true, data: { status: "ok", database: "ok",
+// features: { … } } }` when the DB responds, and 503 `{ success: false, error,
+// code: "db_unreachable" }` when it does not. The `features` map (issue #242)
+// reports which soft-required, feature-gating env vars are configured — booleans
+// only, never the secret values — so ops can spot a deploy that is "up" but
+// silently missing telemetry / email / maps / cron config.
 
 // Bound the probe so a hung connection can't make the health check itself hang.
 const DB_PROBE_TIMEOUT_MS = 5_000;
@@ -22,7 +26,11 @@ export async function GET() {
     return errorResponse("Database unreachable", 503, "db_unreachable");
   }
 
-  return successResponse({ status: "ok", database: "ok" });
+  return successResponse({
+    status: "ok",
+    database: "ok",
+    features: getConfiguredFeatures(),
+  });
 }
 
 /**

--- a/nexa/src/instrumentation.test.ts
+++ b/nexa/src/instrumentation.test.ts
@@ -43,3 +43,93 @@ describe("instrumentation (error-tracking hook)", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+// --- Soft-required env warnings at startup (issue #242) --------------------
+const SOFT_REQUIRED_VARS = [
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "RESEND_API_KEY",
+  "SUBMISSION_FROM_EMAIL",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_MAPS_API_KEY",
+  "CRON_SECRET",
+] as const;
+
+describe("register: soft-required env warnings", () => {
+  const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+  // NODE_ENV is typed read-only; assign through a widened view (mirrors test/env.ts).
+  const env = process.env as Record<string, string | undefined>;
+  const ORIGINAL_NODE_ENV = env.NODE_ENV;
+  const ORIGINAL_SOFT: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    delete process.env.VERCEL_ENV;
+    for (const name of SOFT_REQUIRED_VARS) {
+      ORIGINAL_SOFT[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_VERCEL_ENV === undefined) delete process.env.VERCEL_ENV;
+    else process.env.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
+    env.NODE_ENV = ORIGINAL_NODE_ENV;
+    for (const name of SOFT_REQUIRED_VARS) {
+      const original = ORIGINAL_SOFT[name];
+      if (original === undefined) delete process.env[name];
+      else process.env[name] = original;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("logs a [config] WARNING per unset soft-required var in production", async () => {
+    process.env.VERCEL_ENV = "production";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { register } = await loadInstrumentation();
+    await register();
+
+    const lines = warn.mock.calls.map((c) => String(c[0]));
+    // One line per unset feature gate (telemetry, email, AI, maps, cron).
+    const configLines = lines.filter((l) => l.startsWith("[config] WARNING:"));
+    expect(configLines).toHaveLength(5);
+    expect(configLines.join("\n")).toContain("NEXT_PUBLIC_POSTHOG_KEY");
+    expect(configLines.join("\n")).toContain("AI classification unavailable");
+    expect(configLines.join("\n")).toContain("CRON_SECRET");
+  });
+
+  it("does NOT warn outside production even when vars are unset", async () => {
+    env.NODE_ENV = "development";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { register } = await loadInstrumentation();
+    await register();
+
+    expect(
+      warn.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.startsWith("[config] WARNING:")),
+    ).toHaveLength(0);
+  });
+
+  it("emits no [config] warnings in production once every var is configured", async () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_x";
+    process.env.RESEND_API_KEY = "re_x";
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.test";
+    process.env.OPENAI_API_KEY = "sk-x";
+    process.env.GOOGLE_MAPS_API_KEY = "maps-x";
+    process.env.CRON_SECRET = "cron-x";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { register } = await loadInstrumentation();
+    await register();
+
+    expect(
+      warn.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.startsWith("[config] WARNING:")),
+    ).toHaveLength(0);
+  });
+});

--- a/nexa/src/instrumentation.ts
+++ b/nexa/src/instrumentation.ts
@@ -17,9 +17,38 @@
  */
 import type { Instrumentation } from "next";
 
-import { getSentryDsn } from "@/lib/config";
+import { getSentryDsn, getSoftRequiredEnvWarnings } from "@/lib/config";
 
 const ALERT_PREFIX = "[instrumentation][ALERT]";
+
+/**
+ * Greppable marker for the soft-required env audit (issue #242). A single,
+ * consistent prefix means ops can alert on `[config] WARNING` across logs.
+ */
+const CONFIG_WARNING_PREFIX = "[config] WARNING:";
+
+/**
+ * True only on a real production deploy. Soft-required env vars are expected to
+ * be unset in dev/test (and during the build), so warning there would be noise —
+ * we only surface them where a missing key is an actual misconfiguration.
+ * Mirrors the env resolution used for Sentry's `environment` above.
+ */
+function isProduction(): boolean {
+  return (process.env.VERCEL_ENV ?? process.env.NODE_ENV) === "production";
+}
+
+/**
+ * Log one `[config] WARNING: …` line per unset soft-required env var, naming the
+ * feature it disables. Production-only and never throws — purely informational
+ * ops visibility. Hard-required vars (DATABASE_URL, JWT_SECRET) are unaffected;
+ * they still fail fast through `requireEnv` in `config.ts`.
+ */
+function warnOnMissingSoftRequiredEnv(): void {
+  if (!isProduction()) return;
+  for (const impact of getSoftRequiredEnvWarnings()) {
+    console.warn(`${CONFIG_WARNING_PREFIX} ${impact}`);
+  }
+}
 
 /**
  * Minimal structural type for the bits of `@sentry/nextjs` we touch. Declared
@@ -72,9 +101,12 @@ async function loadSentry(): Promise<SentryModule | null> {
 }
 
 /**
- * Called once per server instance. No-op unless `SENTRY_DSN` is set.
+ * Called once per server instance. Initializes Sentry when `SENTRY_DSN` is set
+ * (a no-op otherwise) and, in production, audits the soft-required env vars,
+ * logging a `[config] WARNING: …` line for each unset one (issue #242).
  */
 export async function register(): Promise<void> {
+  warnOnMissingSoftRequiredEnv();
   await loadSentry();
 }
 

--- a/nexa/src/lib/config.test.ts
+++ b/nexa/src/lib/config.test.ts
@@ -77,3 +77,100 @@ describe("getSentryDsn", () => {
     expect(getSentryDsn()).toBe("https://abc@o0.ingest.sentry.io/1");
   });
 });
+
+// --- Soft-required env audit (issue #242) ----------------------------------
+//
+// These functions read process.env directly (not the cached getters), so a
+// fresh import is unnecessary — but every var must be set/cleared per case to
+// keep the audit deterministic regardless of the ambient test environment.
+const SOFT_REQUIRED_VARS = [
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "RESEND_API_KEY",
+  "SUBMISSION_FROM_EMAIL",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_MAPS_API_KEY",
+  "CRON_SECRET",
+] as const;
+
+describe("soft-required env audit", () => {
+  const ORIGINAL_SOFT: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const name of SOFT_REQUIRED_VARS) {
+      ORIGINAL_SOFT[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of SOFT_REQUIRED_VARS) {
+      const original = ORIGINAL_SOFT[name];
+      if (original === undefined) delete process.env[name];
+      else process.env[name] = original;
+    }
+  });
+
+  it("warns about every soft-required feature when all vars are unset", async () => {
+    const { getSoftRequiredEnvWarnings } = await import("./config");
+    const warnings = getSoftRequiredEnvWarnings();
+    expect(warnings).toHaveLength(5);
+    expect(warnings.join("\n")).toContain("NEXT_PUBLIC_POSTHOG_KEY");
+    expect(warnings.join("\n")).toContain("RESEND_API_KEY");
+    expect(warnings.join("\n")).toContain("AI classification unavailable");
+    expect(warnings.join("\n")).toContain("GOOGLE_MAPS_API_KEY");
+    expect(warnings.join("\n")).toContain("CRON_SECRET");
+  });
+
+  it("emits no warnings once every soft-required var is configured", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_x";
+    process.env.RESEND_API_KEY = "re_x";
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.test";
+    process.env.OPENAI_API_KEY = "sk-x";
+    process.env.GOOGLE_MAPS_API_KEY = "maps-x";
+    process.env.CRON_SECRET = "cron-x";
+    const { getSoftRequiredEnvWarnings } = await import("./config");
+    expect(getSoftRequiredEnvWarnings()).toEqual([]);
+  });
+
+  it("requires BOTH RESEND_API_KEY and SUBMISSION_FROM_EMAIL for emailSubmission", async () => {
+    process.env.RESEND_API_KEY = "re_x"; // only one of the pair
+    const { getConfiguredFeatures, getSoftRequiredEnvWarnings } =
+      await import("./config");
+    expect(getConfiguredFeatures().emailSubmission).toBe(false);
+    expect(getSoftRequiredEnvWarnings().join("\n")).toContain(
+      "EMAIL-intake agencies degrade to manual-assist",
+    );
+  });
+
+  it("treats ANY one AI provider key as sufficient for classification", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-x";
+    const { getConfiguredFeatures, getSoftRequiredEnvWarnings } =
+      await import("./config");
+    expect(getConfiguredFeatures().aiClassification).toBe(true);
+    expect(getSoftRequiredEnvWarnings().join("\n")).not.toContain(
+      "AI classification unavailable",
+    );
+  });
+
+  it("treats whitespace-only values as unset", async () => {
+    process.env.CRON_SECRET = "   ";
+    const { getConfiguredFeatures } = await import("./config");
+    expect(getConfiguredFeatures().statusPollingCron).toBe(false);
+  });
+
+  it("exposes a secret-free boolean feature map (no values leaked)", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_supersecret";
+    const { getConfiguredFeatures } = await import("./config");
+    const features = getConfiguredFeatures();
+    expect(features).toEqual({
+      telemetry: true,
+      emailSubmission: false,
+      aiClassification: false,
+      addressAutocomplete: false,
+      statusPollingCron: false,
+    });
+    expect(JSON.stringify(features)).not.toContain("phc_supersecret");
+  });
+});

--- a/nexa/src/lib/config.ts
+++ b/nexa/src/lib/config.ts
@@ -201,3 +201,106 @@ export const getDuplicateWindowHours = cached(() =>
     DEFAULT_DUPLICATE_WINDOW_HOURS,
   ),
 );
+
+// --- Soft-required configuration audit (issue #242) ------------------------
+//
+// Hard-required vars (DATABASE_URL, JWT_SECRET) fail fast via requireEnv above:
+// the app genuinely cannot run without them. A second tier of "soft-required"
+// vars are individually optional — each gates a feature that degrades quietly
+// when the var is unset — but in a real production deploy their absence is
+// almost always a misconfiguration (KPIs go uncollected, EMAIL agencies never
+// auto-send, etc.). They must never fail the build, but they SHOULD be visible.
+//
+// `getSoftRequiredEnvWarnings()` computes the audit once (read directly from
+// `process.env`, not the memoized getters, so it reflects the live environment
+// at the moment it is called) and `src/instrumentation.ts` logs each warning at
+// startup in production. `getConfiguredFeatures()` exposes the same audit as a
+// boolean map for `/api/health` WITHOUT leaking any secret values.
+
+/** A soft-required feature gate: whether it is configured + why it matters. */
+export interface SoftRequiredFeature {
+  /** Stable feature key, also used in the `/api/health` `features` map. */
+  feature: string;
+  /** `true` when the env var(s) backing this feature are present. */
+  configured: boolean;
+  /** One-line, secret-free description of what breaks when it is unset. */
+  impact: string;
+}
+
+/** True when any of the named env vars holds a non-empty (trimmed) value. */
+function anyEnvSet(...names: string[]): boolean {
+  return names.some((name) => {
+    const value = process.env[name]?.trim();
+    return value !== undefined && value !== "";
+  });
+}
+
+/**
+ * Audit the soft-required configuration against the live environment. Returns
+ * one entry per feature gate, in a stable order, marking each as configured or
+ * not and describing the impact of it being unset. Reads `process.env` directly
+ * (not the cached getters) so it always reflects the current environment.
+ */
+export function getSoftRequiredFeatures(): SoftRequiredFeature[] {
+  return [
+    {
+      feature: "telemetry",
+      configured: anyEnvSet("NEXT_PUBLIC_POSTHOG_KEY"),
+      impact:
+        "NEXT_PUBLIC_POSTHOG_KEY is unset — time-to-submit / KPI telemetry disabled.",
+    },
+    {
+      feature: "emailSubmission",
+      // Both are required for the EMAIL-intake agent to auto-send (see
+      // src/lib/submission/email.ts); either one missing degrades to manual.
+      configured:
+        anyEnvSet("RESEND_API_KEY") && anyEnvSet("SUBMISSION_FROM_EMAIL"),
+      impact:
+        "RESEND_API_KEY / SUBMISSION_FROM_EMAIL unset — EMAIL-intake agencies degrade to manual-assist; no auto-send.",
+    },
+    {
+      feature: "aiClassification",
+      // Any one provider key is enough to run classification.
+      configured: anyEnvSet(
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+      ),
+      impact:
+        "No OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY set — AI classification unavailable.",
+    },
+    {
+      feature: "addressAutocomplete",
+      configured: anyEnvSet("GOOGLE_MAPS_API_KEY"),
+      impact:
+        "GOOGLE_MAPS_API_KEY is unset — address autocomplete falls back to Nominatim.",
+    },
+    {
+      feature: "statusPollingCron",
+      configured: anyEnvSet("CRON_SECRET"),
+      impact:
+        "CRON_SECRET is unset — status-polling cron disabled / fails closed.",
+    },
+  ];
+}
+
+/**
+ * The unset soft-required features, ready to log as warnings at startup. Each
+ * `impact` string is prefixed by the caller with a single greppable marker.
+ */
+export function getSoftRequiredEnvWarnings(): string[] {
+  return getSoftRequiredFeatures()
+    .filter((f) => !f.configured)
+    .map((f) => f.impact);
+}
+
+/**
+ * A secret-free boolean map of which soft-required features are configured,
+ * suitable for surfacing in `/api/health`. Only reports presence — never the
+ * value of any key.
+ */
+export function getConfiguredFeatures(): Record<string, boolean> {
+  return Object.fromEntries(
+    getSoftRequiredFeatures().map((f) => [f.feature, f.configured]),
+  );
+}


### PR DESCRIPTION
Closes #242.

## Problem
A production deploy can look healthy while KPIs go uncollected and EMAIL-intake agencies never auto-send, simply because a soft-required env var is unset. Nothing surfaces the gap.

## Change
Adds a startup audit that distinguishes **hard-required** vars (`DATABASE_URL`, `JWT_SECRET` — still fail fast via `requireEnv`, unchanged) from a **soft-required** tier that degrades features quietly when unset.

- **`src/lib/config.ts`** — `getSoftRequiredFeatures()` / `getSoftRequiredEnvWarnings()` / `getConfiguredFeatures()`. Reads `process.env` directly (not the memoized getters) so the audit reflects the live environment.
- **`src/instrumentation.ts`** — `register()` now logs one greppable `[config] WARNING: ...` line per unset soft-required var, **production only** (`VERCEL_ENV`/`NODE_ENV === "production"`). Never throws; additive to the existing Sentry hook.
- **`/api/health`** — success payload gains a secret-free `features` boolean map (`{ telemetry, emailSubmission, aiClassification, addressAutocomplete, statusPollingCron }`) so an ops monitor can spot an up-but-misconfigured deploy. No key values are exposed.

## Warnings added (logged when unset, in prod)
| feature | var(s) | impact |
|---|---|---|
| telemetry | `NEXT_PUBLIC_POSTHOG_KEY` | time-to-submit / KPI telemetry disabled |
| emailSubmission | `RESEND_API_KEY` + `SUBMISSION_FROM_EMAIL` (both) | EMAIL-intake agencies degrade to manual-assist; no auto-send |
| aiClassification | one of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` | AI classification unavailable |
| addressAutocomplete | `GOOGLE_MAPS_API_KEY` | address autocomplete falls back to Nominatim |
| statusPollingCron | `CRON_SECRET` | status-polling cron disabled / fails closed |

## Tests
- `config.test.ts`: all-unset warns 5 features; all-set warns none; email needs BOTH keys; AI needs ANY one; whitespace-only treated as unset; feature map leaks no values.
- `instrumentation.test.ts`: one `[config] WARNING` per unset var in prod; no warnings outside prod; none when fully configured.
- `health/route.test.ts`: asserts the secret-free `features` map shape.

## CI
`npx tsc --noEmit`, `npm run lint`, `npm run format:check` all clean; `npm run test:coverage` exits 0 (780 tests pass, coverage gate satisfied).