### PR TITLE
feat(dashboard): hover to preview report-map pins

### DIFF
--- a/nexa/src/components/dashboard/reports-map.test.tsx
+++ b/nexa/src/components/dashboard/reports-map.test.tsx
@@ -17,6 +17,9 @@ const marker = {
     popupHtml.push(html);
     return marker;
   }),
+  on: vi.fn(() => marker),
+  openPopup: vi.fn(() => marker),
+  closePopup: vi.fn(() => marker),
 };
 
 const map = {
@@ -113,6 +116,24 @@ describe("ReportsMap", () => {
     await waitFor(() => expect(divIconCalls.length).toBe(2));
     expect(divIconCalls[0].html).toContain("#22c55e");
     expect(divIconCalls[1].html).toContain("#9b87f5");
+  });
+
+  it("opens a pin's popup on hover and closes it on mouse-out", async () => {
+    // Arrange / Act
+    renderWithProviders(<ReportsMap points={[makePoint({ id: "h" })]} />);
+
+    // Assert: hover handlers are wired so pins preview without a click.
+    await waitFor(() =>
+      expect(marker.on).toHaveBeenCalledWith("mouseover", expect.any(Function)),
+    );
+    expect(marker.on).toHaveBeenCalledWith("mouseout", expect.any(Function));
+
+    // Invoke the registered handlers to confirm they open/close the popup.
+    const calls = marker.on.mock.calls as unknown as [string, () => void][];
+    calls.find(([evt]) => evt === "mouseover")?.[1]();
+    calls.find(([evt]) => evt === "mouseout")?.[1]();
+    expect(marker.openPopup).toHaveBeenCalled();
+    expect(marker.closePopup).toHaveBeenCalled();
   });
 
   it("escapes HTML in popup content", async () => {

--- a/nexa/src/components/dashboard/reports-map.tsx
+++ b/nexa/src/components/dashboard/reports-map.tsx
@@ -112,9 +112,15 @@ export function ReportsMap({ points }: ReportsMapProps) {
           </div>
         `;
 
-        L.marker([point.latitude, point.longitude], { icon })
+        const marker = L.marker([point.latitude, point.longitude], { icon })
           .addTo(map)
           .bindPopup(popupHtml, { closeButton: false, offset: [0, -2] });
+
+        // Open the popup on hover so you can scan pins without clicking; clicks
+        // still work (and remain the only path on touch, where hover never
+        // fires). Closing on mouseout keeps only the hovered pin's popup open.
+        marker.on("mouseover", () => marker.openPopup());
+        marker.on("mouseout", () => marker.closePopup());
 
         latLngs.push([point.latitude, point.longitude]);
       }


### PR DESCRIPTION
The dashboard map already plots every report you've submitted (that has coordinates) as a pin, colored green for confirmed/submitted and purple for pending, each with a popup showing the issue type, location, status, and time.

This adds **hover-to-open**: the popup now opens when you hover a pin so you can scan them without clicking. Click still works and remains the only path on touch devices (where hover never fires).

tsc clean · reports-map tests 7 passed (added a hover test) · prettier clean.