### PR TITLE
build(deploy): re-seed agencies on deploy so reference-data fixes reach prod

### DIFF
--- a/nexa/package.json
+++ b/nexa/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && ([ -z \"$DATABASE_URL\" ] || prisma migrate deploy) && next build",
+    "build": "prisma generate && ([ -z \"$DATABASE_URL\" ] || (prisma migrate deploy && (prisma db seed || echo '[build] agency seed failed (non-fatal); reference data may be stale'))) && next build",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
**Root cause of the 'I fixed the Santa Clara link but it's still wrong' problem:** the build runs `prisma migrate deploy` but never the **seed**. Agency data (intake URLs, issue types) lives in `prisma/agencies.ts` and is only written to the DB by `prisma/seed.ts` — which never ran on deploy. So #281's URL fix sat in the seed file but the live DB kept the dead URL.

**Fix:** run `prisma db seed` after `migrate deploy` on every build that has a `DATABASE_URL`. The seed **only upserts agencies** by `(jurisdiction, name)` — idempotent and non-destructive (no users/reports touched), so it's safe to run on every deploy and keeps the agency table in sync with the seed file going forward. Seed failure is non-fatal (logged, doesn't block the deploy). CI's build job is compile-only (no DATABASE_URL) so it's unaffected.

package.json valid · build-script shell syntax verified · prettier clean.