### PR TITLE
fix(report): allow gallery photo selection on mobile [#]

### DIFF
--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -397,7 +397,6 @@ export default function ReportPage() {
         id="photo-input"
         type="file"
         accept="image/*"
-        capture="environment"
         className="hidden"
         onChange={handleFileInput}
       />


### PR DESCRIPTION
Closes #259. Removes `capture="environment"` from the photo file input so mobile browsers show the native chooser (Take Photo and Photo Library) instead of forcing the camera. Desktop is unchanged (`accept="image/*"` kept). Verified: tsc, lint (0 errors), format, 809 tests pass.