### PR TITLE
feat(dashboard): number map pins by the order reports were filed

### DIFF
--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -50,25 +50,28 @@ export default async function DashboardPage() {
   ).length;
   const latestReport = reports[0];
 
-  const mapPoints: ReportMapPoint[] = reports
-    .filter(
-      (
-        report,
-      ): report is typeof report & { latitude: number; longitude: number } =>
-        typeof report.latitude === "number" &&
-        Number.isFinite(report.latitude) &&
-        typeof report.longitude === "number" &&
-        Number.isFinite(report.longitude),
-    )
-    .map((report) => ({
-      id: report.id,
-      latitude: report.latitude,
-      longitude: report.longitude,
-      issueType: report.issueType,
-      shortLocation: shortenAddress(report.address),
-      status: report.status,
-      relativeTime: formatRelativeTime(report.createdAt),
-    }));
+  const mappableReports = reports.filter(
+    (
+      report,
+    ): report is typeof report & { latitude: number; longitude: number } =>
+      typeof report.latitude === "number" &&
+      Number.isFinite(report.latitude) &&
+      typeof report.longitude === "number" &&
+      Number.isFinite(report.longitude),
+  );
+  // Pins are numbered in the order the reports were filed: #1 is the earliest.
+  // `reports` is ordered newest-first, so the last item is the earliest — hence
+  // `length - index`.
+  const mapPoints: ReportMapPoint[] = mappableReports.map((report, index) => ({
+    id: report.id,
+    latitude: report.latitude,
+    longitude: report.longitude,
+    issueType: report.issueType,
+    shortLocation: shortenAddress(report.address),
+    status: report.status,
+    relativeTime: formatRelativeTime(report.createdAt),
+    order: mappableReports.length - index,
+  }));
 
   return (
     <main className="mx-auto w-full max-w-4xl flex-1 px-6 py-10">

--- a/nexa/src/components/dashboard/reports-map.test.tsx
+++ b/nexa/src/components/dashboard/reports-map.test.tsx
@@ -52,6 +52,7 @@ function makePoint(overrides: Partial<ReportMapPoint> = {}): ReportMapPoint {
     shortLocation: "Palo Alto, CA",
     status: "CONFIRMED",
     relativeTime: "2 days ago",
+    order: 1,
     ...overrides,
   };
 }
@@ -116,6 +117,23 @@ describe("ReportsMap", () => {
     await waitFor(() => expect(divIconCalls.length).toBe(2));
     expect(divIconCalls[0].html).toContain("#22c55e");
     expect(divIconCalls[1].html).toContain("#9b87f5");
+  });
+
+  it("renders each pin's filing-order number", async () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReportsMap
+        points={[
+          makePoint({ id: "a", order: 2 }),
+          makePoint({ id: "b", order: 1 }),
+        ]}
+      />,
+    );
+
+    // Assert: the order is drawn into the pin glyph as an SVG <text> label.
+    await waitFor(() => expect(divIconCalls.length).toBe(2));
+    expect(divIconCalls[0].html).toContain(">2</text>");
+    expect(divIconCalls[1].html).toContain(">1</text>");
   });
 
   it("opens a pin's popup on hover and closes it on mouse-out", async () => {

--- a/nexa/src/components/dashboard/reports-map.tsx
+++ b/nexa/src/components/dashboard/reports-map.tsx
@@ -14,6 +14,8 @@ export interface ReportMapPoint {
   shortLocation: string;
   status: string;
   relativeTime: string;
+  /** 1-based sequence in the order the report was filed (1 = earliest). */
+  order: number;
 }
 
 interface ReportsMapProps {
@@ -30,7 +32,9 @@ const CONFIRMED_STATUSES = new Set([
   "CLOSED",
 ]);
 
-function pinSvg(color: string): string {
+function pinSvg(color: string, label: number): string {
+  // Two-digit counts need a slightly smaller glyph to stay inside the head.
+  const fontSize = label >= 10 ? 8 : 10;
   return `
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 36" width="28" height="36" aria-hidden="true">
       <defs>
@@ -40,7 +44,8 @@ function pinSvg(color: string): string {
       </defs>
       <g filter="url(#shadow)">
         <path d="M14 1c-6.6 0-12 5.3-12 11.8 0 8.8 11 21.5 11.5 22 .3.3.8.3 1.1 0 .5-.5 11.4-13.2 11.4-22C26 6.3 20.6 1 14 1z" fill="${color}" />
-        <circle cx="14" cy="13" r="4.5" fill="#ffffff" />
+        <circle cx="14" cy="13" r="7.5" fill="#ffffff" />
+        <text x="14" y="13.5" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif, system-ui, sans-serif" font-size="${fontSize}" font-weight="700" fill="${color}">${label}</text>
       </g>
     </svg>
   `;
@@ -95,7 +100,7 @@ export function ReportsMap({ points }: ReportsMapProps) {
 
         const icon = L.divIcon({
           className: "nexa-map-pin",
-          html: pinSvg(color),
+          html: pinSvg(color, point.order),
           iconSize: [28, 36],
           iconAnchor: [14, 35],
           popupAnchor: [0, -30],


### PR DESCRIPTION
The dashboard map pins were undifferentiated (and an older deploy showed "1" on every pin). Now each pin shows its **filing-order number** — #1 is the earliest report you filed, counting up to the most recent — drawn into the pin glyph.

- `ReportMapPoint` gains an `order` field; the dashboard computes it as `length - index` over the mappable reports (the query is newest-first, so the last item is the earliest → #1).
- The pin SVG renders the number (with a smaller glyph for 2-digit counts).

tsc clean · reports-map tests 8 passed (added an order-label test) · prettier clean.