### PR TITLE
fix(map): number the /map community-map pins by filing order (not all '1')

### DIFF
--- a/nexa/src/app/api/issues/map/route.test.ts
+++ b/nexa/src/app/api/issues/map/route.test.ts
@@ -90,6 +90,35 @@ describe("GET /api/issues/map", () => {
     expect(body.data.points[0].myReportId).toBeNull();
   });
 
+  it("numbers pins by filing order (1 = earliest), independent of display order", async () => {
+    // Arrange: findMany returns newest-active first, but the EARLIER-created
+    // group must still get order 1.
+    mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });
+    prismaMock.issueGroup.findMany.mockResolvedValue([
+      makeGroupRow({
+        id: "newer",
+        createdAt: new Date("2025-03-01T00:00:00.000Z"),
+      }),
+      makeGroupRow({
+        id: "older",
+        createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      }),
+    ] as never);
+
+    // Act
+    const response = await GET();
+    const body = await response.json();
+
+    // Assert: order is by createdAt, not array position.
+    const byId = Object.fromEntries(
+      body.data.points.map((p: { id: string; order: number }) => [
+        p.id,
+        p.order,
+      ]),
+    );
+    expect(byId).toEqual({ older: 1, newer: 2 });
+  });
+
   it("returns an empty points array when there are no issue groups", async () => {
     // Arrange
     mockedGetSession.mockResolvedValue({ userId: "viewer", email: "v@x.com" });

--- a/nexa/src/components/map/community-map.tsx
+++ b/nexa/src/components/map/community-map.tsx
@@ -12,6 +12,8 @@ export interface IssueMapPoint {
   status: string;
   reportCount: number;
   relativeTime: string;
+  /** 1-based sequence in the order the issue was first filed (1 = earliest). */
+  order: number;
   // The current user's own report id within this group, if they filed one.
   myReportId: string | null;
 }
@@ -52,9 +54,10 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
-// Teardrop pin with the reporter count rendered inside the head.
-function pinSvg(color: string, count: number): string {
-  const label = count > 99 ? "99+" : String(count);
+// Teardrop pin with the issue's filing-order number rendered inside the head.
+// (The reporter count stays in the popup.)
+function pinSvg(color: string, order: number): string {
+  const label = order > 999 ? "999+" : String(order);
   const fontSize = label.length >= 3 ? 7 : 9;
   return `
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 36" width="28" height="36" aria-hidden="true">
@@ -130,7 +133,7 @@ export default function CommunityMap({ points, onResolve }: CommunityMapProps) {
 
         const icon = L.divIcon({
           className: "nexa-map-pin",
-          html: pinSvg(color, point.reportCount),
+          html: pinSvg(color, point.order),
           iconSize: [28, 36],
           iconAnchor: [14, 35],
           popupAnchor: [0, -30],

--- a/nexa/src/lib/issues/map.ts
+++ b/nexa/src/lib/issues/map.ts
@@ -30,6 +30,15 @@ export async function getIssueMapPoints(
     },
   });
 
+  // Number the pins by when each issue was first filed (1 = earliest), so the
+  // map is sequenced like the dashboard. Computed independently of the display
+  // order above (which is most-recently-active first).
+  const orderByGroupId = new Map(
+    [...groups]
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      .map((group, index) => [group.id, index + 1] as const),
+  );
+
   return groups.map((group) => ({
     id: group.id,
     latitude: group.latitude,
@@ -39,6 +48,7 @@ export async function getIssueMapPoints(
     status: group.status,
     reportCount: group.reportCount,
     relativeTime: formatRelativeTime(group.createdAt),
+    order: orderByGroupId.get(group.id) ?? 1,
     myReportId: group.reports[0]?.id ?? null,
   }));
 }


### PR DESCRIPTION
The **/map** page (the 'Map' nav tab) is a *different* component from the dashboard map — `community-map.tsx` — which my earlier numbering fix (#280) never touched. It rendered the per-issue **reporter count** inside each pin, so every distinct location showed **"1"** (one report each).

**Fix:** number the pins by the order each issue was **first filed** (1 = earliest), matching the dashboard map. The reporter count stays in the pin's **popup** ("N report(s)"). `getIssueMapPoints` computes `order` by `createdAt` independently of the display order (which is most-recently-active first), so the numbering is stable regardless of map sort.

tsc clean · map route tests 5 passed (added an order test) · lint 0 errors · prettier clean · coverage gate exit 0.