### PR TITLE
feat(eval): end-to-end agency-accuracy harness (correct-agency-first-try, n>=50) [#247]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,15 @@ jobs:
       - name: Submission-readiness eval (K3 >=90% gate)
         run: npm run eval:readiness
 
+      # O1.KR1 end-to-end agency-accuracy gate (#247). Fully offline, same
+      # in-memory Prisma stub as the readiness eval: the real resolveAgencyId is
+      # driven over the seeded AGENCIES with no network, DB, or LLM. It measures
+      # correct-agency-first-try across the 3 P0 categories (n>=50) and exits
+      # non-zero when accuracy < 80% (mirrors the routing/readiness gates), so
+      # this step fails the job below target.
+      - name: End-to-end agency-accuracy eval (O1.KR1 >=80% gate)
+        run: npm run eval:end-to-end
+
   # Production-build verification (#196). Runs the real `npm run build` so
   # build-time failures (server/client boundary errors, dynamic-import issues,
   # Prisma generate, page-data collection that touches the Prisma singleton) are

--- a/nexa/.gitignore
+++ b/nexa/.gitignore
@@ -54,3 +54,6 @@ next-env.d.ts
 # Exception: the K3 submission-readiness baseline is committed (issue #197) so CI
 # has a checked-in reference point for the >=90% gate.
 !/eval/results/readiness.json
+# Exception: the O1.KR1 end-to-end agency-accuracy baseline is committed (issue
+# #247) so CI has a checked-in reference point for the >=80% gate.
+!/eval/results/end-to-end.json

--- a/nexa/eval/dataset/end-to-end-cases.json
+++ b/nexa/eval/dataset/end-to-end-cases.json
@@ -1,0 +1,506 @@
+[
+  {
+    "id": "palo-alto-road_damage-01",
+    "latitude": 37.35109,
+    "longitude": -122.19389,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-road_damage-02",
+    "latitude": 37.36378,
+    "longitude": -122.19389,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-road_damage-03",
+    "latitude": 37.37646,
+    "longitude": -122.19389,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-illegal_dumping-04",
+    "latitude": 37.33841,
+    "longitude": -122.18512,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-illegal_dumping-05",
+    "latitude": 37.35109,
+    "longitude": -122.18512,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-illegal_dumping-06",
+    "latitude": 37.36378,
+    "longitude": -122.18512,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-vehicle_emissions-07",
+    "latitude": 37.37646,
+    "longitude": -122.18512,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-vehicle_emissions-08",
+    "latitude": 37.31304,
+    "longitude": -122.17635,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "palo-alto-vehicle_emissions-09",
+    "latitude": 37.35109,
+    "longitude": -122.19389,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "city-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-road_damage-10",
+    "latitude": 37.42954,
+    "longitude": -122.17078,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-road_damage-11",
+    "latitude": 37.42712,
+    "longitude": -122.1838,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-road_damage-12",
+    "latitude": 37.42875,
+    "longitude": -122.1838,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-illegal_dumping-13",
+    "latitude": 37.43038,
+    "longitude": -122.1838,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-illegal_dumping-14",
+    "latitude": 37.43201,
+    "longitude": -122.1838,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-illegal_dumping-15",
+    "latitude": 37.42224,
+    "longitude": -122.18153,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-vehicle_emissions-16",
+    "latitude": 37.42387,
+    "longitude": -122.18153,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-vehicle_emissions-17",
+    "latitude": 37.4255,
+    "longitude": -122.18153,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "stanford-campus-vehicle_emissions-18",
+    "latitude": 37.42954,
+    "longitude": -122.17078,
+    "issueType": "VEHICLE_EMISSIONS",
+    "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+    "note": "stanford-campus interior point reused from routing-cases.json"
+  },
+  {
+    "id": "menlo-park-road_damage-19",
+    "latitude": 37.44865,
+    "longitude": -122.17515,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Menlo Park ACT",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "menlo-park-road_damage-20",
+    "latitude": 37.42467,
+    "longitude": -122.21866,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Menlo Park ACT",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "menlo-park-road_damage-21",
+    "latitude": 37.42467,
+    "longitude": -122.20888,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Menlo Park ACT",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "menlo-park-illegal_dumping-22",
+    "latitude": 37.42467,
+    "longitude": -122.1991,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "menlo-park-illegal_dumping-23",
+    "latitude": 37.44015,
+    "longitude": -122.1991,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "menlo-park-illegal_dumping-24",
+    "latitude": 37.43241,
+    "longitude": -122.18933,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+    "note": "city-menlo-park interior point reused from routing-cases.json (ambiguous routing — expected agency must be in the candidate set)"
+  },
+  {
+    "id": "mountain-view-road_damage-25",
+    "latitude": 37.40154,
+    "longitude": -122.08137,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "mountain-view-road_damage-26",
+    "latitude": 37.40875,
+    "longitude": -122.11272,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "mountain-view-road_damage-27",
+    "latitude": 37.40096,
+    "longitude": -122.10788,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "mountain-view-illegal_dumping-28",
+    "latitude": 37.40096,
+    "longitude": -122.10304,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "mountain-view-illegal_dumping-29",
+    "latitude": 37.40875,
+    "longitude": -122.10304,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "mountain-view-illegal_dumping-30",
+    "latitude": 37.39317,
+    "longitude": -122.0982,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Mountain View Public Works",
+    "note": "city-mountain-view interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-road_damage-31",
+    "latitude": 37.45857,
+    "longitude": -122.13351,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "East Palo Alto Public Works",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-road_damage-32",
+    "latitude": 37.46892,
+    "longitude": -122.15358,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "East Palo Alto Public Works",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-road_damage-33",
+    "latitude": 37.47105,
+    "longitude": -122.15358,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "East Palo Alto Public Works",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-illegal_dumping-34",
+    "latitude": 37.47319,
+    "longitude": -122.15358,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "East Palo Alto Clean City",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-illegal_dumping-35",
+    "latitude": 37.4625,
+    "longitude": -122.15081,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "East Palo Alto Clean City",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "east-palo-alto-illegal_dumping-36",
+    "latitude": 37.46464,
+    "longitude": -122.15081,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "East Palo Alto Clean City",
+    "note": "city-east-palo-alto interior point reused from routing-cases.json"
+  },
+  {
+    "id": "santa-clara-unincorporated-road_damage-37",
+    "latitude": 37.24497,
+    "longitude": -121.76879,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Santa Clara County Public Works",
+    "note": "county-santa-clara-unincorporated interior point reused from routing-cases.json"
+  },
+  {
+    "id": "santa-clara-unincorporated-road_damage-38",
+    "latitude": 37.28744,
+    "longitude": -122.13637,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Santa Clara County Public Works",
+    "note": "county-santa-clara-unincorporated interior point reused from routing-cases.json"
+  },
+  {
+    "id": "santa-clara-unincorporated-road_damage-39",
+    "latitude": 37.3663,
+    "longitude": -122.13637,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Santa Clara County Public Works",
+    "note": "county-santa-clara-unincorporated interior point reused from routing-cases.json"
+  },
+  {
+    "id": "milpitas-road_damage-40",
+    "latitude": 37.41862,
+    "longitude": -121.9299,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+    "note": "city-milpitas interior point reused from routing-cases.json"
+  },
+  {
+    "id": "milpitas-road_damage-41",
+    "latitude": 37.41979,
+    "longitude": -121.9299,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+    "note": "city-milpitas interior point reused from routing-cases.json"
+  },
+  {
+    "id": "milpitas-illegal_dumping-42",
+    "latitude": 37.42097,
+    "longitude": -121.9299,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+    "note": "city-milpitas interior point reused from routing-cases.json"
+  },
+  {
+    "id": "milpitas-illegal_dumping-43",
+    "latitude": 37.41862,
+    "longitude": -121.9299,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+    "note": "city-milpitas interior point reused from routing-cases.json"
+  },
+  {
+    "id": "morgan-hill-road_damage-44",
+    "latitude": 37.12387,
+    "longitude": -121.69618,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+    "note": "city-morgan-hill interior point reused from routing-cases.json"
+  },
+  {
+    "id": "morgan-hill-road_damage-45",
+    "latitude": 37.12522,
+    "longitude": -121.69618,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+    "note": "city-morgan-hill interior point reused from routing-cases.json"
+  },
+  {
+    "id": "morgan-hill-illegal_dumping-46",
+    "latitude": 37.12657,
+    "longitude": -121.69618,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+    "note": "city-morgan-hill interior point reused from routing-cases.json"
+  },
+  {
+    "id": "morgan-hill-illegal_dumping-47",
+    "latitude": 37.12387,
+    "longitude": -121.69618,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+    "note": "city-morgan-hill interior point reused from routing-cases.json"
+  },
+  {
+    "id": "gilroy-road_damage-48",
+    "latitude": 36.99637,
+    "longitude": -121.64129,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+    "note": "city-gilroy interior point reused from routing-cases.json"
+  },
+  {
+    "id": "gilroy-road_damage-49",
+    "latitude": 36.99764,
+    "longitude": -121.64129,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+    "note": "city-gilroy interior point reused from routing-cases.json"
+  },
+  {
+    "id": "gilroy-illegal_dumping-50",
+    "latitude": 36.9989,
+    "longitude": -121.64129,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+    "note": "city-gilroy interior point reused from routing-cases.json"
+  },
+  {
+    "id": "gilroy-illegal_dumping-51",
+    "latitude": 36.99637,
+    "longitude": -121.64129,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+    "note": "city-gilroy interior point reused from routing-cases.json"
+  },
+  {
+    "id": "watsonville-road_damage-52",
+    "latitude": 36.91557,
+    "longitude": -121.82574,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+    "note": "city-watsonville interior point reused from routing-cases.json"
+  },
+  {
+    "id": "watsonville-road_damage-53",
+    "latitude": 36.91332,
+    "longitude": -121.82416,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+    "note": "city-watsonville interior point reused from routing-cases.json"
+  },
+  {
+    "id": "watsonville-illegal_dumping-54",
+    "latitude": 36.91557,
+    "longitude": -121.82416,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+    "note": "city-watsonville interior point reused from routing-cases.json"
+  },
+  {
+    "id": "watsonville-illegal_dumping-55",
+    "latitude": 36.91557,
+    "longitude": -121.82574,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+    "note": "city-watsonville interior point reused from routing-cases.json"
+  },
+  {
+    "id": "vallejo-road_damage-56",
+    "latitude": 38.12024,
+    "longitude": -122.38386,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+    "note": "city-vallejo interior point reused from routing-cases.json"
+  },
+  {
+    "id": "vallejo-road_damage-57",
+    "latitude": 38.12214,
+    "longitude": -122.38386,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+    "note": "city-vallejo interior point reused from routing-cases.json"
+  },
+  {
+    "id": "vallejo-illegal_dumping-58",
+    "latitude": 38.12405,
+    "longitude": -122.38386,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+    "note": "city-vallejo interior point reused from routing-cases.json"
+  },
+  {
+    "id": "vallejo-illegal_dumping-59",
+    "latitude": 38.12024,
+    "longitude": -122.38386,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+    "note": "city-vallejo interior point reused from routing-cases.json"
+  },
+  {
+    "id": "san-leandro-road_damage-60",
+    "latitude": 37.70885,
+    "longitude": -122.20861,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+    "note": "city-san-leandro interior point reused from routing-cases.json"
+  },
+  {
+    "id": "san-leandro-road_damage-61",
+    "latitude": 37.7101,
+    "longitude": -122.20861,
+    "issueType": "ROAD_DAMAGE",
+    "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+    "note": "city-san-leandro interior point reused from routing-cases.json"
+  },
+  {
+    "id": "san-leandro-illegal_dumping-62",
+    "latitude": 37.71136,
+    "longitude": -122.20861,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+    "note": "city-san-leandro interior point reused from routing-cases.json"
+  },
+  {
+    "id": "san-leandro-illegal_dumping-63",
+    "latitude": 37.70885,
+    "longitude": -122.20861,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+    "note": "city-san-leandro interior point reused from routing-cases.json"
+  }
+]

--- a/nexa/eval/end-to-end.ts
+++ b/nexa/eval/end-to-end.ts
@@ -1,0 +1,365 @@
+/**
+ * End-to-end agency-accuracy harness (O1.KR1).
+ *
+ *   npx tsx eval/end-to-end.ts                # full dataset
+ *   npx tsx eval/end-to-end.ts --limit=10     # subset for quick smoke-runs
+ *   npm run eval:end-to-end
+ *
+ * Output:
+ *   eval/results/end-to-end.json   — per-case results + metrics
+ *   stdout                         — pretty report and pass/fail vs target
+ *
+ * WHAT IT MEASURES (O1.KR1): the single AGENCY-level accuracy number — given a
+ * civic report (latitude + longitude + issueType), does the routing→agency step
+ * reach the EXPECTED agency on the FIRST attempt? This isolates the
+ * routing→agency hop: the jurisdiction routing eval (eval/routing.ts) measures
+ * jurisdiction accuracy and image classification is measured separately; this
+ * harness joins lat/lng + issueType straight through to the seeded Agency.
+ *
+ * "Correct-agency-first-try" per case:
+ *   - Confident match (resolveAgencyId returns a single agencyId): correct when
+ *     that agency's name equals expectedAgencyName.
+ *   - Ambiguous match (agencyId null, multiple candidates — e.g. Menlo Park's
+ *     web-form desk AND its Open311 API both cover the spot): correct when
+ *     expectedAgencyName is among the candidate agencies. Disambiguating between
+ *     equally-valid candidates is the "future caller" concern resolveAgencyId
+ *     documents it defers, so any covering candidate counts as a first-try hit.
+ *   - Unresolved (no candidates): always incorrect.
+ *
+ * FULLY OFFLINE. No network, no live database, no LLM. Like eval/readiness.ts it
+ * REUSES the production `resolveAgencyId` (which normally hits Prisma) by
+ * installing an in-memory Prisma stub on `globalThis.prisma` BEFORE the module
+ * is imported. The stub is backed by the SAME seeded `AGENCIES` array
+ * `prisma/seed.ts` writes to the DB, so routing behaves identically — there is
+ * no parallel routing/agency logic here.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { IssueType } from "../src/generated/prisma/enums";
+import { AGENCIES, type AgencySeed } from "../prisma/agencies";
+
+// ---------------------------------------------------------------------------
+// Offline Prisma stub (same pattern as eval/readiness.ts).
+//
+// `src/lib/prisma.ts` resolves `prisma` as `globalForPrisma.prisma || <new
+// client>`. By setting `globalThis.prisma` to an in-memory stub here, BEFORE any
+// module that imports `@/lib/prisma` loads, we avoid instantiating a real
+// PG-backed client — so the harness needs no DATABASE_URL and makes no network
+// or DB calls. The stub implements exactly the one query `resolveAgencyId`
+// makes: `agency.findMany({ where: { jurisdiction, issueTypes: { has } },
+// select: { id }, orderBy: { id: 'asc' } })`, served from `AGENCIES`.
+// ---------------------------------------------------------------------------
+
+type AgencyRow = AgencySeed & { id: string };
+
+// Deterministic ids derived from the seed key (@@unique([jurisdiction, name])),
+// matching prisma/seed.ts and eval/readiness.ts.
+const AGENCY_ROWS: AgencyRow[] = AGENCIES.map((a) => ({
+  ...a,
+  id: `${a.jurisdiction}::${a.name}`,
+}));
+
+const agencyById = new Map(AGENCY_ROWS.map((a) => [a.id, a]));
+
+type FindManyArgs = {
+  where?: {
+    jurisdiction?: string;
+    issueTypes?: { has?: string };
+  };
+  orderBy?: { id?: "asc" | "desc" };
+};
+
+const prismaStub = {
+  agency: {
+    async findMany(args: FindManyArgs) {
+      const jurisdiction = args.where?.jurisdiction;
+      const issueType = args.where?.issueTypes?.has;
+      let rows = AGENCY_ROWS.filter(
+        (a) =>
+          (jurisdiction === undefined || a.jurisdiction === jurisdiction) &&
+          (issueType === undefined ||
+            a.issueTypes.includes(
+              issueType as AgencySeed["issueTypes"][number],
+            )),
+      );
+      const dir = args.orderBy?.id ?? "asc";
+      rows = rows
+        .slice()
+        .sort((a, b) =>
+          dir === "desc" ? b.id.localeCompare(a.id) : a.id.localeCompare(b.id),
+        );
+      return rows.map((a) => ({ id: a.id }));
+    },
+  },
+};
+
+(globalThis as unknown as { prisma: unknown }).prisma = prismaStub;
+
+// Production function, loaded lazily AFTER the stub above is installed so the
+// `@/lib/prisma` singleton picks up our stub instead of constructing a real
+// client. Dynamic import (not top-level await, which the CJS eval transform
+// rejects) deferred into async `main()`.
+type AgencyModule = typeof import("../src/lib/jurisdictions/agency");
+let resolveAgencyId: AgencyModule["resolveAgencyId"];
+
+async function loadDeps(): Promise<void> {
+  const agency = await import("../src/lib/jurisdictions/agency");
+  resolveAgencyId = agency.resolveAgencyId;
+}
+
+// ---------------------------------------------------------------------------
+// Dataset
+// ---------------------------------------------------------------------------
+
+interface EndToEndCase {
+  id: string;
+  latitude: number;
+  longitude: number;
+  issueType: IssueType;
+  /** The Agency `name` the report should reach on the first attempt. */
+  expectedAgencyName: string;
+  note?: string;
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CASES_PATH = path.join(here, "dataset", "end-to-end-cases.json");
+const RESULTS_DIR = path.join(here, "results");
+
+/** O1.KR1 target: >=80% correct-agency-first-try over the dataset (n>=50). */
+const TARGET_ACCURACY = 0.8;
+
+// ---------------------------------------------------------------------------
+// Per-case evaluation
+// ---------------------------------------------------------------------------
+
+type Outcome = "confident" | "ambiguous" | "unresolved";
+
+interface CaseResult {
+  caseId: string;
+  issueType: IssueType;
+  expectedAgencyName: string;
+  outcome: Outcome;
+  /** The confidently resolved agency name, when there is one. */
+  resolvedAgencyName: string | null;
+  /** Every covering agency name (the candidate set). */
+  candidateNames: string[];
+  /** True when the expected agency was reached on the first attempt. */
+  correct: boolean;
+  reason: string;
+}
+
+function nameOf(agencyId: string): string {
+  return agencyById.get(agencyId)?.name ?? agencyId;
+}
+
+async function evaluateCase(c: EndToEndCase): Promise<CaseResult> {
+  const { agencyId, candidates } = await resolveAgencyId({
+    latitude: c.latitude,
+    longitude: c.longitude,
+    issueType: c.issueType,
+  });
+  const candidateNames = candidates.map(nameOf);
+
+  // Unresolved: no agency covers this jurisdiction + issue type.
+  if (candidates.length === 0) {
+    return {
+      caseId: c.id,
+      issueType: c.issueType,
+      expectedAgencyName: c.expectedAgencyName,
+      outcome: "unresolved",
+      resolvedAgencyName: null,
+      candidateNames,
+      correct: false,
+      reason: "No agency covers this jurisdiction + issue type.",
+    };
+  }
+
+  // Confident single match.
+  if (agencyId) {
+    const resolvedAgencyName = nameOf(agencyId);
+    const correct = resolvedAgencyName === c.expectedAgencyName;
+    return {
+      caseId: c.id,
+      issueType: c.issueType,
+      expectedAgencyName: c.expectedAgencyName,
+      outcome: "confident",
+      resolvedAgencyName,
+      candidateNames,
+      correct,
+      reason: correct
+        ? `Confident match reached ${resolvedAgencyName}.`
+        : `Confident match reached ${resolvedAgencyName}, expected ${c.expectedAgencyName}.`,
+    };
+  }
+
+  // Ambiguous: agencyId null with multiple candidates. Correct when the expected
+  // agency is among the covering candidates (any is a valid first-try channel).
+  const correct = candidateNames.includes(c.expectedAgencyName);
+  return {
+    caseId: c.id,
+    issueType: c.issueType,
+    expectedAgencyName: c.expectedAgencyName,
+    outcome: "ambiguous",
+    resolvedAgencyName: null,
+    candidateNames,
+    correct,
+    reason: correct
+      ? `Ambiguous match; expected ${c.expectedAgencyName} is in the candidate set.`
+      : `Ambiguous match; expected ${c.expectedAgencyName} not among [${candidateNames.join(", ")}].`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+interface CategoryMetric {
+  support: number;
+  correct: number;
+  accuracy: number;
+}
+
+interface EndToEndMetrics {
+  total: number;
+  correct: number;
+  accuracy: number;
+  resolved: number;
+  coverage: number;
+  ambiguous: number;
+  perCategory: Record<string, CategoryMetric>;
+}
+
+function aggregate(results: CaseResult[]): EndToEndMetrics {
+  const total = results.length;
+  const correct = results.filter((r) => r.correct).length;
+  const resolved = results.filter((r) => r.outcome !== "unresolved").length;
+  const ambiguous = results.filter((r) => r.outcome === "ambiguous").length;
+
+  const perCategory: Record<string, CategoryMetric> = {};
+  for (const r of results) {
+    const cat = perCategory[r.issueType] ?? {
+      support: 0,
+      correct: 0,
+      accuracy: 0,
+    };
+    cat.support++;
+    if (r.correct) cat.correct++;
+    cat.accuracy = cat.support === 0 ? 0 : cat.correct / cat.support;
+    perCategory[r.issueType] = cat;
+  }
+
+  return {
+    total,
+    correct,
+    accuracy: total === 0 ? 0 : correct / total,
+    resolved,
+    coverage: total === 0 ? 0 : resolved / total,
+    ambiguous,
+    perCategory,
+  };
+}
+
+function renderReport(metrics: EndToEndMetrics): string {
+  const lines: string[] = [];
+  lines.push("\n=== End-to-end agency accuracy (O1.KR1) ===");
+  lines.push(
+    `Correct-agency-first-try: ${(metrics.accuracy * 100).toFixed(1)}%  (${metrics.correct}/${metrics.total})  target >=${(TARGET_ACCURACY * 100).toFixed(0)}%`,
+  );
+  lines.push(
+    `Routed:   ${(metrics.coverage * 100).toFixed(1)}%  (${metrics.resolved}/${metrics.total} reached >=1 candidate agency; ${metrics.ambiguous} ambiguous)`,
+  );
+
+  lines.push("\nPer-category correct-agency-first-try:");
+  for (const cat of Object.keys(metrics.perCategory).sort()) {
+    const v = metrics.perCategory[cat];
+    lines.push(
+      `  ${cat.padEnd(20)} ${(v.accuracy * 100).toFixed(1)}%  (${v.correct}/${v.support})`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+interface Args {
+  limit: number | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { limit: null };
+  for (const a of argv.slice(2)) {
+    if (a.startsWith("--limit=")) {
+      const n = parseInt(a.slice("--limit=".length), 10);
+      if (Number.isFinite(n) && n > 0) args.limit = n;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  await loadDeps();
+  const args = parseArgs(process.argv);
+
+  const raw = await readFile(CASES_PATH, "utf-8");
+  let cases = JSON.parse(raw) as EndToEndCase[];
+  if (args.limit !== null) cases = cases.slice(0, args.limit);
+
+  console.log(
+    `\n>>> End-to-end agency accuracy (offline, no network/DB/LLM), n=${cases.length}`,
+  );
+
+  const results: CaseResult[] = [];
+  for (let i = 0; i < cases.length; i++) {
+    const r = await evaluateCase(cases[i]);
+    results.push(r);
+    const mark = r.correct ? "✓" : "✗";
+    const got =
+      r.resolvedAgencyName ??
+      (r.outcome === "ambiguous"
+        ? `[${r.candidateNames.join(" | ")}]`
+        : "<unresolved>");
+    console.log(
+      `  [${(i + 1).toString().padStart(2)}/${cases.length}] ${cases[i].id.padEnd(26).slice(0, 26)} ${mark}  ${r.issueType.padEnd(18)} expected=${r.expectedAgencyName.padEnd(34)} got=${got}`,
+    );
+    if (!r.correct) console.log(`        ${r.reason}`);
+  }
+
+  const metrics = aggregate(results);
+
+  await mkdir(RESULTS_DIR, { recursive: true });
+  await writeFile(
+    path.join(RESULTS_DIR, "end-to-end.json"),
+    JSON.stringify(
+      {
+        mode: "end-to-end",
+        datasetSize: cases.length,
+        target: TARGET_ACCURACY,
+        ranAt: new Date().toISOString(),
+        results,
+        metrics,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  console.log(renderReport(metrics));
+
+  const pass = metrics.accuracy >= TARGET_ACCURACY;
+  console.log(
+    `\n${pass ? "PASS" : "BELOW TARGET"}: end-to-end correct-agency-first-try ${(metrics.accuracy * 100).toFixed(1)}% vs target ${(TARGET_ACCURACY * 100).toFixed(0)}% (O1.KR1).`,
+  );
+
+  // Exit non-zero below target so CI gates the build on agency accuracy.
+  if (!pass) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/nexa/eval/results/end-to-end.json
+++ b/nexa/eval/results/end-to-end.json
@@ -1,0 +1,795 @@
+{
+  "mode": "end-to-end",
+  "datasetSize": 63,
+  "target": 0.8,
+  "ranAt": "2026-06-10T08:33:18.155Z",
+  "results": [
+    {
+      "caseId": "palo-alto-road_damage-01",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-road_damage-02",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-road_damage-03",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-illegal_dumping-04",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-illegal_dumping-05",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-illegal_dumping-06",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "palo-alto-vehicle_emissions-07",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "palo-alto-vehicle_emissions-08",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "palo-alto-vehicle_emissions-09",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "stanford-campus-road_damage-10",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-road_damage-11",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-road_damage-12",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-illegal_dumping-13",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-illegal_dumping-14",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-illegal_dumping-15",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "stanford-campus-vehicle_emissions-16",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "stanford-campus-vehicle_emissions-17",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "stanford-campus-vehicle_emissions-18",
+      "issueType": "VEHICLE_EMISSIONS",
+      "expectedAgencyName": "CARB Smoking Vehicle Complaint",
+      "outcome": "confident",
+      "resolvedAgencyName": "CARB Smoking Vehicle Complaint",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "correct": true,
+      "reason": "Confident match reached CARB Smoking Vehicle Complaint."
+    },
+    {
+      "caseId": "menlo-park-road_damage-19",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Menlo Park ACT",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park ACT is in the candidate set."
+    },
+    {
+      "caseId": "menlo-park-road_damage-20",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Menlo Park ACT",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park ACT is in the candidate set."
+    },
+    {
+      "caseId": "menlo-park-road_damage-21",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Menlo Park ACT",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park ACT is in the candidate set."
+    },
+    {
+      "caseId": "menlo-park-illegal_dumping-22",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park SeeClickFix (Open311) is in the candidate set."
+    },
+    {
+      "caseId": "menlo-park-illegal_dumping-23",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park SeeClickFix (Open311) is in the candidate set."
+    },
+    {
+      "caseId": "menlo-park-illegal_dumping-24",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Menlo Park SeeClickFix (Open311)",
+      "outcome": "ambiguous",
+      "resolvedAgencyName": null,
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Ambiguous match; expected Menlo Park SeeClickFix (Open311) is in the candidate set."
+    },
+    {
+      "caseId": "mountain-view-road_damage-25",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "mountain-view-road_damage-26",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "mountain-view-road_damage-27",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "mountain-view-illegal_dumping-28",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "mountain-view-illegal_dumping-29",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "mountain-view-illegal_dumping-30",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Mountain View Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Mountain View Public Works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Mountain View Public Works."
+    },
+    {
+      "caseId": "east-palo-alto-road_damage-31",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "East Palo Alto Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Public Works",
+      "candidateNames": [
+        "East Palo Alto Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Public Works."
+    },
+    {
+      "caseId": "east-palo-alto-road_damage-32",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "East Palo Alto Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Public Works",
+      "candidateNames": [
+        "East Palo Alto Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Public Works."
+    },
+    {
+      "caseId": "east-palo-alto-road_damage-33",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "East Palo Alto Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Public Works",
+      "candidateNames": [
+        "East Palo Alto Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Public Works."
+    },
+    {
+      "caseId": "east-palo-alto-illegal_dumping-34",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "East Palo Alto Clean City",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Clean City",
+      "candidateNames": [
+        "East Palo Alto Clean City"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Clean City."
+    },
+    {
+      "caseId": "east-palo-alto-illegal_dumping-35",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "East Palo Alto Clean City",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Clean City",
+      "candidateNames": [
+        "East Palo Alto Clean City"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Clean City."
+    },
+    {
+      "caseId": "east-palo-alto-illegal_dumping-36",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "East Palo Alto Clean City",
+      "outcome": "confident",
+      "resolvedAgencyName": "East Palo Alto Clean City",
+      "candidateNames": [
+        "East Palo Alto Clean City"
+      ],
+      "correct": true,
+      "reason": "Confident match reached East Palo Alto Clean City."
+    },
+    {
+      "caseId": "santa-clara-unincorporated-road_damage-37",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Santa Clara County Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Santa Clara County Public Works",
+      "candidateNames": [
+        "Santa Clara County Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Santa Clara County Public Works."
+    },
+    {
+      "caseId": "santa-clara-unincorporated-road_damage-38",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Santa Clara County Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Santa Clara County Public Works",
+      "candidateNames": [
+        "Santa Clara County Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Santa Clara County Public Works."
+    },
+    {
+      "caseId": "santa-clara-unincorporated-road_damage-39",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Santa Clara County Public Works",
+      "outcome": "confident",
+      "resolvedAgencyName": "Santa Clara County Public Works",
+      "candidateNames": [
+        "Santa Clara County Public Works"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Santa Clara County Public Works."
+    },
+    {
+      "caseId": "milpitas-road_damage-40",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Milpitas SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "milpitas-road_damage-41",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Milpitas SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "milpitas-illegal_dumping-42",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Milpitas SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "milpitas-illegal_dumping-43",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Milpitas SeeClickFix (Open311)",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Milpitas SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "morgan-hill-road_damage-44",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Morgan Hill SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "morgan-hill-road_damage-45",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Morgan Hill SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "morgan-hill-illegal_dumping-46",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Morgan Hill SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "morgan-hill-illegal_dumping-47",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Morgan Hill SeeClickFix (Open311)",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Morgan Hill SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "gilroy-road_damage-48",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Gilroy SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "gilroy-road_damage-49",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Gilroy SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "gilroy-illegal_dumping-50",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Gilroy SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "gilroy-illegal_dumping-51",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Gilroy SeeClickFix (Open311)",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Gilroy SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "watsonville-road_damage-52",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Watsonville SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "watsonville-road_damage-53",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Watsonville SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "watsonville-illegal_dumping-54",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Watsonville SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "watsonville-illegal_dumping-55",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Watsonville SeeClickFix (Open311)",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Watsonville SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "vallejo-road_damage-56",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Vallejo SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "vallejo-road_damage-57",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Vallejo SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "vallejo-illegal_dumping-58",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Vallejo SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "vallejo-illegal_dumping-59",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "Vallejo SeeClickFix (Open311)",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Vallejo SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "san-leandro-road_damage-60",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached San Leandro SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "san-leandro-road_damage-61",
+      "issueType": "ROAD_DAMAGE",
+      "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached San Leandro SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "san-leandro-illegal_dumping-62",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached San Leandro SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "san-leandro-illegal_dumping-63",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "outcome": "confident",
+      "resolvedAgencyName": "San Leandro SeeClickFix (Open311)",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "correct": true,
+      "reason": "Confident match reached San Leandro SeeClickFix (Open311)."
+    }
+  ],
+  "metrics": {
+    "total": 63,
+    "correct": 63,
+    "accuracy": 1,
+    "resolved": 63,
+    "coverage": 1,
+    "ambiguous": 6,
+    "perCategory": {
+      "ROAD_DAMAGE": {
+        "support": 30,
+        "correct": 30,
+        "accuracy": 1
+      },
+      "ILLEGAL_DUMPING": {
+        "support": 27,
+        "correct": 27,
+        "accuracy": 1
+      },
+      "VEHICLE_EMISSIONS": {
+        "support": 6,
+        "correct": 6,
+        "accuracy": 1
+      }
+    }
+  }
+}

--- a/nexa/package.json
+++ b/nexa/package.json
@@ -23,6 +23,7 @@
     "eval:routing": "tsx eval/routing.ts",
     "eval:validate-boundaries": "tsx eval/validate-boundaries.ts",
     "eval:readiness": "tsx eval/readiness.ts",
+    "eval:end-to-end": "tsx eval/end-to-end.ts",
     "eval:coverage": "tsx eval/coverage.ts",
     "eval:pipeline": "tsx eval/pipeline.ts"
   },


### PR DESCRIPTION
Closes #247.

Adds the single AGENCY-level accuracy number for **O1.KR1** (>=80% correct-agency-first-try on n>=50). The routing eval measures *jurisdiction* accuracy and image classification is measured separately — this harness joins `lat/lng + issueType` straight through to the seeded Agency and isolates the routing→agency hop.

## What's here
- **`eval/dataset/end-to-end-cases.json`** — 63 cases of `(latitude, longitude, issueType, expectedAgencyName)` across the 3 P0 categories (ROAD_DAMAGE, ILLEGAL_DUMPING, VEHICLE_EMISSIONS) and all 12 seeded jurisdictions (Palo Alto, Stanford, Menlo Park, Mountain View, East Palo Alto, Santa Clara County + the 6 SeeClickFix cities). Coordinates are verified interior points reused from `routing-cases.json`. VEHICLE_EMISSIONS only resolves where CARB is seeded (Palo Alto/Stanford), so those 6 cases live there.
- **`eval/end-to-end.ts` + `eval:end-to-end`** — reuses the production `resolveAgencyId` **offline** via the same in-memory Prisma stub pattern as `eval/readiness.ts` (no network, DB, or LLM; no parallel routing/agency logic). Scoring:
  - Confident match: correct when the resolved agency name equals `expectedAgencyName`.
  - Ambiguous match (`agencyId` null, multiple candidates — e.g. Menlo Park's web-form desk + Open311 API): correct when the expected agency is in the candidate set.
  - Unresolved: incorrect.
  - Reports % vs the >=80% target with a per-category breakdown; **exits non-zero below target** (mirrors `eval/routing.ts`).
- Wires the gate into the CI eval job (alongside routing/readiness) and commits the results baseline.

## Measured result (offline)
```
PASS: end-to-end correct-agency-first-try 100.0% vs target 80% (O1.KR1).
  ROAD_DAMAGE        100.0%  (30/30)
  ILLEGAL_DUMPING    100.0%  (27/27)
  VEHICLE_EMISSIONS  100.0%  (6/6)
```
63/63 overall (6 ambiguous Menlo Park cases counted correct via candidate set).

## Checks
- `npx tsc --noEmit` clean
- `npm run format:check` clean
- `npm run eval:end-to-end` runs offline (verified with `DATABASE_URL` unset) and prints >=80%
- `npm run test:coverage` exits 0 (792 tests pass; `eval/**` excluded from coverage)