### PR TITLE
fix(agencies): repair the dead Santa Clara County Public Works link

### DIFF
--- a/nexa/prisma/agencies.ts
+++ b/nexa/prisma/agencies.ts
@@ -353,8 +353,11 @@ export const AGENCIES: AgencySeed[] = [
       "STREET_SWEEPING",
     ],
     intakeMethod: "WEB_FORM",
-    intakeUrl:
-      "https://publicworks.sccgov.org/services/road-maintenance/report-problem",
+    // The old publicworks.sccgov.org host no longer resolves (NXDOMAIN). The
+    // County's Roads & Airports Department moved to roads.santaclaracounty.gov;
+    // this is its service-requests hub for reporting road/expressway problems
+    // (potholes, traffic signals, signage, etc.) in unincorporated areas.
+    intakeUrl: "https://roads.santaclaracounty.gov/services/service-requests",
     intakeEmail: null,
     requiredFields: {
       description: { type: "string", required: true },


### PR DESCRIPTION
The Santa Clara County intake link went nowhere — `publicworks.sccgov.org` no longer resolves (NXDOMAIN). Verified via multi-agent link audit of every seeded intake URL: this was the **only** dead one (the others return 403 from bot-protection but are confirmed live/correct).

The County's Roads & Airports Department moved to **roads.santaclaracounty.gov**. Pointing the seed at its service-requests hub: `https://roads.santaclaracounty.gov/services/service-requests` — the landing for reporting unincorporated-area road problems (potholes, traffic signals, signage, etc.), confirmed live via search.

tsc clean · eval:coverage 153 triples · prettier clean.

Sources:
- [Service requests | County Roads](https://roads.santaclaracounty.gov/services/service-requests)
- [Report potholes, graffiti, illegal dumping on County-maintained roads](https://roads.santaclaracounty.gov/services/service-requests/report-potholes-graffiti-illegal-dumping-county-maintained-roads)