### PR TITLE
fix(submission): short-circuit un-fileable API agencies to manual-assist + map more Open311 statuses [#250][#252]

### DIFF
--- a/nexa/eval/results/end-to-end.json
+++ b/nexa/eval/results/end-to-end.json
@@ -2,7 +2,7 @@
   "mode": "end-to-end",
   "datasetSize": 63,
   "target": 0.8,
-  "ranAt": "2026-06-10T08:33:18.155Z",
+  "ranAt": "2026-06-10T09:37:04.849Z",
   "results": [
     {
       "caseId": "palo-alto-road_damage-01",

--- a/nexa/eval/results/readiness.json
+++ b/nexa/eval/results/readiness.json
@@ -2,7 +2,7 @@
   "mode": "readiness",
   "datasetSize": 20,
   "target": 0.9,
-  "ranAt": "2026-06-10T07:38:27.147Z",
+  "ranAt": "2026-06-10T09:36:52.013Z",
   "results": [
     {
       "caseId": "road-pa-01",

--- a/nexa/src/lib/submission/open311.test.ts
+++ b/nexa/src/lib/submission/open311.test.ts
@@ -6,6 +6,7 @@ import { TimeoutError } from "@/lib/http";
 
 import {
   buildRequestParams,
+  canAutoFileOpen311,
   fetchOpen311Status,
   mapOpen311Status,
   parseOpen311Config,
@@ -330,6 +331,58 @@ describe("parseOpen311Config", () => {
   });
 });
 
+describe("canAutoFileOpen311", () => {
+  it("is false for a multi-tenant SeeClickFix endpoint without a jurisdictionId", () => {
+    // The seeded SeeClickFix agencies omit jurisdictionId (issue #239), so a
+    // POST would 404 — they cannot auto-file.
+    expect(
+      canAutoFileOpen311(
+        { endpoint: "https://seeclickfix.com/open311/v2" },
+        "https://seeclickfix.com/open311/v2",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to the agency intakeUrl to detect the SeeClickFix host", () => {
+    // No config endpoint, but the agency intakeUrl is the multi-tenant host.
+    expect(
+      canAutoFileOpen311(undefined, "https://seeclickfix.com/open311/v2"),
+    ).toBe(false);
+    // Trailing slash still resolves to the same host.
+    expect(
+      canAutoFileOpen311(undefined, "https://int.seeclickfix.com/open311/v2/"),
+    ).toBe(false);
+  });
+
+  it("is true for a SeeClickFix endpoint that has been given a jurisdictionId", () => {
+    expect(
+      canAutoFileOpen311(
+        {
+          endpoint: "https://seeclickfix.com/open311/v2",
+          jurisdictionId: "org-12345",
+        },
+        "https://seeclickfix.com/open311/v2",
+      ),
+    ).toBe(true);
+  });
+
+  it("is true for a single-tenant endpoint without a jurisdictionId", () => {
+    // A city's own GeoReport server doesn't multiplex jurisdictions, so it can
+    // auto-file without a jurisdiction_id.
+    expect(
+      canAutoFileOpen311(
+        { endpoint: "https://sandbox.open311.org/v2" },
+        "https://sandbox.open311.org/v2",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when no endpoint resolves at all", () => {
+    expect(canAutoFileOpen311(undefined, null)).toBe(false);
+    expect(canAutoFileOpen311({}, undefined)).toBe(false);
+  });
+});
+
 describe("mapOpen311Status", () => {
   it("maps open to ACKNOWLEDGED", () => {
     expect(mapOpen311Status("open")).toBe(ReportStatus.ACKNOWLEDGED);
@@ -339,10 +392,39 @@ describe("mapOpen311Status", () => {
     expect(mapOpen311Status("closed")).toBe(ReportStatus.RESOLVED);
   });
 
+  it("maps acknowledged and received to ACKNOWLEDGED", () => {
+    expect(mapOpen311Status("acknowledged")).toBe(ReportStatus.ACKNOWLEDGED);
+    expect(mapOpen311Status("received")).toBe(ReportStatus.ACKNOWLEDGED);
+  });
+
+  it("maps in_progress / in progress / started to IN_PROGRESS", () => {
+    expect(mapOpen311Status("in_progress")).toBe(ReportStatus.IN_PROGRESS);
+    expect(mapOpen311Status("in progress")).toBe(ReportStatus.IN_PROGRESS);
+    expect(mapOpen311Status("started")).toBe(ReportStatus.IN_PROGRESS);
+  });
+
+  it("maps resolved (a SeeClickFix synonym for closed) to RESOLVED", () => {
+    expect(mapOpen311Status("resolved")).toBe(ReportStatus.RESOLVED);
+  });
+
   it("is case-insensitive and trims surrounding whitespace", () => {
     // Arrange / Act / Assert
     expect(mapOpen311Status("  OPEN  ")).toBe(ReportStatus.ACKNOWLEDGED);
     expect(mapOpen311Status("Closed")).toBe(ReportStatus.RESOLVED);
+    expect(mapOpen311Status("  In_Progress ")).toBe(ReportStatus.IN_PROGRESS);
+    expect(mapOpen311Status("ACKNOWLEDGED")).toBe(ReportStatus.ACKNOWLEDGED);
+  });
+
+  it("returns the new mappings in monotonically non-decreasing rank order", () => {
+    // The poller only applies a mapped status through the STATUS_RANK /
+    // isForwardTransition guard; these mappings must sit in the right order so a
+    // later vendor state never ranks below an earlier one.
+    expect(STATUS_RANK[mapOpen311Status("acknowledged")!]).toBeLessThan(
+      STATUS_RANK[mapOpen311Status("in_progress")!],
+    );
+    expect(STATUS_RANK[mapOpen311Status("in_progress")!]).toBeLessThan(
+      STATUS_RANK[mapOpen311Status("resolved")!],
+    );
   });
 
   it("returns null for an unrecognized status", () => {

--- a/nexa/src/lib/submission/open311.ts
+++ b/nexa/src/lib/submission/open311.ts
@@ -180,6 +180,57 @@ function resolveEndpoint(
   return raw.replace(/\/+$/, "");
 }
 
+// Multi-tenant Open311 hosts serve many cities behind one base endpoint and key
+// every write on a `jurisdiction_id`; POSTing without one 404s. SeeClickFix is
+// the canonical example (and the provider behind every seeded API agency). We
+// match its hostname so we can tell, BEFORE attempting the POST, whether an
+// agency's config is complete enough to actually auto-file. Single-tenant
+// endpoints (e.g. a city's own GeoReport server) don't need a jurisdiction_id,
+// so they remain auto-fileable without one.
+const MULTI_TENANT_OPEN311_HOSTS = new Set([
+  "seeclickfix.com",
+  "int.seeclickfix.com",
+]);
+
+function endpointRequiresJurisdictionId(endpoint: string): boolean {
+  try {
+    return MULTI_TENANT_OPEN311_HOSTS.has(new URL(endpoint).hostname);
+  } catch {
+    // An unparseable endpoint can't be matched to a known multi-tenant host;
+    // treat it as not-requiring (submitToOpen311 will surface any real failure).
+    return false;
+  }
+}
+
+/**
+ * Whether an API agency's Open311 config is complete enough to actually auto-
+ * file a request, used by the orchestrator to short-circuit un-fileable agencies
+ * straight to manual-assist instead of attempting a doomed POST (issue #250).
+ *
+ * "Can auto-file" means BOTH:
+ *   1. a usable base endpoint resolves (from `config.endpoint` or the agency's
+ *      `intakeUrl`), and
+ *   2. if that endpoint is a multi-tenant host (SeeClickFix) whose write path
+ *      keys on `jurisdiction_id`, the config supplies a `jurisdictionId`.
+ *
+ * Most seeded SeeClickFix agencies omit `jurisdictionId` (it's an internal org
+ * id not available via the public API — see issue #239), so they return false
+ * here and the orchestrator degrades them to manual-assist with their intakeUrl.
+ * A single-tenant endpoint, or a SeeClickFix agency that has been given a real
+ * `jurisdictionId`, returns true and still auto-files.
+ */
+export function canAutoFileOpen311(
+  config: Open311Config | undefined,
+  intakeUrl: string | null | undefined,
+): boolean {
+  const endpoint = resolveEndpoint(config, intakeUrl);
+  if (!endpoint) return false;
+  if (endpointRequiresJurisdictionId(endpoint)) {
+    return Boolean(config?.jurisdictionId);
+  }
+  return true;
+}
+
 /**
  * Files a new service request with an Open311 GeoReport v2 endpoint.
  *
@@ -425,16 +476,35 @@ export async function fetchOpen311Status(
 }
 
 /**
- * Maps a GeoReport v2 status onto our ReportStatus lifecycle. The spec only
- * guarantees "open" and "closed"; some endpoints emit richer notes, but we
- * stay conservative and treat anything non-closed as acknowledged-but-open.
- * Returns null for an unrecognized value so callers leave the record untouched.
+ * Maps a GeoReport v2 / SeeClickFix status onto our ReportStatus lifecycle.
+ *
+ * The GeoReport spec only guarantees "open" and "closed", but SeeClickFix (the
+ * provider behind every seeded API agency) and other vendors emit a richer set
+ * of intermediate states. We fold the common ones into our lifecycle:
+ *   - open / received          -> ACKNOWLEDGED (filed, agency aware, not started)
+ *   - acknowledged             -> ACKNOWLEDGED (agency has acknowledged it)
+ *   - in_progress / started    -> IN_PROGRESS  (agency is actively working it)
+ *   - closed / resolved        -> RESOLVED     (issue resolved)
+ *
+ * The returned status is only ever *applied* through the poller's monotonic
+ * STATUS_RANK + isForwardTransition guard (see the poll-status route), so a
+ * vendor reporting an earlier state (e.g. "open" after a human moved the report
+ * to IN_PROGRESS) can never demote it; this function just normalizes the vendor
+ * vocabulary. Returns null for an unrecognized value so callers leave the
+ * record untouched.
  */
 export function mapOpen311Status(open311Status: string): ReportStatus | null {
   switch (open311Status.trim().toLowerCase()) {
     case "open":
+    case "received":
+    case "acknowledged":
       return ReportStatus.ACKNOWLEDGED;
+    case "in_progress":
+    case "in progress":
+    case "started":
+      return ReportStatus.IN_PROGRESS;
     case "closed":
+    case "resolved":
       return ReportStatus.RESOLVED;
     default:
       return null;

--- a/nexa/src/lib/submission/orchestrate.test.ts
+++ b/nexa/src/lib/submission/orchestrate.test.ts
@@ -177,6 +177,91 @@ describe("orchestrateSubmission — API intake (automated)", () => {
   });
 });
 
+describe("orchestrateSubmission — un-fileable API agency (short-circuit, #250)", () => {
+  it("short-circuits to manual_assist with the intake link, never POSTing or claiming", async () => {
+    // Arrange: a SeeClickFix API agency with no jurisdictionId — its multi-tenant
+    // write path can't accept a POST (issue #239), so it cannot auto-file.
+    const { reportId } = stubReportWithAgency(
+      { userId: null },
+      {
+        intakeMethod: IntakeMethod.API,
+        name: "Menlo Park SeeClickFix (Open311)",
+        intakeUrl: "https://seeclickfix.com/open311/v2",
+        intakeEmail: null,
+        requiredFields: {
+          open311: {
+            endpoint: "https://seeclickfix.com/open311/v2",
+            serviceCodes: { ROAD_DAMAGE: "94213" },
+          },
+        },
+      },
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert: immediate manual-assist carrying the SeeClickFix city report page.
+    expect(result).toEqual({
+      status: "manual_assist",
+      reportId,
+      intakeMethod: IntakeMethod.API,
+      agencyName: "Menlo Park SeeClickFix (Open311)",
+      intakeUrl: "https://seeclickfix.com/open311/v2",
+      intakeEmail: null,
+      intakePhone: null,
+    });
+    // No doomed POST, and the report is never claimed (stays CONFIRMED — not lost).
+    expect(submitToOpen311).not.toHaveBeenCalled();
+    expect(prismaMock.report.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.report.update).not.toHaveBeenCalled();
+  });
+
+  it("still auto-files an API agency whose config CAN auto-file (jurisdictionId present)", async () => {
+    // Arrange: a SeeClickFix agency that HAS a jurisdictionId can auto-file.
+    const { reportId } = stubReportWithAgency(
+      { userId: null },
+      {
+        intakeMethod: IntakeMethod.API,
+        intakeUrl: "https://seeclickfix.com/open311/v2",
+        requiredFields: {
+          open311: {
+            endpoint: "https://seeclickfix.com/open311/v2",
+            jurisdictionId: "org-12345",
+            serviceCodes: { ROAD_DAMAGE: "94213" },
+          },
+        },
+      },
+    );
+    prismaMock.report.updateMany.mockResolvedValue({ count: 1 } as never);
+    submitToOpen311.mockResolvedValue({
+      status: "submitted",
+      serviceRequestId: "SR-juris",
+      token: null,
+    });
+    prismaMock.report.update.mockResolvedValue(
+      makeReport({
+        id: reportId,
+        status: ReportStatus.SUBMITTED,
+        externalTrackingId: "SR-juris",
+      }) as never,
+    );
+
+    // Act
+    const result = await orchestrateSubmission(reportId, {});
+
+    // Assert: claimed, filed, and advanced — unchanged behaviour.
+    expect(result).toMatchObject({
+      status: "submitted",
+      externalTrackingId: "SR-juris",
+    });
+    expect(submitToOpen311).toHaveBeenCalledOnce();
+    expect(prismaMock.report.updateMany).toHaveBeenCalledWith({
+      where: { id: reportId, status: ReportStatus.CONFIRMED },
+      data: { status: ReportStatus.SUBMITTING },
+    });
+  });
+});
+
 describe("orchestrateSubmission — non-automated intake (graceful fallback)", () => {
   it.each([IntakeMethod.WEB_FORM, IntakeMethod.PHONE])(
     "returns manual_assist (not an error) for %s intake",

--- a/nexa/src/lib/submission/orchestrate.ts
+++ b/nexa/src/lib/submission/orchestrate.ts
@@ -1,7 +1,11 @@
 import { prisma } from "@/lib/prisma";
 import { IntakeMethod, ReportStatus } from "@/generated/prisma/enums";
 import { resolveAgencyId } from "@/lib/jurisdictions/agency";
-import { parseOpen311Config, submitToOpen311 } from "@/lib/submission/open311";
+import {
+  canAutoFileOpen311,
+  parseOpen311Config,
+  submitToOpen311,
+} from "@/lib/submission/open311";
 import { submitViaEmail } from "@/lib/submission/email";
 
 // ---------------------------------------------------------------------------
@@ -104,9 +108,12 @@ export type OrchestrationActor = {
  *     stay submittable by any link-holder).
  *  2. Ensure an agency is assigned, resolving + persisting one on demand.
  *  3. Dispatch by `agency.intakeMethod`:
- *       - API: atomically claim CONFIRMED -> SUBMITTING, run the Open311 agent,
- *         then SUBMITTING -> SUBMITTED (storing the tracking id) on success or
- *         roll back to CONFIRMED on failure.
+ *       - API: if the agency's Open311 config can't actually auto-file (no
+ *         usable jurisdiction_id where the endpoint requires one — issue #250),
+ *         short-circuit to `manual_assist` before claiming or POSTing. Otherwise
+ *         atomically claim CONFIRMED -> SUBMITTING, run the Open311 agent, then
+ *         SUBMITTING -> SUBMITTED (storing the tracking id) on success or roll
+ *         back to CONFIRMED on failure.
  *       - EMAIL: atomically claim CONFIRMED -> SUBMITTING, run the email agent,
  *         then SUBMITTING -> SUBMITTED (storing the Resend message id) on
  *         success; on `not_configured` (env-gated off) or send failure, roll
@@ -251,6 +258,22 @@ export async function orchestrateSubmission(
 
   // --- API path: fully automated Open311 submission -----------------------
 
+  const config = parseOpen311Config(agency.requiredFields);
+
+  // Short-circuit un-fileable API agencies to manual-assist BEFORE claiming the
+  // report or attempting the POST (issue #250). Most seeded SeeClickFix agencies
+  // lack the `jurisdiction_id` their multi-tenant write path requires (it's an
+  // internal org id not available via the public API — issue #239), so a POST
+  // would 404 and roll back anyway. Detecting that up front means no doomed POST
+  // and an immediate manual-assist carrying the agency's intakeUrl (the city's
+  // SeeClickFix report page) so the user can still file. The report stays
+  // CONFIRMED — never claimed, never lost. Agencies whose config IS complete
+  // (single-tenant endpoint, or a real jurisdictionId) fall through and still
+  // auto-file with a tracking id below.
+  if (!canAutoFileOpen311(config, agency.intakeUrl)) {
+    return manualAssist();
+  }
+
   // Atomically claim the report for submission. A single conditional update
   // (CONFIRMED -> SUBMITTING) is the DB-level guard against concurrent submits:
   // only one of two simultaneous calls can flip the row, so only one ever
@@ -267,7 +290,6 @@ export async function orchestrateSubmission(
     };
   }
 
-  const config = parseOpen311Config(agency.requiredFields);
   const result = await submitToOpen311(report, {
     config,
     intakeUrl: agency.intakeUrl,


### PR DESCRIPTION
Closes #250 #252.

## #250 — Short-circuit un-fileable API agencies to manual-assist
Most seeded SeeClickFix API agencies omit the `jurisdiction_id` their multi-tenant Open311 write path requires (it's an internal org id not available via the public API — see #239), so today `orchestrateSubmission` attempts the POST, gets a 404, then rolls back. Functionally safe but wasteful/confusing.

- New `canAutoFileOpen311(config, intakeUrl)` in `open311.ts`: an agency can auto-file iff a base endpoint resolves **and**, when that endpoint is a known multi-tenant host (SeeClickFix), the config carries a `jurisdictionId`. Single-tenant endpoints don't need one and remain auto-fileable.
- `orchestrateSubmission` checks this **before** claiming the report or POSTing, and short-circuits to `manual_assist` carrying the agency's `intakeUrl` (the city's SeeClickFix report page). No doomed POST; the report is never claimed and never lost.
- Agencies whose config is complete (single-tenant endpoint, or a real `jurisdictionId`) are unchanged and still auto-file with a tracking id.

## #252 — Map more Open311 statuses
`mapOpen311Status` previously mapped only `open`/`closed` (so `acknowledged`/`in_progress` returned null and the poller couldn't advance those reports). Now folds the common SeeClickFix/Open311 vendor statuses into the lifecycle:

- `open` / `received` / `acknowledged` -> `ACKNOWLEDGED`
- `in_progress` / `in progress` / `started` -> `IN_PROGRESS`
- `closed` / `resolved` -> `RESOLVED`

The poller applies a mapped status only through the monotonic `STATUS_RANK` + `isForwardTransition` guard (poll-status route), so the forward-only invariant is preserved — a vendor reporting an earlier state can never demote a report.

## Tests
- `orchestrate.test.ts`: un-fileable SeeClickFix agency -> `manual_assist` with intake link, no POST/claim/update; a SeeClickFix agency **with** a `jurisdictionId` still auto-files.
- `open311.test.ts`: `canAutoFileOpen311` (multi-tenant w/o + w/ jurisdictionId, single-tenant, no endpoint, intakeUrl fallback) and the new status mappings (incl. rank ordering).

## CI / evals
- `npm run test:coverage` exits 0 — 806 tests pass.
- `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run format:check` all clean.
- `eval:readiness` (95%), `eval:end-to-end` (100%), `eval:coverage` (34/30 triples — unchanged) all PASS.