### PR TITLE
feat(eval): expand datasets for new issue taxonomy + fix Watsonville anchor [taxonomy eval]

### DIFF
--- a/nexa/eval/dataset/end-to-end-cases.json
+++ b/nexa/eval/dataset/end-to-end-cases.json
@@ -409,35 +409,35 @@
   },
   {
     "id": "watsonville-road_damage-52",
-    "latitude": 36.91557,
-    "longitude": -121.82574,
+    "latitude": 36.91,
+    "longitude": -121.7681,
     "issueType": "ROAD_DAMAGE",
     "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
-    "note": "city-watsonville interior point reused from routing-cases.json"
+    "note": "city-watsonville central interior point reused from wat-01 (re-anchored off the far-western polygon edge)"
   },
   {
     "id": "watsonville-road_damage-53",
-    "latitude": 36.91332,
-    "longitude": -121.82416,
+    "latitude": 36.9105,
+    "longitude": -121.76,
     "issueType": "ROAD_DAMAGE",
     "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
-    "note": "city-watsonville interior point reused from routing-cases.json"
+    "note": "city-watsonville central interior point reused from wat-02 (re-anchored off the far-western polygon edge)"
   },
   {
     "id": "watsonville-illegal_dumping-54",
-    "latitude": 36.91557,
-    "longitude": -121.82416,
+    "latitude": 36.912,
+    "longitude": -121.765,
     "issueType": "ILLEGAL_DUMPING",
     "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
-    "note": "city-watsonville interior point reused from routing-cases.json"
+    "note": "city-watsonville central interior point reused from wat-03 (re-anchored off the far-western polygon edge)"
   },
   {
     "id": "watsonville-illegal_dumping-55",
-    "latitude": 36.91557,
-    "longitude": -121.82574,
+    "latitude": 36.91,
+    "longitude": -121.7681,
     "issueType": "ILLEGAL_DUMPING",
     "expectedAgencyName": "Watsonville SeeClickFix (Open311)",
-    "note": "city-watsonville interior point reused from routing-cases.json"
+    "note": "city-watsonville central interior point reused from wat-01 (re-anchored off the far-western polygon edge)"
   },
   {
     "id": "vallejo-road_damage-56",

--- a/nexa/eval/dataset/readiness-cases.json
+++ b/nexa/eval/dataset/readiness-cases.json
@@ -346,8 +346,8 @@
     "report": {
       "description": "Deep pothole damaging tires on the road.",
       "aiDescription": "Pothole in roadway.",
-      "latitude": 36.91557,
-      "longitude": -121.82574,
+      "latitude": 36.91,
+      "longitude": -121.7681,
       "address": "Watsonville, CA",
       "photoUrl": "https://uploads.nexa.example/reports/road-wat-18-api.jpg",
       "contactEmail": "reporter@example.com",

--- a/nexa/eval/dataset/routing-cases.json
+++ b/nexa/eval/dataset/routing-cases.json
@@ -493,27 +493,27 @@
   },
   {
     "id": "wat-01",
-    "latitude": 36.91557,
-    "longitude": -121.82574,
+    "latitude": 36.91,
+    "longitude": -121.7681,
     "issueType": "ROAD_DAMAGE",
     "expectedJurisdictionId": "city-watsonville",
-    "note": "Watsonville SeeClickFix Open311 city (verified interior point)"
+    "note": "Watsonville SeeClickFix Open311 city (central interior point; previous (36.91557,-121.82574) sat on the far-western polygon edge)"
   },
   {
     "id": "wat-02",
-    "latitude": 36.91332,
-    "longitude": -121.82416,
+    "latitude": 36.9105,
+    "longitude": -121.76,
     "issueType": "ILLEGAL_DUMPING",
     "expectedJurisdictionId": "city-watsonville",
-    "note": "Watsonville SeeClickFix Open311 city (verified interior point)"
+    "note": "Watsonville SeeClickFix Open311 city (central interior point; previous (36.91332,-121.82416) sat on the far-western polygon edge)"
   },
   {
     "id": "wat-03",
-    "latitude": 36.91557,
-    "longitude": -121.82416,
+    "latitude": 36.912,
+    "longitude": -121.765,
     "issueType": "STREETLIGHT_OUTAGE",
     "expectedJurisdictionId": "city-watsonville",
-    "note": "Watsonville SeeClickFix Open311 city (verified interior point)"
+    "note": "Watsonville SeeClickFix Open311 city (central interior point; previous (36.91557,-121.82416) sat on the far-western polygon edge)"
   },
   {
     "id": "val-01",
@@ -562,5 +562,109 @@
     "issueType": "STREETLIGHT_OUTAGE",
     "expectedJurisdictionId": "city-san-leandro",
     "note": "San Leandro SeeClickFix Open311 city (verified interior point)"
+  },
+  {
+    "id": "taxonomy-mil-graffiti",
+    "latitude": 37.41862,
+    "longitude": -121.9299,
+    "issueType": "GRAFFITI",
+    "expectedJurisdictionId": "city-milpitas",
+    "note": "New taxonomy type (#264). Milpitas interior point reused from mil-01; jurisdiction resolution is issue-type independent so this resolves today, and the agency assertion lands with the sibling routing seed."
+  },
+  {
+    "id": "taxonomy-mil-sidewalk_damage",
+    "latitude": 37.41979,
+    "longitude": -121.9299,
+    "issueType": "SIDEWALK_DAMAGE",
+    "expectedJurisdictionId": "city-milpitas",
+    "note": "New taxonomy type (#264). Milpitas interior point reused from mil-02."
+  },
+  {
+    "id": "taxonomy-mil-tree_maintenance",
+    "latitude": 37.42097,
+    "longitude": -121.9299,
+    "issueType": "TREE_MAINTENANCE",
+    "expectedJurisdictionId": "city-milpitas",
+    "note": "New taxonomy type (#264). Milpitas interior point reused from mil-03."
+  },
+  {
+    "id": "taxonomy-mh-traffic_signal",
+    "latitude": 37.12387,
+    "longitude": -121.69618,
+    "issueType": "TRAFFIC_SIGNAL",
+    "expectedJurisdictionId": "city-morgan-hill",
+    "note": "New taxonomy type (#264). Morgan Hill interior point reused from mh-01."
+  },
+  {
+    "id": "taxonomy-mh-public_signage",
+    "latitude": 37.12522,
+    "longitude": -121.69618,
+    "issueType": "PUBLIC_SIGNAGE",
+    "expectedJurisdictionId": "city-morgan-hill",
+    "note": "New taxonomy type (#264). Morgan Hill interior point reused from mh-02."
+  },
+  {
+    "id": "taxonomy-gil-flooding_drainage",
+    "latitude": 36.99637,
+    "longitude": -121.64129,
+    "issueType": "FLOODING_DRAINAGE",
+    "expectedJurisdictionId": "city-gilroy",
+    "note": "New taxonomy type (#264). Gilroy interior point reused from gil-01."
+  },
+  {
+    "id": "taxonomy-gil-water_system",
+    "latitude": 36.99764,
+    "longitude": -121.64129,
+    "issueType": "WATER_SYSTEM",
+    "expectedJurisdictionId": "city-gilroy",
+    "note": "New taxonomy type (#264). Gilroy interior point reused from gil-02."
+  },
+  {
+    "id": "taxonomy-wat-parks_playgrounds",
+    "latitude": 36.91,
+    "longitude": -121.7681,
+    "issueType": "PARKS_PLAYGROUNDS",
+    "expectedJurisdictionId": "city-watsonville",
+    "note": "New taxonomy type (#264). Watsonville central interior point reused from wat-01."
+  },
+  {
+    "id": "taxonomy-wat-weed_abatement",
+    "latitude": 36.9105,
+    "longitude": -121.76,
+    "issueType": "WEED_ABATEMENT",
+    "expectedJurisdictionId": "city-watsonville",
+    "note": "New taxonomy type (#264). Watsonville central interior point reused from wat-02."
+  },
+  {
+    "id": "taxonomy-val-abandoned_vehicle",
+    "latitude": 38.12024,
+    "longitude": -122.38386,
+    "issueType": "ABANDONED_VEHICLE",
+    "expectedJurisdictionId": "city-vallejo",
+    "note": "New taxonomy type (#264). Vallejo interior point reused from val-01."
+  },
+  {
+    "id": "taxonomy-val-parking",
+    "latitude": 38.12214,
+    "longitude": -122.38386,
+    "issueType": "PARKING",
+    "expectedJurisdictionId": "city-vallejo",
+    "note": "New taxonomy type (#264). Vallejo interior point reused from val-02."
+  },
+  {
+    "id": "taxonomy-sl-code_enforcement",
+    "latitude": 37.70885,
+    "longitude": -122.20861,
+    "issueType": "CODE_ENFORCEMENT",
+    "expectedJurisdictionId": "city-san-leandro",
+    "note": "New taxonomy type (#264). San Leandro interior point reused from sl-01."
+  },
+  {
+    "id": "taxonomy-sl-street_sweeping",
+    "latitude": 37.7101,
+    "longitude": -122.20861,
+    "issueType": "STREET_SWEEPING",
+    "expectedJurisdictionId": "city-san-leandro",
+    "note": "New taxonomy type (#264). San Leandro interior point reused from sl-02."
   }
 ]


### PR DESCRIPTION
## Summary

Expands the Nexa eval datasets to cover the new issue taxonomy (13 new types merged in #264) and fixes the Watsonville routing anchor flagged by research. Eval-dataset-only — disjoint from the sibling **feat/taxonomy-routing-seed** PR that seeds the agency service codes.

## Changes

### 1. Watsonville anchor fix
The three Watsonville dataset points sat on the far-western edge of the city polygon (lng `-121.82574` / `-121.82416`, where the polygon's western bound is `-121.827324`). Re-anchored to central interior points in the city core, each verified interior via the **real** `resolveJurisdiction` (9/9 robust under ±0.0008° jitter):

- `36.91, -121.7681`
- `36.9105, -121.76`
- `36.912, -121.765`

Applied across all three datasets that reused the stale coordinates: `routing-cases.json` (wat-01/02/03), `end-to-end-cases.json` (watsonville-52/53/54/55), `readiness-cases.json` (road-wat-18-api).

### 2. New-taxonomy routing cases
Added 13 routing cases — one per new type from #264 — distributed across the six seeded SeeClickFix Open311 cities (Milpitas, Morgan Hill, Gilroy, Watsonville, Vallejo, San Leandro). Every point reuses a verified interior coordinate already in the dataset. Jurisdiction resolution is issue-type independent (`resolveJurisdiction` is pure polygon lookup), so all 13 resolve to the correct jurisdiction **today** and remain correct after the seed lands.

### 3. Scope note (CI-green-on-this-branch priority)
End-to-end and readiness datasets are **not** given new-type cases here. On the current `main` seed no agency covers the new types, so such cases would route to no agency and fail the O1.KR1 / K3 gates. Those agency-level new-type assertions are deferred to the sibling **feat/taxonomy-routing-seed** PR. This keeps this PR's eval gates green standalone.

## Verification (all green on this branch)

| Gate | Result |
|---|---|
| `npm run eval:routing` | PASS 100% (83/83) |
| `npm run eval:end-to-end` | PASS 100% (63/63) |
| `npm run eval:readiness` | PASS 95% (target 90%) |
| `npm run eval:validate-boundaries` | PASS (12 features) |
| `npm run eval:coverage` | PASS 34/30 triples |
| `npx tsc --noEmit` | clean |
| `npm run format:check` | clean |
| `npm run test:coverage` | exit 0 (825 passed, 3 skipped) |

## Merge order

This PR is green on its own. Once **feat/taxonomy-routing-seed** merges, the seeded service codes will route the new types to each city's SeeClickFix agency, enabling follow-up end-to-end/readiness new-type cases.