### PR TITLE
refactor(dashboard): prove map pins renumber contiguously after delete

### DIFF
--- a/nexa/src/app/dashboard/page.tsx
+++ b/nexa/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { ArrowRight, CheckCircle2, Clock3, ClipboardList } from "lucide-react";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { shortenAddress } from "@/lib/constants";
+import { buildReportMapPoints } from "@/lib/dashboard/map-points";
 import { formatFullDateTime, formatRelativeTime } from "@/lib/utils";
 import { ReportCard } from "@/components/dashboard/report-card";
 import {
@@ -50,28 +50,9 @@ export default async function DashboardPage() {
   ).length;
   const latestReport = reports[0];
 
-  const mappableReports = reports.filter(
-    (
-      report,
-    ): report is typeof report & { latitude: number; longitude: number } =>
-      typeof report.latitude === "number" &&
-      Number.isFinite(report.latitude) &&
-      typeof report.longitude === "number" &&
-      Number.isFinite(report.longitude),
-  );
-  // Pins are numbered in the order the reports were filed: #1 is the earliest.
-  // `reports` is ordered newest-first, so the last item is the earliest — hence
-  // `length - index`.
-  const mapPoints: ReportMapPoint[] = mappableReports.map((report, index) => ({
-    id: report.id,
-    latitude: report.latitude,
-    longitude: report.longitude,
-    issueType: report.issueType,
-    shortLocation: shortenAddress(report.address),
-    status: report.status,
-    relativeTime: formatRelativeTime(report.createdAt),
-    order: mappableReports.length - index,
-  }));
+  // Pins are numbered by filing order (#1 = earliest), recomputed from the
+  // current reports, so deleting one re-sequences the rest contiguously.
+  const mapPoints: ReportMapPoint[] = buildReportMapPoints(reports);
 
   return (
     <main className="mx-auto w-full max-w-4xl flex-1 px-6 py-10">

--- a/nexa/src/lib/dashboard/map-points.test.ts
+++ b/nexa/src/lib/dashboard/map-points.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildReportMapPoints, type MappableReportInput } from "./map-points";
+
+// Reports as the dashboard queries them: newest-first.
+function report(
+  id: string,
+  overrides: Partial<MappableReportInput> = {},
+): MappableReportInput {
+  return {
+    id,
+    issueType: "ROAD_DAMAGE",
+    status: "CONFIRMED",
+    address: "1 Main St, Palo Alto, CA",
+    latitude: 37.44,
+    longitude: -122.16,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("buildReportMapPoints", () => {
+  it("numbers pins by filing order (#1 = earliest)", () => {
+    // newest-first input: d (newest) .. a (oldest)
+    const points = buildReportMapPoints([
+      report("d"),
+      report("c"),
+      report("b"),
+      report("a"),
+    ]);
+    const orderById = Object.fromEntries(points.map((p) => [p.id, p.order]));
+    expect(orderById).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it("re-sequences contiguously after a report is deleted (1·2·3·4, delete 2 -> 1·2·3)", () => {
+    // Start with a,b,c,d (orders 1,2,3,4). Delete "b" (the #2) and rebuild from
+    // the remaining reports — the pins must become 1·2·3, never 1·3·4.
+    const remaining = [report("d"), report("c"), report("a")]; // newest-first, no "b"
+    const points = buildReportMapPoints(remaining);
+    const orderById = Object.fromEntries(points.map((p) => [p.id, p.order]));
+    expect(orderById).toEqual({ a: 1, c: 2, d: 3 });
+    // No gaps: the orders are exactly 1..N.
+    expect(points.map((p) => p.order).sort((x, y) => x - y)).toEqual([1, 2, 3]);
+  });
+
+  it("drops reports without valid coordinates before numbering", () => {
+    const points = buildReportMapPoints([
+      report("withGeo"),
+      report("noGeo", { latitude: null, longitude: null }),
+      report("oldest"),
+    ]);
+    expect(points.map((p) => p.id)).toEqual(["withGeo", "oldest"]);
+    // Only the two mappable reports are numbered, contiguously.
+    expect(points.map((p) => p.order)).toEqual([2, 1]);
+  });
+});

--- a/nexa/src/lib/dashboard/map-points.ts
+++ b/nexa/src/lib/dashboard/map-points.ts
@@ -1,0 +1,51 @@
+import { shortenAddress } from "@/lib/constants";
+import { formatRelativeTime } from "@/lib/utils";
+import type { ReportMapPoint } from "@/components/dashboard/reports-map";
+
+/** The report fields the dashboard map needs, newest-first (as queried). */
+export type MappableReportInput = {
+  id: string;
+  issueType: string | null;
+  status: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  createdAt: Date;
+};
+
+/**
+ * Builds the dashboard map pins from the user's reports. Keeps only reports
+ * with valid coordinates and numbers them by filing order (#1 = earliest).
+ *
+ * The number is computed from the CURRENT set every call, so deleting a report
+ * re-sequences the rest contiguously (delete the "2" of 1·2·3·4 and the pins
+ * become 1·2·3, never 1·3·4). `reports` is newest-first, so the earliest is
+ * last — hence `length - index`.
+ */
+export function buildReportMapPoints(
+  reports: MappableReportInput[],
+): ReportMapPoint[] {
+  const mappable = reports.filter(
+    (
+      report,
+    ): report is MappableReportInput & {
+      latitude: number;
+      longitude: number;
+    } =>
+      typeof report.latitude === "number" &&
+      Number.isFinite(report.latitude) &&
+      typeof report.longitude === "number" &&
+      Number.isFinite(report.longitude),
+  );
+
+  return mappable.map((report, index) => ({
+    id: report.id,
+    latitude: report.latitude,
+    longitude: report.longitude,
+    issueType: report.issueType,
+    shortLocation: shortenAddress(report.address),
+    status: report.status,
+    relativeTime: formatRelativeTime(report.createdAt),
+    order: mappable.length - index,
+  }));
+}


### PR DESCRIPTION
Per request — deleting a report should renumber the remaining map pins **1·2·3**, not leave a gap (**1·3·4**).

This already happens in the merged code: the dashboard numbers pins from the *current* reports on every render (`order = length - index`), and the delete button calls `router.refresh()`, which re-runs that computation — so the gap you see live is the **old deployed build**, not the code.

To lock the behavior in, this extracts the inline ordering into a pure `buildReportMapPoints()` helper and adds a test that **deletes the #2 of 1·2·3·4 and asserts the pins become 1·2·3** (plus: numbers by filing order, drops no-coordinate reports). No behavior change — just verified + regression-proofed.

tsc clean · 3 new tests pass · lint 0 errors · prettier clean · coverage exit 0.