### PR TITLE
fix(a11y): hide the visible adjust-pin box, keep keyboard access [#265]

### DIFF
--- a/nexa/src/components/report/location-map.tsx
+++ b/nexa/src/components/report/location-map.tsx
@@ -164,13 +164,15 @@ export default function LocationMap({
       />
       {/* Keyboard parity for the draggable pin: a focusable control that nudges
           the marker via the same onMove handler. Sibling (not a Leaflet-owned
-          child) so Leaflet's DOM ownership of the container is never disturbed. */}
+          child) so Leaflet's DOM ownership of the container is never disturbed.
+          Visually hidden by default (mouse users just drag the pin) but revealed
+          on focus so keyboard / screen-reader users still get the control. */}
       <button
         type="button"
         aria-label={t("report.mapPinKeyboardLabel")}
         aria-describedby={instructionsId}
         onKeyDown={handleKeyDown}
-        className="absolute left-2 top-2 z-[1000] rounded-md border border-border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-[1000] focus:rounded-md focus:border focus:border-border focus:bg-background/90 focus:px-2 focus:py-1 focus:text-xs focus:text-muted-foreground focus:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {t("report.mapPinKeyboardLabel")}
       </button>


### PR DESCRIPTION
Closes #265. The 'Adjust location pin' button on the map is redundant for mouse users (the pin is directly draggable), so it's now visually hidden by default and revealed on focus (sr-only focus:not-sr-only). Mouse users see only the draggable pin; keyboard and screen-reader users still get the control when they tab to the map (the #203 a11y behavior is preserved). location-map tests pass.