### PR TITLE
fix(ui): navbar dropdown hidden behind the map + oversized Report Issue CTA

### DIFF
--- a/nexa/src/app/globals.css
+++ b/nexa/src/app/globals.css
@@ -182,10 +182,22 @@
   font-weight: 500;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+  /* Keep the label on one line — a wrapped CTA (e.g. "REPORT ISSUE" -> two
+     lines) reads as an oversized button on a narrow navbar. */
+  white-space: nowrap;
   border-radius: 0.5rem;
   transition: all 150ms ease;
   cursor: pointer;
   text-decoration: none;
+}
+
+/* Tighten the in-navbar CTAs on small screens so the top bar stays compact. */
+@media (max-width: 639px) {
+  nav .btn-cta {
+    padding: 0.5rem 0.85rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.03em;
+  }
 }
 
 .btn-cta-purple {

--- a/nexa/src/components/dashboard/reports-map.tsx
+++ b/nexa/src/components/dashboard/reports-map.tsx
@@ -165,7 +165,9 @@ export function ReportsMap({ points }: ReportsMapProps) {
       </div>
       <div
         ref={containerRef}
-        className="h-[360px] w-full"
+        // Isolate Leaflet's z-index stack so its panes never paint over
+        // overlays like the navbar dropdown.
+        className="isolate h-[360px] w-full"
         role="img"
         aria-label={t("dashboard.mapAria", {
           count: points.length,

--- a/nexa/src/components/map/community-map.tsx
+++ b/nexa/src/components/map/community-map.tsx
@@ -206,7 +206,10 @@ export default function CommunityMap({ points, onResolve }: CommunityMapProps) {
   return (
     <div
       ref={containerRef}
-      className="h-[calc(100vh-72px)] w-full"
+      // `isolate` keeps Leaflet's internal pane/control z-indexes (up to ~1000)
+      // from leaking into the root stacking context and painting over the
+      // navbar's account dropdown.
+      className="isolate h-[calc(100vh-72px)] w-full"
       role="img"
       aria-label={`Map showing ${points.length} community ${points.length === 1 ? "issue" : "issues"}`}
     />


### PR DESCRIPTION
Two navbar issues from device testing.

## 1. Account dropdown hidden behind the map (`/map`)
The Leaflet map container was **static-positioned**, so Leaflet's internal pane/control z-indexes (up to ~1000) leaked into the **root** stacking context and painted over the navbar account dropdown (which is `z-50`). Fix: add **`isolate`** to the map containers (community map + dashboard map) so Leaflet's z-index stack is contained — the navbar menu now sits above the map. Cleaner than bumping every overlay's z-index.

## 2. Oversized "Report Issue" button
On a narrow navbar the CTA label wrapped to two lines ("REPORT / ISSUE"), making the button look huge. Fix: `white-space: nowrap` on `.btn-cta` (keeps it one line) plus a small-screen rule that tightens **in-navbar** CTAs (smaller padding/font) without shrinking the full-width CTAs elsewhere.

tsc clean · lint 0 errors · prettier clean · map tests pass · `next build` compiles.