### PR TITLE
feat(home): municipalities-covered stat + serviced-city list

### DIFF
--- a/nexa/src/components/home/stats-section.tsx
+++ b/nexa/src/components/home/stats-section.tsx
@@ -2,9 +2,29 @@
 
 import { useI18n } from "@/i18n/provider";
 
+// Municipalities Nexa currently routes reports for. Mirrors the verified
+// jurisdictions seeded in prisma/agencies.ts (kept in sync by hand — there are
+// only a handful and they change rarely). The count drives the stat below.
+const SERVICED_MUNICIPALITIES = [
+  "Palo Alto",
+  "Menlo Park",
+  "East Palo Alto",
+  "Mountain View",
+  "Santa Clara County",
+  "Milpitas",
+  "Morgan Hill",
+  "Gilroy",
+  "Watsonville",
+  "Vallejo",
+  "San Leandro",
+] as const;
+
 const STATS = [
   { value: "30s", labelKey: "home.statAverage" },
-  { value: "100%", labelKey: "home.statAccuracy" },
+  {
+    value: String(SERVICED_MUNICIPALITIES.length),
+    labelKey: "home.statMunicipalities",
+  },
   { value: "18", labelKey: "home.statIssueTypes" },
 ] as const;
 
@@ -67,6 +87,16 @@ export function StatsSection() {
             ))}
           </div>
         </div>
+
+        {/* Small-font roll of the municipalities we actually route reports for. */}
+        <p className="mt-10 text-center text-xs leading-relaxed text-muted-foreground">
+          <span className="font-mono uppercase tracking-wider">
+            {t("home.servicedLabel")}
+          </span>{" "}
+          <span className="text-foreground">
+            {SERVICED_MUNICIPALITIES.join(" · ")}
+          </span>
+        </p>
       </div>
     </section>
   );

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -53,6 +53,8 @@ const enMessages = {
   "home.statsTitle": "Reporting made radically simpler.",
   "home.statAverage": "Average report time",
   "home.statAccuracy": "Routing accuracy",
+  "home.statMunicipalities": "Municipalities covered",
+  "home.servicedLabel": "Cities we currently service:",
   "home.statIssueTypes": "Issue types supported",
   "home.challenge": "/ Challenge",
   "home.challengeText":
@@ -376,6 +378,8 @@ export const messages = {
     "home.statsTitle": "Reportar es radicalmente más simple.",
     "home.statAverage": "Tiempo promedio de reporte",
     "home.statAccuracy": "Precisión de enrutamiento",
+    "home.statMunicipalities": "Municipios cubiertos",
+    "home.servicedLabel": "Ciudades que atendemos actualmente:",
     "home.statIssueTypes": "Tipos de problemas soportados",
     "home.challenge": "/ Reto",
     "home.challengeText":
@@ -691,6 +695,8 @@ export const messages = {
     "home.statsTitle": "让报告变得极其简单。",
     "home.statAverage": "平均报告时间",
     "home.statAccuracy": "路由准确率",
+    "home.statMunicipalities": "覆盖的城市",
+    "home.servicedLabel": "我们目前服务的城市：",
     "home.statIssueTypes": "支持的问题类型",
     "home.challenge": "/ 挑战",
     "home.challengeText":
@@ -1001,6 +1007,8 @@ export const messages = {
     "home.statsTitle": "Le signalement rendu radicalement plus simple.",
     "home.statAverage": "Temps moyen de signalement",
     "home.statAccuracy": "Précision du routage",
+    "home.statMunicipalities": "Municipalités couvertes",
+    "home.servicedLabel": "Villes que nous desservons actuellement :",
     "home.statIssueTypes": "Types de problèmes pris en charge",
     "home.challenge": "/ Défi",
     "home.challengeText":


### PR DESCRIPTION
Per request: drop the *Routing accuracy* stat and instead show **how many municipalities we cover** (11), with a small-font list of the actual serviced cities at the bottom.

- Stat is derived from the city list (`SERVICED_MUNICIPALITIES.length`) so the number and list never drift.
- Cities mirror the verified jurisdictions seeded in `prisma/agencies.ts`: Palo Alto, Menlo Park, East Palo Alto, Mountain View, Santa Clara County, Milpitas, Morgan Hill, Gilroy, Watsonville, Vallejo, San Leandro.

tsc clean · lint 0 errors · `next build` compiles.