### PR TITLE
feat(report): one-tap clear button for the AI-suggested description [#263]

### DIFF
--- a/nexa/src/app/report/page.test.tsx
+++ b/nexa/src/app/report/page.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/components/report/describe-step", () => ({
     autoSuggesting: boolean;
     detectedIssueType: string | null;
     onDescriptionChange: (v: string) => void;
+    onClearDescription: () => void;
     onClassify: () => void;
   }) => (
     <div>
@@ -33,6 +34,7 @@ vi.mock("@/components/report/describe-step", () => ({
       <button onClick={() => props.onDescriptionChange("user typed")}>
         type
       </button>
+      <button onClick={() => props.onClearDescription()}>clear</button>
       <button onClick={() => props.onClassify()}>analyze</button>
     </div>
   ),
@@ -218,6 +220,79 @@ describe("ReportPage auto-suggest on upload", () => {
       expect(screen.getByTestId("review-step")).toBeInTheDocument(),
     );
     expect(classify).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the AI suggestion and keeps it cleared for the same image (#263)", async () => {
+    // Arrange: upload a photo so the field auto-fills with the AI suggestion.
+    stubFetch();
+    const { user } = renderWithProviders(<ReportPage />);
+    setImage("data:image/jpeg;base64,AAAA");
+    await waitFor(() =>
+      expect(screen.getByTestId("description")).toHaveTextContent(
+        WINNER.aiDescription,
+      ),
+    );
+
+    // Act: one-tap clear.
+    await user.click(screen.getByText("clear"));
+
+    // Assert: the field is wiped and no longer badged as an AI suggestion.
+    expect(screen.getByTestId("description")).toHaveTextContent("");
+    expect(screen.getByTestId("is-ai")).toHaveTextContent("false");
+
+    // Assert: the clear sticks — the suggestion does NOT re-populate from the
+    // same image. Settle pending effects, then re-check the field stays empty.
+    await waitFor(() =>
+      expect(screen.getByTestId("auto-suggesting")).toHaveTextContent("false"),
+    );
+    expect(screen.getByTestId("description")).toHaveTextContent("");
+    expect(screen.getByTestId("is-ai")).toHaveTextContent("false");
+  });
+
+  it("can type a new description after clearing the suggestion (#263)", async () => {
+    // Arrange: auto-fill then clear.
+    stubFetch();
+    const { user } = renderWithProviders(<ReportPage />);
+    setImage("data:image/jpeg;base64,AAAA");
+    await waitFor(() =>
+      expect(screen.getByTestId("description")).toHaveTextContent(
+        WINNER.aiDescription,
+      ),
+    );
+    await user.click(screen.getByText("clear"));
+
+    // Act: the user writes their own description.
+    await user.click(screen.getByText("type"));
+
+    // Assert: their text is kept and not treated as an AI suggestion.
+    expect(screen.getByTestId("description")).toHaveTextContent("user typed");
+    expect(screen.getByTestId("is-ai")).toHaveTextContent("false");
+  });
+
+  it("re-suggests for a NEW image after a clear (#263)", async () => {
+    // Arrange: auto-fill from one image, then clear it.
+    stubFetch();
+    const { user } = renderWithProviders(<ReportPage />);
+    setImage("data:image/jpeg;base64,AAAA");
+    await waitFor(() =>
+      expect(screen.getByTestId("description")).toHaveTextContent(
+        WINNER.aiDescription,
+      ),
+    );
+    await user.click(screen.getByText("clear"));
+    expect(screen.getByTestId("description")).toHaveTextContent("");
+
+    // Act: upload a genuinely different image.
+    setImage("data:image/jpeg;base64,BBBB");
+
+    // Assert: a fresh suggestion fills the cleared field — the clear only
+    // suppressed the SAME image, not a new one.
+    await waitFor(() =>
+      expect(screen.getByTestId("description")).toHaveTextContent(
+        WINNER.aiDescription,
+      ),
+    );
+    expect(screen.getByTestId("is-ai")).toHaveTextContent("true");
   });
 
   it("degrades gracefully when classification fails", async () => {

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -39,9 +39,15 @@ export default function ReportPage() {
   // never clobbers what the user wrote. "none" = empty/untouched (safe to fill),
   // "ai" = an AI suggestion the user has not edited (safe to replace with a
   // fresh suggestion when the image changes), "user" = the user typed or edited
-  // it (never overwrite). Once "user", auto-suggest leaves the field alone.
+  // it (never overwrite), "cleared" = the user explicitly wiped the field with
+  // the one-tap Clear control (#263). Once "user", auto-suggest leaves the field
+  // alone. "cleared" must stick against the *same* image but still allow a *new*
+  // image to re-suggest: the same-image guard is already enforced by
+  // `lastAnalyzedImage` (the auto-suggest effect never re-runs for unchanged
+  // bytes), so "cleared" only needs to read as "fillable" to a fresh image —
+  // which it does, since the suggestion guard blocks "user" alone.
   const [descriptionSource, setDescriptionSource] = useState<
-    "none" | "ai" | "user"
+    "none" | "ai" | "user" | "cleared"
   >("none");
 
   // On-upload auto-suggestion UI state (distinct from the explicit "Analyze
@@ -347,6 +353,17 @@ export default function ReportPage() {
     }
   };
 
+  // One-tap clear for the whole description (#263). Wipes the field and marks it
+  // "cleared" so the on-upload auto-suggest does not re-treat the empty field as
+  // fresh AI text. The clear sticks for the current image: that effect keys off
+  // the image bytes and is further guarded by `lastAnalyzedImage`, so it never
+  // re-fires for the same photo. A *new* image still re-suggests — "cleared" is
+  // not "user", so the suggestion guard lets a fresh result fill the field.
+  const handleClearDescription = () => {
+    setDescription("");
+    setDescriptionSource("cleared");
+  };
+
   const handleImageDrop = (e: React.DragEvent) => {
     markCaptureStart();
     image.handleDrop(e);
@@ -409,6 +426,7 @@ export default function ReportPage() {
             onDrop={handleImageDrop}
             onClearImage={handleClearImage}
             onDescriptionChange={handleDescriptionChange}
+            onClearDescription={handleClearDescription}
             onAddressChange={handleAddressChange}
             onDetectLocation={geo.detect}
             onLocationChange={geo.movePin}

--- a/nexa/src/components/report/describe-step.test.tsx
+++ b/nexa/src/components/report/describe-step.test.tsx
@@ -58,6 +58,7 @@ function baseProps() {
     onDrop: vi.fn(),
     onClearImage: vi.fn(),
     onDescriptionChange: vi.fn(),
+    onClearDescription: vi.fn(),
     onAddressChange: vi.fn(),
     onDetectLocation: vi.fn(),
     onLocationChange: vi.fn(),
@@ -140,6 +141,48 @@ describe("DescribeStep", () => {
 
     // Assert
     expect(props.onDescriptionChange).toHaveBeenCalledWith("x");
+  });
+
+  it("hides the clear-description control when the field is empty", () => {
+    // Arrange / Act: empty description -> nothing to clear.
+    renderWithProviders(<DescribeStep {...baseProps()} description="" />);
+
+    // Assert
+    expect(
+      screen.queryByRole("button", { name: "Clear description" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the clear-description control when the field has content", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <DescribeStep {...baseProps()} description="A large pothole." />,
+    );
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: "Clear description" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClearDescription when the clear control is clicked", async () => {
+    // Arrange
+    const props = baseProps();
+    const { user } = renderWithProviders(
+      <DescribeStep
+        {...props}
+        descriptionIsAiSuggestion
+        description="A large pothole in the roadway."
+      />,
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Clear description" }));
+
+    // Assert: one-tap clear delegates to the parent; description state is owned
+    // there, so the component only forwards the intent.
+    expect(props.onClearDescription).toHaveBeenCalledTimes(1);
+    expect(props.onDescriptionChange).not.toHaveBeenCalled();
   });
 
   it("starts dictation through the mic toggle when supported", async () => {

--- a/nexa/src/components/report/describe-step.tsx
+++ b/nexa/src/components/report/describe-step.tsx
@@ -56,6 +56,8 @@ interface DescribeStepProps {
   onDrop: (e: React.DragEvent) => void;
   onClearImage: () => void;
   onDescriptionChange: (value: string) => void;
+  /** Wipes the entire description in one tap (#263). */
+  onClearDescription: () => void;
   onAddressChange: (value: string) => void;
   onDetectLocation: () => void;
   onLocationChange: (latitude: number, longitude: number) => void;
@@ -84,6 +86,7 @@ export function DescribeStep({
   onDrop,
   onClearImage,
   onDescriptionChange,
+  onClearDescription,
   onAddressChange,
   onDetectLocation,
   onLocationChange,
@@ -245,28 +248,50 @@ export function DescribeStep({
               )
             )}
           </div>
-          {speech.supported && (
-            <button
-              type="button"
-              onClick={handleMicToggle}
-              aria-label={
-                speech.listening
-                  ? t("report.stopDictation")
-                  : t("report.dictateDescription")
-              }
-              aria-pressed={speech.listening}
-              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider transition-colors ${
-                speech.listening
-                  ? "bg-red-50 text-red-600 hover:bg-red-100"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
-              }`}
-            >
-              <Mic
-                className={`size-3.5 ${speech.listening ? "animate-pulse" : ""}`}
-              />
-              {speech.listening ? t("report.dictating") : t("report.dictate")}
-            </button>
-          )}
+          <div className="flex shrink-0 items-center gap-1.5">
+            {/*
+              One-tap Clear (#263): wipes the whole description — handy for
+              dropping an AI suggestion the user does not want. Shown only when
+              the field has content, reusing the same X icon as the image-clear
+              control. The parent marks the cleared field so the on-upload
+              auto-suggest does not immediately re-populate it from the same
+              photo.
+            */}
+            {description.trim() !== "" && (
+              <button
+                type="button"
+                onClick={onClearDescription}
+                aria-label={t("report.clearDescription")}
+                title={t("report.clearDescription")}
+                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <X className="size-3.5" />
+                {t("report.clear")}
+              </button>
+            )}
+            {speech.supported && (
+              <button
+                type="button"
+                onClick={handleMicToggle}
+                aria-label={
+                  speech.listening
+                    ? t("report.stopDictation")
+                    : t("report.dictateDescription")
+                }
+                aria-pressed={speech.listening}
+                className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 font-mono text-xs uppercase tracking-wider transition-colors ${
+                  speech.listening
+                    ? "bg-red-50 text-red-600 hover:bg-red-100"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                }`}
+              >
+                <Mic
+                  className={`size-3.5 ${speech.listening ? "animate-pulse" : ""}`}
+                />
+                {speech.listening ? t("report.dictating") : t("report.dictate")}
+              </button>
+            )}
+          </div>
         </div>
         <Textarea
           id="description"

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -157,6 +157,8 @@ const enMessages = {
   "report.aiSuggestion": "AI suggestion",
   "report.aiSuggestionHint":
     "We drafted this from your photo — edit or clear it and write your own.",
+  "report.clear": "Clear",
+  "report.clearDescription": "Clear description",
   "report.detectedIssue": "Detected issue:",
   "report.reviewLabel": "/ Review Classification",
   "report.reviewTitle": "Does this look right?",
@@ -476,6 +478,8 @@ export const messages = {
     "report.aiSuggestion": "Sugerencia de IA",
     "report.aiSuggestionHint":
       "Redactamos esto a partir de tu foto: edítalo o bórralo y escribe el tuyo.",
+    "report.clear": "Borrar",
+    "report.clearDescription": "Borrar descripción",
     "report.detectedIssue": "Problema detectado:",
     "report.reviewLabel": "/ Revisar clasificación",
     "report.reviewTitle": "¿Esto se ve correcto?",
@@ -781,6 +785,8 @@ export const messages = {
     "report.aiSuggestion": "AI 建议",
     "report.aiSuggestionHint":
       "我们根据您的照片草拟了此内容，可编辑或删除后自行填写。",
+    "report.clear": "清除",
+    "report.clearDescription": "清除描述",
     "report.detectedIssue": "检测到的问题：",
     "report.reviewLabel": "/ 检查分类",
     "report.reviewTitle": "看起来正确吗？",
@@ -1091,6 +1097,8 @@ export const messages = {
     "report.aiSuggestion": "Suggestion IA",
     "report.aiSuggestionHint":
       "Nous avons rédigé ceci à partir de votre photo : modifiez-le ou effacez-le et écrivez le vôtre.",
+    "report.clear": "Effacer",
+    "report.clearDescription": "Effacer la description",
     "report.detectedIssue": "Problème détecté :",
     "report.reviewLabel": "/ Vérifier la classification",
     "report.reviewTitle": "Est-ce correct ?",


### PR DESCRIPTION
Closes #263.

## What
Adds a small one-tap **Clear** / X control to the describe step that wipes the **entire** description in a single tap — handy for dropping an AI suggestion (#261) the user does not want.

- Shown only when the description field is non-empty, in the description card header next to the dictation toggle.
- Reuses the existing `X` icon and the same pill styling already used by the image-clear and mic controls (no parallel state — it drives the existing `description` / `descriptionSource` state in `report/page.tsx`).
- After clearing, the user can still type their own description.

## How the clear sticks vs the #261 auto-suggest
On click the parent sets `description = ""` and tags `descriptionSource = "cleared"` (a new member of the existing union).

- **Same image — clear sticks:** the auto-suggest `useEffect` keys off the image bytes (`image.imageBase64`) and is further guarded by `lastAnalyzedImage`, so it never re-runs for unchanged bytes. Clearing the description does not touch the image, so nothing re-populates the field.
- **New image — re-suggests:** the suggestion guard only blocks `"user"`. `"cleared"` reads as fillable, so uploading a genuinely different photo produces a fresh suggestion as before.

## i18n
`report.clear` + `report.clearDescription` added in all four locales (en/es/zh/fr).

## Tests
- `describe-step.test.tsx`: clear control hidden when empty, shown when non-empty, and delegates to `onClearDescription` on click.
- `report/page.test.tsx`: clear wipes the field and unbadges it; the clear **sticks** for the same image; the user can type afterward; a **new** image re-suggests.

## CI
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run format:check` — clean
- `npm run test:coverage` — exits 0 (831 passed, 3 skipped)
- `npm run test:e2e` — 9 passed