### PR TITLE
feat(submission): make email submission verifiable (SUBMISSION_OVERRIDE_EMAIL)

### DIFF
--- a/nexa/.env.example
+++ b/nexa/.env.example
@@ -52,6 +52,12 @@ BREVO_SENDER_EMAIL=noreply@nexa.app
 # domain sender for SUBMISSION_FROM_EMAIL.
 RESEND_API_KEY=
 SUBMISSION_FROM_EMAIL=reports@nexa.app
+# OPTIONAL test/demo safety valve. When set, EVERY submission email is
+# redirected to this single inbox instead of the agency's real address (the
+# subject is tagged with the intended destination). Point it at your own inbox
+# to verify real end-to-end sending without emailing a live city. Leave UNSET in
+# production so reports go to the actual agency.
+SUBMISSION_OVERRIDE_EMAIL=
 
 # --- Manual reminder job ---
 # Protects POST /api/reports/send-follow-up-reminders. Generate with:

--- a/nexa/src/lib/submission/email.test.ts
+++ b/nexa/src/lib/submission/email.test.ts
@@ -54,6 +54,7 @@ function fakePhotoFetch(): typeof fetch {
 afterEach(() => {
   delete process.env.RESEND_API_KEY;
   delete process.env.SUBMISSION_FROM_EMAIL;
+  delete process.env.SUBMISSION_OVERRIDE_EMAIL;
   vi.restoreAllMocks();
 });
 
@@ -176,6 +177,28 @@ describe("submitViaEmail — sending", () => {
     expect(payload.subject).toContain("Road Damage");
     expect(payload.attachments).toHaveLength(1);
     expect(payload.attachments?.[0].filename).toBe("abc123.png");
+  });
+
+  it("redirects to SUBMISSION_OVERRIDE_EMAIL and tags the subject when set", async () => {
+    // Arrange: a test/demo inbox override is configured.
+    process.env.SUBMISSION_FROM_EMAIL = "reports@nexa.app";
+    process.env.SUBMISSION_OVERRIDE_EMAIL = "me@example.com";
+    const send = vi.fn(async () => ({ data: { id: "msg-ovr" }, error: null }));
+
+    // Act
+    const result = await submitViaEmail(makeEmailReport(), {
+      agencyName: "Palo Alto Public Works",
+      intakeEmail: "311@paloalto.gov",
+      resendClient: fakeResend(send),
+      fetchImpl: fakePhotoFetch(),
+    });
+
+    // Assert: delivered to the override inbox, not the agency, with a clear tag
+    // naming the real destination so the test inbox isn't misleading.
+    expect(result).toEqual({ status: "submitted", messageId: "msg-ovr" });
+    const payload = firstSendPayload(send) as { to: string; subject: string };
+    expect(payload.to).toBe("me@example.com");
+    expect(payload.subject).toContain("[Nexa test → 311@paloalto.gov]");
   });
 
   it("still sends (no attachment) when the photo download fails", async () => {

--- a/nexa/src/lib/submission/email.ts
+++ b/nexa/src/lib/submission/email.ts
@@ -235,7 +235,14 @@ export async function submitViaEmail(
       reason: "SUBMISSION_FROM_EMAIL is not set; email submission is disabled.",
     };
   }
-  const to = options.intakeEmail?.trim();
+  // Optional test/demo safety valve: when SUBMISSION_OVERRIDE_EMAIL is set,
+  // every submission email is redirected to that single inbox instead of the
+  // agency's real address. This lets you verify real end-to-end sending against
+  // your own inbox without emailing a live city. Leave it unset in production
+  // to file with the actual agency.
+  const overrideTo = process.env.SUBMISSION_OVERRIDE_EMAIL?.trim();
+  const agencyTo = options.intakeEmail?.trim();
+  const to = overrideTo || agencyTo;
   if (!to) {
     return {
       status: "not_configured",
@@ -246,6 +253,12 @@ export async function submitViaEmail(
   const composed = composeSubmissionEmail(report, {
     agencyName: options.agencyName,
   });
+
+  // When redirected, tag the subject so the test inbox makes clear where this
+  // would have gone in production.
+  if (overrideTo && agencyTo && overrideTo !== agencyTo) {
+    composed.subject = `[Nexa test → ${agencyTo}] ${composed.subject}`;
+  }
 
   // A custom fetchImpl (tests) is used verbatim; otherwise fetchWithTimeout
   // bounds the photo download so a hung asset host can't stall the submission.


### PR DESCRIPTION
Follows up the "does Submit actually submit?" question. The email agent already files real reports (with the photo attached) via Resend for **EMAIL-intake agencies** the moment `RESEND_API_KEY` + `SUBMISSION_FROM_EMAIL` are set — no synthetic stub. This makes it safe to verify.

## What
- New optional **`SUBMISSION_OVERRIDE_EMAIL`**: when set, every submission email is redirected to that single inbox instead of the agency's real address, and the subject is tagged `[Nexa test → <real address>]`. Point it at your own inbox to confirm real end-to-end sending **without emailing a live city**. Leave unset in production to file with the actual agency.

## How to verify it actually sends
1. Set `RESEND_API_KEY`, `SUBMISSION_FROM_EMAIL` (verified Resend sender), and `SUBMISSION_OVERRIDE_EMAIL` (your inbox).
2. Report **illegal dumping** at an **East Palo Alto** location — that routes to *East Palo Alto Clean City*, the seeded EMAIL-intake agency.
3. Hit Submit → status goes CONFIRMED → SUBMITTING → SUBMITTED, and the email (with photo) lands in your inbox.

Documented in `.env.example`. tsc clean · email tests 11 passed (added the override test) · prettier clean.