### PR TITLE
fix(telemetry): emit timed report_submitted on real agency submission, not report creation [#240]

### DIFF
--- a/nexa/docs/metrics/time-to-submit.md
+++ b/nexa/docs/metrics/time-to-submit.md
@@ -7,21 +7,35 @@ O1.KR2 / K2 service-level objectives.
 
 - **Source event:** `report_submitted` (PostHog), property `time_to_submit_ms`.
 - **Interval:** from the user's first capture action (first photo, or first
-  keystroke of the description) through a successful submit. This span
-  **includes** classification latency, matching the OKR definition of
-  capture → submitted.
-- **Stage event:** `report_classified` fires when classification completes, so
-  the capture → classify and classify → submit sub-stages remain queryable.
+  keystroke of the description) through the report being **actually filed with
+  the agency** (a real API/EMAIL submission). This span **includes**
+  classification latency, matching the OKR definition of capture → submitted.
+- **Emit point (#240):** `report_submitted` fires when the agency submission
+  succeeds — `SubmissionAssistant` (`src/components/report/submission-assistant.tsx`)
+  observes the `POST /api/reports/[id]/submit` response with `submitted=true`.
+  It does **not** fire at report creation/CONFIRMED, and it does **not** fire for
+  manual-assist (WEB_FORM/PHONE) agencies, whose reports stay CONFIRMED and are
+  never auto-submitted. Earlier the timed event was emitted in the report-page
+  create `onSuccess`, which measured capture → CONFIRMED and over-counted
+  manual-assist reports; that path now emits `report_created` instead.
+- **Stage events:** `report_classified` fires when classification completes and
+  `report_created` fires when the report row is created/CONFIRMED, so the
+  capture → classify, classify → create, and create → submit sub-stages remain
+  queryable. `report_created` carries `time_to_confirm_ms` (capture → CONFIRMED)
+  but is intentionally NOT the timed K2 event.
 
 These event names and property keys are the ones actually emitted by the app —
-see `src/app/report/page.tsx` (`posthog?.capture("report_classified", …)` and
-`posthog?.capture("report_submitted", { … time_to_submit_ms … })`). The clock
+see `src/app/report/page.tsx` (`report_classified`, `report_created`) and
+`src/components/report/submission-assistant.tsx`
+(`posthog?.capture("report_submitted", { … time_to_submit_ms … })`). The clock
 (`flowStartedAt`) is started by `markCaptureStart()` on the first photo or first
-description keystroke. The event payloads are:
+description keystroke and threaded through to the submission assistant. The event
+payloads are:
 
 | Event               | Properties                                                                             |
 | ------------------- | -------------------------------------------------------------------------------------- |
 | `report_submitted`  | `report_id`, `issue_type`, `time_to_submit_ms`, `has_image`, `has_location`, `offline` |
+| `report_created`    | `report_id`, `issue_type`, `time_to_confirm_ms`, `has_image`, `has_location`           |
 | `report_classified` | `issue_type`, `severity`, `has_image`, `has_location`                                  |
 
 ### Offline submissions (#237)

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -35,6 +35,13 @@ export default function ReportPage() {
   const [step, setStep] = useState<ReportStep>("describe");
   const [description, setDescription] = useState("");
 
+  // Snapshot of `flowStartedAt` taken when the report row is created/CONFIRMED.
+  // Held in state (not read off the ref during render) so it can be threaded to
+  // the confirmed step's SubmissionAssistant, which emits the timed K2
+  // `report_submitted` on the real agency submission (#240). React forbids
+  // reading a ref's value during render, hence the snapshot here.
+  const [submitCaptureStart, setSubmitCaptureStart] = useState(0);
+
   // When routing is ambiguous (more than one agency covers the location + issue
   // type), the review step lets the user pick one; we hold their choice here and
   // pass it to the create route, which validates it server-side.
@@ -179,14 +186,25 @@ export default function ReportPage() {
           if (isLoggedIn === false) {
             addPendingReportId(report.id);
           }
-          // Guard against an unstarted clock (0) so we never emit an
-          // epoch-sized interval; in practice a submit always follows a
-          // capture, so the fallback is defensive only.
+          // Creation/CONFIRMED — NOT the K2 submit event. The timed
+          // `report_submitted` (with `time_to_submit_ms`) is emitted later, by
+          // SubmissionAssistant, only when the report is ACTUALLY filed with the
+          // agency (API/EMAIL submit returns submitted=true). Emitting it here
+          // would measure capture -> CONFIRMED and fire even for WEB_FORM/PHONE
+          // agencies that never auto-submit (#240). We keep a creation event for
+          // funnel analytics — without `time_to_submit_ms` — and record
+          // `time_to_confirm_ms` (capture -> CONFIRMED) as a separate, distinctly
+          // named metric. Guard against an unstarted clock (0) so we never emit an
+          // epoch-sized interval; in practice a submit always follows a capture,
+          // so the fallback is defensive only.
           const captureStart = flowStartedAt.current || Date.now();
-          posthog?.capture("report_submitted", {
+          // Hand the clock-start to the confirmed step so SubmissionAssistant can
+          // emit the timed `report_submitted` from the same first-capture anchor.
+          setSubmitCaptureStart(captureStart);
+          posthog?.capture("report_created", {
             report_id: report.id,
             issue_type: classification.issueType,
-            time_to_submit_ms: Date.now() - captureStart,
+            time_to_confirm_ms: Date.now() - captureStart,
             has_image: !!image.imageBase64,
             has_location: !!geo.latitude,
           });
@@ -221,6 +239,7 @@ export default function ReportPage() {
   const resetForm = () => {
     // Re-arm the clock: the next capture action starts a fresh interval.
     flowStartedAt.current = 0;
+    setSubmitCaptureStart(0);
     setStep("describe");
     setDescription("");
     image.clearImage();
@@ -361,6 +380,14 @@ export default function ReportPage() {
             report={submission.createdReport}
             offline={submission.submittedOffline}
             isLoggedIn={isLoggedIn}
+            // First-capture timestamp (the K2 clock start) plus the capture
+            // context. Threaded down to SubmissionAssistant so the timed
+            // `report_submitted` it emits on a real agency submission measures
+            // capture -> SUBMITTED and carries the same has_image/has_location
+            // dimensions as the online/offline emits (#240).
+            captureStartedAt={submitCaptureStart}
+            hasImage={!!image.imageBase64}
+            hasLocation={!!geo.latitude}
             onReportAnother={resetForm}
           />
         )}

--- a/nexa/src/components/report/confirmed-step.tsx
+++ b/nexa/src/components/report/confirmed-step.tsx
@@ -20,6 +20,18 @@ interface ConfirmedStepProps {
    * user is a guest (`false`), never speculatively.
    */
   isLoggedIn?: boolean;
+  /**
+   * The report page's first-capture timestamp (`flowStartedAt`), i.e. the K2
+   * clock start. Forwarded to {@link SubmissionAssistant} so the timed
+   * `report_submitted` event it emits on a real agency submission measures the
+   * full capture -> SUBMITTED interval (#240). Omitted/0 means the clock never
+   * started; the assistant falls back to its own observation time.
+   */
+  captureStartedAt?: number;
+  /** Whether the report carried a photo — passed through for K2 event parity. */
+  hasImage?: boolean;
+  /** Whether the report carried a location — passed through for K2 event parity. */
+  hasLocation?: boolean;
   onReportAnother: () => void;
 }
 
@@ -27,6 +39,9 @@ export function ConfirmedStep({
   report,
   offline = false,
   isLoggedIn,
+  captureStartedAt,
+  hasImage,
+  hasLocation,
   onReportAnother,
 }: ConfirmedStepProps) {
   const { t, locale } = useI18n();
@@ -102,7 +117,15 @@ export function ConfirmedStep({
         </div>
       </div>
 
-      {!offline && <SubmissionAssistant reportId={report.id} />}
+      {!offline && (
+        <SubmissionAssistant
+          reportId={report.id}
+          issueType={report.issueType}
+          captureStartedAt={captureStartedAt}
+          hasImage={hasImage}
+          hasLocation={hasLocation}
+        />
+      )}
 
       {showUpgradePrompt && (
         <div className="ep-card w-full max-w-md p-6 text-left">

--- a/nexa/src/components/report/submission-assistant.test.tsx
+++ b/nexa/src/components/report/submission-assistant.test.tsx
@@ -19,7 +19,10 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture }),
 }));
 
-function submitResponse(submitted: boolean, extra: Record<string, unknown> = {}) {
+function submitResponse(
+  submitted: boolean,
+  extra: Record<string, unknown> = {},
+) {
   return {
     success: true,
     data: {
@@ -39,9 +42,12 @@ describe("SubmissionAssistant K2 emit (#240)", () => {
   it("emits report_submitted with time_to_submit_ms on a real agency submission", async () => {
     // Arrange: the orchestrator reports a real API/EMAIL submission.
     server.use(
-      jsonPost("*/api/reports/:id/submit", submitResponse(true, {
-        externalTrackingId: "TRK-1",
-      })),
+      jsonPost(
+        "*/api/reports/:id/submit",
+        submitResponse(true, {
+          externalTrackingId: "TRK-1",
+        }),
+      ),
     );
     const captureStart = Date.now() - 5_000;
 
@@ -57,7 +63,9 @@ describe("SubmissionAssistant K2 emit (#240)", () => {
     );
 
     // Assert: success state + a single timed report_submitted event.
-    expect(await screen.findByText("Filed with the agency")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Filed with the agency"),
+    ).toBeInTheDocument();
     await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
     const [event, props] = capture.mock.calls[0];
     expect(event).toBe("report_submitted");

--- a/nexa/src/components/report/submission-assistant.test.tsx
+++ b/nexa/src/components/report/submission-assistant.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  jsonGet,
+  jsonPost,
+  renderWithProviders,
+  screen,
+  server,
+  waitFor,
+} from "@/test";
+
+import { SubmissionAssistant } from "./submission-assistant";
+
+// The K2 `report_submitted` event is emitted via usePostHog(). PostHogProvider
+// no-ops in tests (no NEXT_PUBLIC_POSTHOG_KEY), so mock the hook to expose a
+// spyable `capture` and assert on the timed event the assistant emits (#240).
+const capture = vi.fn();
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture }),
+}));
+
+function submitResponse(submitted: boolean, extra: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    data: {
+      reportId: "report_abc",
+      status: submitted ? "SUBMITTED" : "CONFIRMED",
+      submitted,
+      ...extra,
+    },
+  };
+}
+
+describe("SubmissionAssistant K2 emit (#240)", () => {
+  beforeEach(() => {
+    capture.mockClear();
+  });
+
+  it("emits report_submitted with time_to_submit_ms on a real agency submission", async () => {
+    // Arrange: the orchestrator reports a real API/EMAIL submission.
+    server.use(
+      jsonPost("*/api/reports/:id/submit", submitResponse(true, {
+        externalTrackingId: "TRK-1",
+      })),
+    );
+    const captureStart = Date.now() - 5_000;
+
+    // Act
+    renderWithProviders(
+      <SubmissionAssistant
+        reportId="report_abc"
+        issueType="ROAD_DAMAGE"
+        captureStartedAt={captureStart}
+        hasImage
+        hasLocation={false}
+      />,
+    );
+
+    // Assert: success state + a single timed report_submitted event.
+    expect(await screen.findByText("Filed with the agency")).toBeInTheDocument();
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+    const [event, props] = capture.mock.calls[0];
+    expect(event).toBe("report_submitted");
+    expect(props).toMatchObject({
+      report_id: "report_abc",
+      issue_type: "ROAD_DAMAGE",
+      has_image: true,
+      has_location: false,
+    });
+    // Measured from first capture -> now (>= the 5s we backdated the clock).
+    expect(props.time_to_submit_ms).toBeGreaterThanOrEqual(5_000);
+    expect(props.time_to_submit_ms).toBeLessThan(60_000);
+  });
+
+  it("does NOT emit report_submitted for manual-assist (CONFIRMED, not submitted)", async () => {
+    // Arrange: WEB_FORM/PHONE agency -> manual assist, report stays CONFIRMED.
+    server.use(
+      jsonPost("*/api/reports/:id/submit", submitResponse(false)),
+      jsonGet("*/api/reports/:id/submission-fields", {
+        agency: null,
+        fields: [],
+      }),
+    );
+
+    // Act
+    renderWithProviders(
+      <SubmissionAssistant reportId="report_abc" issueType="ROAD_DAMAGE" />,
+    );
+
+    // Assert: the manual-assist path resolves and no K2 event is emitted.
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Preparing your filing details…"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("falls back to now() for time_to_submit_ms when the clock never started", async () => {
+    // Arrange: captureStartedAt omitted (0) — defensive fallback path.
+    server.use(jsonPost("*/api/reports/:id/submit", submitResponse(true)));
+
+    // Act
+    renderWithProviders(<SubmissionAssistant reportId="report_abc" />);
+
+    // Assert: still emits with a small, non-negative interval.
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+    const [event, props] = capture.mock.calls[0];
+    expect(event).toBe("report_submitted");
+    expect(props.time_to_submit_ms).toBeGreaterThanOrEqual(0);
+    expect(props.time_to_submit_ms).toBeLessThan(5_000);
+  });
+});

--- a/nexa/src/components/report/submission-assistant.tsx
+++ b/nexa/src/components/report/submission-assistant.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   Check,
   CheckCircle2,
@@ -49,6 +50,24 @@ interface SubmitResponse {
 
 interface SubmissionAssistantProps {
   reportId: string;
+  /**
+   * The report's issue type, surfaced on the K2 `report_submitted` event for
+   * parity with the offline-replay and (former) create-time emits.
+   */
+  issueType?: string | null;
+  /**
+   * The report page's first-capture timestamp (`flowStartedAt`) — the K2 clock
+   * start. When a real agency submission succeeds (API/EMAIL, submitted=true),
+   * `report_submitted` is emitted with `time_to_submit_ms = now - captureStart`,
+   * so the metric measures the full capture -> SUBMITTED loop instead of
+   * capture -> CONFIRMED (#240). Omitted/0 means the clock never started; we
+   * then fall back to the moment the submission is observed (defensive only).
+   */
+  captureStartedAt?: number;
+  /** Whether the report carried a photo — a K2 event dimension. */
+  hasImage?: boolean;
+  /** Whether the report carried a location — a K2 event dimension. */
+  hasLocation?: boolean;
 }
 
 // What the orchestrator told us to do with this report.
@@ -72,10 +91,22 @@ type Outcome =
  *     returns a `manualAssist` result and we fall back to the copy-over guide:
  *     the official form/address plus each field pre-filled.
  */
-export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
+export function SubmissionAssistant({
+  reportId,
+  issueType,
+  captureStartedAt,
+  hasImage,
+  hasLocation,
+}: SubmissionAssistantProps) {
+  const posthog = usePostHog();
   const [outcome, setOutcome] = useState<Outcome>({ kind: "loading" });
   const [fields, setFields] = useState<SubmissionFieldsResponse | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  // K2 `report_submitted` is the moment the report is ACTUALLY filed with the
+  // agency. Guard so a retry or a remount (which re-runs the submit POST) can't
+  // double-count the same report into the metric — it fires once per assistant.
+  const emittedSubmitted = useRef(false);
 
   // Attempt submission once on mount. The orchestrator decides — automated for
   // API intake, manual-assist otherwise — so we don't need to know the agency's
@@ -92,6 +123,24 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
         const payload = (await res.json()) as ApiResponse<SubmitResponse>;
 
         if (payload.success && payload.data.submitted) {
+          // A real agency submission just succeeded (API/EMAIL). Emit the timed
+          // K2 event here — NOT at report creation — so `time_to_submit_ms`
+          // measures capture -> SUBMITTED. Manual-assist (WEB_FORM/PHONE) leaves
+          // the report CONFIRMED and `submitted=false`, so it never reaches this
+          // branch and is correctly excluded (#240). Same PostHog event and
+          // properties the online create path used to emit and the offline
+          // replay emits (lib/offline-queue.ts) — not a parallel path.
+          if (!emittedSubmitted.current) {
+            emittedSubmitted.current = true;
+            const captureStart = captureStartedAt || Date.now();
+            posthog?.capture("report_submitted", {
+              report_id: reportId,
+              ...(issueType ? { issue_type: issueType } : {}),
+              time_to_submit_ms: Date.now() - captureStart,
+              has_image: !!hasImage,
+              has_location: !!hasLocation,
+            });
+          }
           next = {
             kind: "submitted",
             trackingId: payload.data.externalTrackingId,
@@ -118,7 +167,7 @@ export function SubmissionAssistant({ reportId }: SubmissionAssistantProps) {
     return () => {
       cancelled = true;
     };
-  }, [reportId]);
+  }, [reportId, posthog, issueType, captureStartedAt, hasImage, hasLocation]);
 
   // Lazily load the copy-over fields only when we're in the manual-assist path.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #240. The timed K2 event (`report_submitted` with `time_to_submit_ms`) was emitted in the report-page create `onSuccess` — when the report became CONFIRMED, **before** the agency submission. It therefore measured capture → CONFIRMED (not capture → SUBMITTED) and fired even for WEB_FORM/PHONE agencies that never auto-submit, inflating the K2 / O1.KR2 reading.

## What changed

- **`src/app/report/page.tsx`** — the create-time emit is renamed `report_created` (kept for funnel analytics; drops `time_to_submit_ms`, records `time_to_confirm_ms` = capture → CONFIRMED instead). The first-capture timestamp is snapshotted into state and threaded down to the confirmed step.
- **`src/components/report/confirmed-step.tsx`** — forwards `captureStartedAt` / `issueType` / `hasImage` / `hasLocation` to `SubmissionAssistant`.
- **`src/components/report/submission-assistant.tsx`** — emits `report_submitted` with `time_to_submit_ms` (first capture → now) **only** when `POST /api/reports/[id]/submit` returns `submitted=true` (real API/EMAIL submission). Manual-assist (WEB_FORM/PHONE, stays CONFIRMED) does **not** emit. Guarded with a ref so a retry/remount can't double-count.
- **`src/lib/offline-queue.ts`** — unchanged; #237's offline-replay `report_submitted` emit still works.
- **`src/components/report/submission-assistant.test.tsx`** — new tests covering the real-submit emit, the manual-assist no-emit, and the clock-fallback path.
- **`docs/metrics/time-to-submit.md`** — updated to document the new emit point and the `report_created` stage event.

## Where the event now fires

`report_submitted` (timed K2) now fires from `SubmissionAssistant` when the agency submission actually succeeds (`submitted=true`). `report_created` fires at report creation/CONFIRMED for funnel analytics.

## Checks

- `npm run test:coverage` — 795 passed, exits 0
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, exits 0
- `npm run format:check` — clean
- e2e: `chromium` (CI), `k2-measure`, and `full-workflow-video` projects all pass