### PR TITLE
feat(data): persist Report.submittedAt on submission so time-to-submit is DB-recoverable [#241]

### DIFF
--- a/nexa/prisma/migrations/20260610000000_add_report_submitted_at/migration.sql
+++ b/nexa/prisma/migrations/20260610000000_add_report_submitted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Report" ADD COLUMN     "submittedAt" TIMESTAMP(3);

--- a/nexa/prisma/schema.prisma
+++ b/nexa/prisma/schema.prisma
@@ -58,6 +58,11 @@ model Report {
   agencyId           String?
   agency             Agency?      @relation(fields: [agencyId], references: [id])
   externalTrackingId String?
+  // When the report was successfully filed with an agency (the SUBMITTING ->
+  // SUBMITTED transition in src/lib/submission/orchestrate.ts). Persisting this
+  // makes time-to-submit (submittedAt - createdAt) recoverable from the DB
+  // rather than only from the client PostHog event. Null until submitted.
+  submittedAt        DateTime?
   userResolved       Boolean?
   userResolvedAt     DateTime?
   issueGroupId       String?

--- a/nexa/src/lib/admin/analytics.test.ts
+++ b/nexa/src/lib/admin/analytics.test.ts
@@ -98,10 +98,11 @@ describe("computeTimeToSubmit", () => {
     });
   });
 
-  it("computes rounded median and p90 seconds from createdAt..updatedAt", () => {
+  it("computes rounded median and p90 seconds from createdAt..submittedAt", () => {
     const rows = [10, 20, 30, 40].map((s) => ({
       createdAt: base,
-      updatedAt: plus(s),
+      updatedAt: plus(s + 1000), // ignored when submittedAt is present
+      submittedAt: plus(s),
     }));
     const result = computeTimeToSubmit(rows);
     expect(result.count).toBe(4);
@@ -109,10 +110,27 @@ describe("computeTimeToSubmit", () => {
     expect(result.p90Seconds).toBe(37); // 0.9*3=2.7 -> 30+0.7*10=37
   });
 
-  it("drops negative durations (updatedAt before createdAt)", () => {
+  it("prefers submittedAt over updatedAt for the submission time", () => {
+    // updatedAt (a later edit) would give 90s, but submittedAt is exact at 30s.
     const rows = [
-      { createdAt: plus(100), updatedAt: base }, // negative -> dropped
-      { createdAt: base, updatedAt: plus(50) },
+      { createdAt: base, updatedAt: plus(90), submittedAt: plus(30) },
+    ];
+    const result = computeTimeToSubmit(rows);
+    expect(result.count).toBe(1);
+    expect(result.medianSeconds).toBe(30);
+  });
+
+  it("falls back to updatedAt when submittedAt is null (legacy rows)", () => {
+    const rows = [{ createdAt: base, updatedAt: plus(50), submittedAt: null }];
+    const result = computeTimeToSubmit(rows);
+    expect(result.count).toBe(1);
+    expect(result.medianSeconds).toBe(50);
+  });
+
+  it("drops negative durations (submission before createdAt)", () => {
+    const rows = [
+      { createdAt: plus(100), updatedAt: base, submittedAt: base }, // negative -> dropped
+      { createdAt: base, updatedAt: plus(999), submittedAt: plus(50) },
     ];
     const result = computeTimeToSubmit(rows);
     expect(result.count).toBe(1);
@@ -123,7 +141,8 @@ describe("computeTimeToSubmit", () => {
 describe("computeAdminAnalytics", () => {
   it("aggregates counts, breakdowns, timing, and ambiguity via Prisma", async () => {
     const created = new Date("2026-01-01T00:00:00.000Z");
-    const updated = new Date("2026-01-01T00:01:00.000Z"); // +60s
+    const updated = new Date("2026-01-01T00:05:00.000Z"); // +300s (a later edit)
+    const submitted = new Date("2026-01-01T00:01:00.000Z"); // +60s (the real submit)
 
     prismaMock.report.count.mockImplementation((args?: { where?: unknown }) => {
       // No-args call => total; { where: { agencyId: null } } => no-agency count.
@@ -152,7 +171,7 @@ describe("computeAdminAnalytics", () => {
     });
 
     prismaMock.report.findMany.mockResolvedValue([
-      { createdAt: created, updatedAt: updated },
+      { createdAt: created, updatedAt: updated, submittedAt: submitted },
     ] as never);
 
     prismaMock.agency.findMany.mockResolvedValue([

--- a/nexa/src/lib/admin/analytics.ts
+++ b/nexa/src/lib/admin/analytics.ts
@@ -14,8 +14,10 @@ import { ReportStatus } from "@/generated/prisma/enums";
 // Data layer note: this reuses the shared Prisma singleton (no parallel data
 // access) and pushes the heavy lifting into the DB with `groupBy` / `aggregate`
 // rather than pulling every row into the app. The one exception is
-// time-to-submit, which needs per-row `(updatedAt - createdAt)` and so reads a
-// trimmed projection of the submitted-or-later reports.
+// time-to-submit, which needs per-row `(submittedAt - createdAt)` and so reads a
+// trimmed projection of the submitted-or-later reports. `submittedAt` is the
+// timestamp orchestrateSubmission stamps on the SUBMITTED transition (#241); we
+// fall back to `updatedAt` only for rows submitted before that column existed.
 //
 // The pure shaping helpers (rates, percentiles, distribution) are exported so
 // they can be unit-tested without a database.
@@ -145,15 +147,19 @@ export function computeSubmissionRates(
 /**
  * Compute median & p90 time-to-submit (in whole seconds) from a list of
  * creation/submission timestamp pairs. The submission timestamp is the report's
- * `updatedAt` for reports that reached SUBMITTED — an approximation, since
- * `updatedAt` reflects the most recent change, but it's the best signal the
- * schema records. Negative or non-finite durations are dropped defensively.
+ * `submittedAt` — stamped on the SUBMITTED transition (#241) — which is exact.
+ * Rows submitted before that column existed have a null `submittedAt`; for those
+ * we fall back to `updatedAt`, an approximation since it reflects the most recent
+ * change. Negative or non-finite durations are dropped defensively.
  */
 export function computeTimeToSubmit(
-  rows: { createdAt: Date; updatedAt: Date }[],
+  rows: { createdAt: Date; updatedAt: Date; submittedAt: Date | null }[],
 ): TimeToSubmitStats {
   const durations = rows
-    .map((row) => (row.updatedAt.getTime() - row.createdAt.getTime()) / 1000)
+    .map((row) => {
+      const submittedAt = row.submittedAt ?? row.updatedAt;
+      return (submittedAt.getTime() - row.createdAt.getTime()) / 1000;
+    })
     .filter((seconds) => Number.isFinite(seconds) && seconds >= 0);
 
   const median = percentile(durations, 50);
@@ -187,7 +193,7 @@ export async function computeAdminAnalytics(): Promise<AdminAnalytics> {
     prisma.report.count({ where: { agencyId: null } }),
     prisma.report.findMany({
       where: { status: { in: SUBMITTED_STATUSES } },
-      select: { createdAt: true, updatedAt: true },
+      select: { createdAt: true, updatedAt: true, submittedAt: true },
     }),
     prisma.agency.findMany({ select: { id: true, name: true } }),
   ]);

--- a/nexa/src/lib/submission/orchestrate.test.ts
+++ b/nexa/src/lib/submission/orchestrate.test.ts
@@ -95,6 +95,16 @@ describe("orchestrateSubmission — API intake (automated)", () => {
       where: { id: reportId, status: ReportStatus.CONFIRMED },
       data: { status: ReportStatus.SUBMITTING },
     });
+    // Stamped submittedAt on the SUBMITTED transition so time-to-submit is
+    // DB-recoverable (#241).
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: reportId },
+      data: {
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "SR-123",
+        submittedAt: expect.any(Date),
+      },
+    });
   });
 
   it("falls back to the async token when no service_request_id is returned", async () => {
@@ -198,6 +208,9 @@ describe("orchestrateSubmission — non-automated intake (graceful fallback)", (
       expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
       expect(submitToOpen311).not.toHaveBeenCalled();
       expect(submitViaEmail).not.toHaveBeenCalled();
+      // Manual-assist never reaches a SUBMITTED transition, so submittedAt is
+      // never stamped (#241): the report row is left untouched.
+      expect(prismaMock.report.update).not.toHaveBeenCalled();
     },
   );
 });
@@ -244,6 +257,15 @@ describe("orchestrateSubmission — EMAIL intake (email agent, #31)", () => {
     });
     expect(submitViaEmail).toHaveBeenCalledOnce();
     expect(submitToOpen311).not.toHaveBeenCalled();
+    // Stamped submittedAt on the SUBMITTED transition (#241).
+    expect(prismaMock.report.update).toHaveBeenCalledWith({
+      where: { id: reportId },
+      data: {
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "msg-789",
+        submittedAt: expect.any(Date),
+      },
+    });
   });
 
   it("falls back to manual_assist (env-gated off) and rolls back to CONFIRMED", async () => {

--- a/nexa/src/lib/submission/orchestrate.ts
+++ b/nexa/src/lib/submission/orchestrate.ts
@@ -228,6 +228,9 @@ export async function orchestrateSubmission(
         data: {
           status: ReportStatus.SUBMITTED,
           externalTrackingId: emailResult.messageId,
+          // Stamp the submission time so time-to-submit is recoverable from the
+          // DB (submittedAt - createdAt) rather than only from PostHog. (#241)
+          submittedAt: new Date(),
         },
       });
       return {
@@ -290,6 +293,9 @@ export async function orchestrateSubmission(
       // Prefer the immediate id; fall back to the async token until a later
       // poll resolves it to a real service_request_id.
       externalTrackingId: result.serviceRequestId ?? result.token,
+      // Stamp the submission time so time-to-submit is recoverable from the DB
+      // (submittedAt - createdAt) rather than only from PostHog. (#241)
+      submittedAt: new Date(),
     },
   });
 

--- a/nexa/src/test/factories/report.ts
+++ b/nexa/src/test/factories/report.ts
@@ -23,6 +23,7 @@ export function makeReport(overrides: Partial<Report> = {}): Report {
     status: ReportStatus.CONFIRMED,
     agencyId: null,
     externalTrackingId: null,
+    submittedAt: null,
     userResolved: null,
     userResolvedAt: null,
     issueGroupId: null,


### PR DESCRIPTION
Closes #241.

## Problem
Time-to-submit (K2) was recorded **only** via the client PostHog event, which is a no-op unless `NEXT_PUBLIC_POSTHOG_KEY` is set. The `Report` model carried only `createdAt`/`updatedAt`, so with PostHog unconfigured the metric was unrecoverable, and the admin dashboard approximated it with `updatedAt − createdAt` (which drifts with any later edit).

## Changes
- **Schema + migration**: add `Report.submittedAt DateTime?` (`prisma/migrations/20260610000000_add_report_submitted_at/migration.sql`), matching the existing `ADD COLUMN ... TIMESTAMP(3)` format.
- **orchestrate.ts**: stamp `submittedAt = new Date()` on the `SUBMITTING → SUBMITTED` transition for **both** the Open311 (API) and EMAIL success paths — exactly where `externalTrackingId` is stored. Manual-assist and rollback paths leave it null (no parallel path; reuses the existing transition).
- **analytics.ts**: `computeTimeToSubmit` now derives the duration from `submittedAt − createdAt`, falling back to `updatedAt` only for legacy rows where `submittedAt` is null. The dashboard median/p90 is now exact and PostHog-independent.
- **Tests**: orchestrate stamps `submittedAt` on SUBMITTED (API + EMAIL) and never on manual-assist; analytics prefers `submittedAt`, falls back when null, and `computeAdminAnalytics` proves it uses `submittedAt` over a later `updatedAt`.

## Verification
- `npm run test:coverage` → exit 0 (74 files, 783 tests passed)
- `npx tsc --noEmit` clean
- `npm run lint` → 0 errors (only pre-existing warnings)
- `npm run format:check` clean
- Migration SQL matches the Prisma-generated format for a nullable `DateTime` column.

Serves K2 durability.