### PR TITLE
feat(report): detect whether a custom agency link is a submittable form

### DIFF
--- a/nexa/src/app/api/reports/check-link/route.test.ts
+++ b/nexa/src/app/api/reports/check-link/route.test.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The detection service is the unit under test elsewhere; here we mock it so the
+// route test exercises only the route's posture (rate limit, parse, envelope).
+const { checkSubmittableLink } = vi.hoisted(() => ({
+  checkSubmittableLink: vi.fn(),
+}));
+
+vi.mock("@/lib/submission/link-check", () => ({ checkSubmittableLink }));
+
+import { POST } from "./route";
+import { __resetRateLimitStore } from "@/lib/rate-limit";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/reports/check-link", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": "10.2.0.1",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/reports/check-link", () => {
+  beforeEach(() => {
+    __resetRateLimitStore();
+    checkSubmittableLink.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the detection verdict for a valid URL", async () => {
+    // Arrange
+    checkSubmittableLink.mockResolvedValue({
+      status: "form_found",
+      confidence: "high",
+      signals: ["post_form"],
+    });
+
+    // Act
+    const res = await POST(post({ url: "https://city.gov/report" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      data: {
+        status: "form_found",
+        confidence: "high",
+        signals: ["post_form"],
+      },
+    });
+    expect(checkSubmittableLink).toHaveBeenCalledWith(
+      "https://city.gov/report",
+    );
+  });
+
+  it("returns 400 for a malformed URL without invoking the checker", async () => {
+    // Act
+    const res = await POST(post({ url: "not a url" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(checkSubmittableLink).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when url is missing", async () => {
+    const res = await POST(post({}));
+    expect(res.status).toBe(400);
+    expect(checkSubmittableLink).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/reports/check-link", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "10.2.0.9",
+      },
+      body: "{not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rate-limits abusive callers with a 429 (matches sibling routes)", async () => {
+    // Arrange: drive the shared per-IP limiter past its window cap.
+    checkSubmittableLink.mockResolvedValue({ status: "no_form", reason: "x" });
+    const max = 20; // default RATE_LIMIT_MAX
+    let last: Response | undefined;
+    for (let i = 0; i < max + 1; i++) {
+      last = await POST(post({ url: "https://city.gov/report" }));
+    }
+
+    // Assert
+    expect(last?.status).toBe(429);
+    expect(last?.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("returns 500 when the checker itself rejects (it normally never throws)", async () => {
+    // Arrange
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    checkSubmittableLink.mockRejectedValue(new Error("unexpected"));
+
+    // Act
+    const res = await POST(post({ url: "https://city.gov/report" }));
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      success: false,
+      error: "Failed to check the link.",
+    });
+  });
+});

--- a/nexa/src/app/api/reports/check-link/route.ts
+++ b/nexa/src/app/api/reports/check-link/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { CheckLinkRequestSchema } from "@/lib/api/schemas";
+import {
+  parseJsonRequest,
+  RequestParseError,
+  parseErrorResponse,
+} from "@/lib/api/request-parser";
+import { successResponse, errorResponse } from "@/lib/api/response";
+import { enforceRateLimit } from "@/lib/rate-limit";
+import { checkSubmittableLink } from "@/lib/submission/link-check";
+import type { LinkCheckResult } from "@/lib/api/types";
+
+/**
+ * `POST /api/reports/check-link` — given a user-supplied custom agency link
+ * (the "Filing somewhere else?" override on the review step), report whether it
+ * points at a submittable form. Mirrors the form-link route's posture: no auth
+ * (the report flow itself is anonymous-friendly), the shared per-IP rate limit
+ * (this route fans out a third-party fetch and is otherwise trivially abusable),
+ * zod-validated body, and the standard success/error envelope.
+ *
+ * The detection itself never throws (see {@link checkSubmittableLink}); a 500 is
+ * therefore reserved for genuinely unexpected route-level failures.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request.headers);
+    if (limited) return limited;
+
+    const { url } = await parseJsonRequest(request, CheckLinkRequestSchema);
+
+    const result: LinkCheckResult = await checkSubmittableLink(url);
+    return successResponse(result);
+  } catch (error) {
+    if (error instanceof RequestParseError) {
+      return parseErrorResponse(error);
+    }
+    console.error("Custom-link check error:", error);
+    return errorResponse("Failed to check the link.", 500);
+  }
+}

--- a/nexa/src/app/report/page.tsx
+++ b/nexa/src/app/report/page.tsx
@@ -12,6 +12,7 @@ import { useImageUpload } from "@/hooks/use-image-upload";
 import { useGeolocation } from "@/hooks/use-geolocation";
 import { useAddressLookup } from "@/hooks/use-address-lookup";
 import { useFormLookup } from "@/hooks/use-form-lookup";
+import { useLinkCheck } from "@/hooks/use-link-check";
 import { useAgencyCandidates } from "@/hooks/use-agency-candidates";
 import { useReportSubmission } from "@/hooks/use-report-submission";
 import { useI18n } from "@/i18n/provider";
@@ -108,7 +109,20 @@ export default function ReportPage() {
   const geo = useGeolocation();
   const addressLookup = useAddressLookup();
   const formLookup = useFormLookup();
+  const linkCheck = useLinkCheck();
   const agencyCandidates = useAgencyCandidates();
+
+  // Wrong-agency override: as the user types/pastes a link, run the advisory
+  // submittable-form check (debounced inside the hook). Purely informational —
+  // never gates submit; the override is always stored verbatim.
+  const checkLink = linkCheck.check;
+  const handleCustomAgencyUrlChange = useCallback(
+    (value: string) => {
+      setCustomAgencyUrl(value);
+      checkLink(value);
+    },
+    [checkLink],
+  );
   const submission = useReportSubmission();
 
   // Latest values the auto-suggest effect needs to read without re-firing on
@@ -413,6 +427,7 @@ export default function ReportPage() {
     addressLookup.reset();
     submission.reset();
     formLookup.reset();
+    linkCheck.reset();
     agencyCandidates.reset();
     setSelectedAgencyId(null);
     setCustomAgencyUrl("");
@@ -478,7 +493,9 @@ export default function ReportPage() {
               selectedAgencyId={selectedAgencyId}
               onSelectAgency={setSelectedAgencyId}
               customAgencyUrl={customAgencyUrl}
-              onCustomAgencyUrlChange={setCustomAgencyUrl}
+              onCustomAgencyUrlChange={handleCustomAgencyUrlChange}
+              linkCheck={linkCheck.result}
+              linkCheckLoading={linkCheck.loading}
               onDescriptionChange={handleDescriptionChange}
               onAddressChange={geo.setAddress}
               onBack={() => setStep("describe")}

--- a/nexa/src/components/report/review-step.test.tsx
+++ b/nexa/src/components/report/review-step.test.tsx
@@ -6,6 +6,7 @@ import { ReviewStep } from "./review-step";
 
 type OfficialForm = Parameters<typeof ReviewStep>[0]["officialForm"];
 type Candidates = Parameters<typeof ReviewStep>[0]["agencyCandidates"];
+type LinkCheck = Parameters<typeof ReviewStep>[0]["linkCheck"];
 
 function baseProps() {
   return {
@@ -30,6 +31,8 @@ function baseProps() {
     onSelectAgency: vi.fn(),
     customAgencyUrl: "",
     onCustomAgencyUrlChange: vi.fn(),
+    linkCheck: null as LinkCheck,
+    linkCheckLoading: false,
     onDescriptionChange: vi.fn(),
     onAddressChange: vi.fn(),
     onBack: vi.fn(),
@@ -414,6 +417,78 @@ describe("ReviewStep", () => {
     // Assert
     expect(props.onCustomAgencyUrlChange).toHaveBeenCalledWith("x");
   });
+
+  it("shows no link-check feedback until the user has typed a link", () => {
+    // Arrange / Act: a verdict exists but the field is empty (e.g. cleared).
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        customAgencyUrl=""
+        linkCheck={{ status: "form_found", confidence: "high", signals: [] }}
+      />,
+    );
+
+    // Assert: nothing rendered for an empty field.
+    expect(
+      screen.queryByText("Looks like a submittable form."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the checking spinner text while the link check is in flight", () => {
+    // Arrange / Act
+    renderWithProviders(
+      <ReviewStep
+        {...baseProps()}
+        customAgencyUrl="https://city.gov/report"
+        linkCheckLoading
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("Checking link...")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "form_found",
+      { status: "form_found", confidence: "high", signals: [] },
+      "Looks like a submittable form.",
+    ],
+    [
+      "no_form",
+      { status: "no_form", reason: "no form" },
+      "We couldn't find a form at that link — double-check it.",
+    ],
+    [
+      "unreachable",
+      { status: "unreachable", reason: "boom" },
+      "That link doesn't work — double-check it.",
+    ],
+    [
+      "invalid_url",
+      { status: "invalid_url" },
+      "That doesn't look like a valid web link.",
+    ],
+  ] as const)(
+    "renders advisory feedback for the %s verdict",
+    (_label, verdict, expected) => {
+      // Arrange / Act
+      renderWithProviders(
+        <ReviewStep
+          {...baseProps()}
+          customAgencyUrl="https://city.gov/report"
+          linkCheck={verdict as LinkCheck}
+        />,
+      );
+
+      // Assert: the matching advisory message renders, and submit stays enabled
+      // (the check is purely advisory — it never blocks submission).
+      expect(screen.getByText(expected)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Submit Report/ }),
+      ).not.toBeDisabled();
+    },
+  );
 
   it("shows an informative message when the candidate list is empty", () => {
     // Arrange / Act: fetch succeeded but no agency covers this spot.

--- a/nexa/src/components/report/review-step.tsx
+++ b/nexa/src/components/report/review-step.tsx
@@ -3,9 +3,11 @@
 import {
   ArrowLeft,
   ArrowRight,
+  CheckCircle2,
   ExternalLink,
   Loader2,
   Pencil,
+  XCircle,
 } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -15,6 +17,7 @@ import { useI18n } from "@/i18n/provider";
 import type { ClassificationResult } from "@/lib/classify/types";
 import type {
   AgencyCandidatesResult,
+  LinkCheckResult,
   OfficialFormLookupResult,
 } from "@/lib/api/types";
 
@@ -53,6 +56,14 @@ interface ReviewStepProps {
    */
   customAgencyUrl: string;
   onCustomAgencyUrlChange: (value: string) => void;
+  /**
+   * Advisory verdict on whether `customAgencyUrl` points at a submittable form,
+   * from `useLinkCheck`. Null until the user has typed a link. Purely advisory —
+   * submission is NEVER blocked on it, the field stays usable regardless.
+   */
+  linkCheck: LinkCheckResult | null;
+  /** Whether the link check is in flight (debounced fetch). */
+  linkCheckLoading: boolean;
   onDescriptionChange: (value: string) => void;
   onAddressChange: (value: string) => void;
   onBack: () => void;
@@ -76,6 +87,8 @@ export function ReviewStep({
   onSelectAgency,
   customAgencyUrl,
   onCustomAgencyUrlChange,
+  linkCheck,
+  linkCheckLoading,
   onDescriptionChange,
   onAddressChange,
   onBack,
@@ -346,7 +359,57 @@ export function ReviewStep({
           onChange={(e) => onCustomAgencyUrlChange(e.target.value)}
           className="mt-3"
           placeholder={t("report.customAgencyPlaceholder")}
+          aria-describedby="custom-agency-url-feedback"
         />
+        {/*
+          Advisory link-check feedback. Verdict colors: green = a submittable
+          form was found, amber = reachable but no form, red = broken/invalid
+          link. It NEVER blocks submit — the field stays usable regardless, the
+          override is always stored verbatim. Shows only once the user has typed
+          something (linkCheckLoading or a verdict is present).
+        */}
+        {customAgencyUrl.trim() &&
+          (linkCheckLoading ? (
+            <p
+              id="custom-agency-url-feedback"
+              className="mt-3 flex items-center gap-2 text-xs text-muted-foreground"
+            >
+              <Loader2 className="size-3.5 animate-spin" />
+              {t("report.linkChecking")}
+            </p>
+          ) : linkCheck?.status === "form_found" ? (
+            <p
+              id="custom-agency-url-feedback"
+              className="mt-3 flex items-center gap-2 text-xs text-ep-green"
+            >
+              <CheckCircle2 className="size-3.5" />
+              {t("report.linkFormFound")}
+            </p>
+          ) : linkCheck?.status === "no_form" ? (
+            <p
+              id="custom-agency-url-feedback"
+              className="mt-3 flex items-center gap-2 text-xs text-yellow-600 dark:text-yellow-400"
+            >
+              <XCircle className="size-3.5" />
+              {t("report.linkNoForm")}
+            </p>
+          ) : linkCheck?.status === "invalid_url" ? (
+            <p
+              id="custom-agency-url-feedback"
+              className="mt-3 flex items-center gap-2 text-xs text-red-600 dark:text-red-400"
+            >
+              <XCircle className="size-3.5" />
+              {t("report.linkInvalid")}
+            </p>
+          ) : linkCheck?.status === "unreachable" ? (
+            <p
+              id="custom-agency-url-feedback"
+              className="mt-3 flex items-center gap-2 text-xs text-red-600 dark:text-red-400"
+            >
+              <XCircle className="size-3.5" />
+              {t("report.linkUnreachable")}
+            </p>
+          ) : null)}
       </div>
 
       {submitError && <ErrorBanner message={submitError} />}

--- a/nexa/src/hooks/use-link-check.test.tsx
+++ b/nexa/src/hooks/use-link-check.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { act, renderHook } from "@/test";
+
+import { useLinkCheck } from "./use-link-check";
+import type { LinkCheckResult } from "@/lib/api/types";
+
+/** Stub a `fetch` JSON response with the given status + envelope. */
+function mockFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+/** Advance past the hook's debounce window and flush the pending fetch. */
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(600);
+  });
+}
+
+describe("useLinkCheck", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("debounces and stores the verdict for a valid link", async () => {
+    const verdict: LinkCheckResult = {
+      status: "form_found",
+      confidence: "high",
+      signals: ["post_form"],
+    };
+    const fetchFn = mockFetch(200, { success: true, data: verdict });
+
+    const { result } = renderHook(() => useLinkCheck());
+
+    // Typing fires no fetch until the debounce elapses.
+    act(() => result.current.check("https://city.gov/report"));
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await flush();
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result.current.result).toEqual(verdict);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("clears the verdict for a blank field without fetching", async () => {
+    const fetchFn = mockFetch(200, { success: true, data: null });
+    const { result } = renderHook(() => useLinkCheck());
+
+    act(() => result.current.check("   "));
+    await flush();
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(result.current.result).toBeNull();
+  });
+
+  it("maps a 400 to an invalid_url verdict", async () => {
+    mockFetch(400, { success: false, error: "Enter a valid URL." });
+    const { result } = renderHook(() => useLinkCheck());
+
+    act(() => result.current.check("http://bad"));
+    await flush();
+
+    expect(result.current.result).toEqual({ status: "invalid_url" });
+  });
+
+  it("maps a network throw to an unreachable verdict", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchFn);
+    const { result } = renderHook(() => useLinkCheck());
+
+    act(() => result.current.check("https://city.gov/report"));
+    await flush();
+
+    expect(result.current.result).toMatchObject({ status: "unreachable" });
+  });
+
+  it("reset() clears the verdict and cancels the pending debounced check", async () => {
+    const fetchFn = mockFetch(200, {
+      success: true,
+      data: { status: "no_form", reason: "x" },
+    });
+    const { result } = renderHook(() => useLinkCheck());
+
+    act(() => result.current.check("https://city.gov/report"));
+    act(() => result.current.reset());
+
+    await flush();
+
+    // reset() cleared the debounce timer, so the fetch never fired.
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/nexa/src/hooks/use-link-check.ts
+++ b/nexa/src/hooks/use-link-check.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { ApiResponse } from "@/lib/api/response";
+import type { LinkCheckResult } from "@/lib/api/types";
+
+export type { LinkCheckResult };
+
+/**
+ * Verifies a user-supplied custom agency link against `/api/reports/check-link`
+ * and exposes the verdict for the review step's inline feedback. Mirrors
+ * `useFormLookup`: owns the `result` + a `loading` flag, and is purely advisory
+ * (the caller never blocks submit on it).
+ *
+ * `check` is debounced internally so typing/pasting into the field doesn't fire
+ * a request per keystroke. A blank/whitespace URL clears the verdict instead of
+ * calling the API. Each call supersedes any in-flight one, so a stale response
+ * can never overwrite a newer verdict.
+ */
+const DEBOUNCE_MS = 500;
+
+export function useLinkCheck() {
+  const [result, setResult] = useState<LinkCheckResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Monotonic token: only the latest request is allowed to write state.
+  const requestIdRef = useRef(0);
+
+  const run = useCallback(async (url: string) => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/reports/check-link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      const payload = (await res.json()) as ApiResponse<LinkCheckResult>;
+
+      // A superseding call started after this one — drop the stale result.
+      if (requestId !== requestIdRef.current) return;
+
+      if (!res.ok || !payload.success) {
+        // A 400 means the URL is syntactically invalid; surface that verdict so
+        // the user gets the same "doesn't work" feedback as a network failure,
+        // rather than a silent no-op.
+        setResult(
+          res.status === 400
+            ? { status: "invalid_url" }
+            : { status: "unreachable", reason: "We couldn't check that link." },
+        );
+        return;
+      }
+      setResult(payload.data);
+    } catch {
+      if (requestId !== requestIdRef.current) return;
+      setResult({
+        status: "unreachable",
+        reason: "We couldn't check that link.",
+      });
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, []);
+
+  const check = useCallback(
+    (url: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      const trimmed = url.trim();
+      if (!trimmed) {
+        // Blank field: cancel any pending verdict and clear the current one.
+        requestIdRef.current++;
+        setResult(null);
+        setLoading(false);
+        return;
+      }
+
+      debounceRef.current = setTimeout(() => {
+        void run(trimmed);
+      }, DEBOUNCE_MS);
+    },
+    [run],
+  );
+
+  const reset = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    requestIdRef.current++;
+    setResult(null);
+    setLoading(false);
+  }, []);
+
+  return { result, loading, check, reset };
+}

--- a/nexa/src/i18n/messages.ts
+++ b/nexa/src/i18n/messages.ts
@@ -201,6 +201,12 @@ const enMessages = {
   "report.customAgencyHelp":
     "If we routed to the wrong agency, paste the correct agency's link here.",
   "report.customAgencyPlaceholder": "https://city.gov/report",
+  "report.linkChecking": "Checking link...",
+  "report.linkFormFound": "Looks like a submittable form.",
+  "report.linkNoForm":
+    "We couldn't find a form at that link — double-check it.",
+  "report.linkUnreachable": "That link doesn't work — double-check it.",
+  "report.linkInvalid": "That doesn't look like a valid web link.",
   "report.submit": "Submit Report",
   "report.submitting": "Submitting...",
   "report.submitted": "Report submitted!",
@@ -536,6 +542,12 @@ export const messages = {
     "report.customAgencyHelp":
       "Si lo dirigimos a la agencia equivocada, pega aquí el enlace de la agencia correcta.",
     "report.customAgencyPlaceholder": "https://ciudad.gov/reportar",
+    "report.linkChecking": "Comprobando el enlace...",
+    "report.linkFormFound": "Parece un formulario que se puede enviar.",
+    "report.linkNoForm":
+      "No encontramos un formulario en ese enlace; verifícalo.",
+    "report.linkUnreachable": "Ese enlace no funciona; verifícalo.",
+    "report.linkInvalid": "Eso no parece un enlace web válido.",
     "report.submit": "Enviar reporte",
     "report.submitting": "Enviando...",
     "report.submitted": "¡Reporte enviado!",
@@ -857,6 +869,11 @@ export const messages = {
     "report.customAgencyHelp":
       "如果我们转交给了错误的机构，请在此粘贴正确机构的链接。",
     "report.customAgencyPlaceholder": "https://city.gov/report",
+    "report.linkChecking": "正在检查链接...",
+    "report.linkFormFound": "看起来是一个可提交的表单。",
+    "report.linkNoForm": "我们在该链接未找到表单，请再核对一下。",
+    "report.linkUnreachable": "该链接无法使用，请再核对一下。",
+    "report.linkInvalid": "这看起来不是有效的网页链接。",
     "report.submit": "提交报告",
     "report.submitting": "正在提交...",
     "report.submitted": "报告已提交！",
@@ -1184,6 +1201,13 @@ export const messages = {
     "report.customAgencyHelp":
       "Si nous avons acheminé vers la mauvaise agence, collez ici le lien de la bonne agence.",
     "report.customAgencyPlaceholder": "https://ville.gov/signaler",
+    "report.linkChecking": "Vérification du lien...",
+    "report.linkFormFound":
+      "Cela ressemble à un formulaire que l'on peut envoyer.",
+    "report.linkNoForm":
+      "Nous n'avons pas trouvé de formulaire à ce lien — vérifiez-le.",
+    "report.linkUnreachable": "Ce lien ne fonctionne pas — vérifiez-le.",
+    "report.linkInvalid": "Cela ne ressemble pas à un lien web valide.",
     "report.submit": "Envoyer le signalement",
     "report.submitting": "Envoi...",
     "report.submitted": "Signalement envoyé !",

--- a/nexa/src/lib/api/schemas.ts
+++ b/nexa/src/lib/api/schemas.ts
@@ -100,6 +100,21 @@ export const FormLinkRequestSchema = z.object({
 });
 export type FormLinkRequestInput = z.infer<typeof FormLinkRequestSchema>;
 
+/**
+ * `POST /api/reports/check-link` — verify a user-supplied custom agency link
+ * points at a submittable form. The URL bound mirrors `customAgencyUrl` on
+ * {@link CreateReportSchema} (a real http(s) URL, capped at 2048 chars). A
+ * malformed/empty URL is rejected here with a 400 rather than fetched.
+ */
+export const CheckLinkRequestSchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .url({ error: "Enter a valid URL." })
+    .max(2048, { error: "URL must be at most 2048 characters." }),
+});
+export type CheckLinkRequestInput = z.infer<typeof CheckLinkRequestSchema>;
+
 /** `POST /api/auth/register` — create an account. */
 export const RegisterSchema = z.object({
   name: z.string().optional(),

--- a/nexa/src/lib/api/types.ts
+++ b/nexa/src/lib/api/types.ts
@@ -64,3 +64,32 @@ export type OfficialFormLookupResult =
       message: string;
       reason?: string;
     };
+
+/**
+ * `POST /api/reports/check-link` response payload (the `data` of the success
+ * envelope). When a user overrides Nexa's auto-routing with their own agency
+ * link ("Filing somewhere else?"), this verdict tells the review step whether
+ * that link points at something a person could actually file a report at. It is
+ * purely advisory — submission is never blocked on it — so every failure mode
+ * resolves to one of these four states rather than an exception:
+ *
+ *   - `invalid_url`  — not a syntactically valid http(s) URL (bad scheme,
+ *                      missing host, `javascript:`/`data:`, etc.). Never fetched.
+ *   - `unreachable`  — DNS/connection failure, timeout, or a non-2xx/3xx HTTP
+ *                      status that does not look like bot-protection.
+ *   - `no_form`      — the page was reachable and returned HTML, but no
+ *                      submittable form / reporting portal was detected.
+ *   - `form_found`   — a submittable form or known reporting portal was
+ *                      detected (or a bot-protected gov domain we treat as
+ *                      likely-form), with a confidence band and the matched
+ *                      `signals` for transparency.
+ */
+export type LinkCheckResult =
+  | { status: "invalid_url" }
+  | { status: "unreachable"; reason: string }
+  | { status: "no_form"; reason: string }
+  | {
+      status: "form_found";
+      confidence: FormLookupConfidence;
+      signals: string[];
+    };

--- a/nexa/src/lib/submission/link-check.test.ts
+++ b/nexa/src/lib/submission/link-check.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   checkSubmittableLink,
   parseHttpUrl,
+  isPrivateIp,
+  isBlockedHostname,
   MAX_BODY_BYTES,
 } from "./link-check";
 import { TimeoutError } from "@/lib/http";
@@ -47,6 +49,65 @@ describe("parseHttpUrl", () => {
     [""],
   ])("rejects %s", (raw) => {
     expect(parseHttpUrl(raw)).toBeNull();
+  });
+});
+
+describe("SSRF guard", () => {
+  it("flags private / loopback / link-local addresses", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "0.0.0.0",
+      "10.0.0.5",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "100.64.0.1", // CGNAT
+      "::1",
+      "fe80::1",
+      "fd00::1",
+      "::ffff:127.0.0.1",
+    ]) {
+      expect(isPrivateIp(ip)).toBe(true);
+    }
+    for (const ip of ["8.8.8.8", "1.1.1.1", "172.32.0.1", "192.169.0.1"]) {
+      expect(isPrivateIp(ip)).toBe(false);
+    }
+  });
+
+  it("blocks localhost-ish and single-label hosts, allows public domains", () => {
+    for (const host of [
+      "localhost",
+      "app.localhost",
+      "router.local",
+      "service.internal",
+      "intranet", // single label
+      "127.0.0.1",
+      "169.254.169.254",
+    ]) {
+      expect(isBlockedHostname(host)).toBe(true);
+    }
+    for (const host of ["paloalto.gov", "seeclickfix.com", "8.8.8.8"]) {
+      expect(isBlockedHostname(host)).toBe(false);
+    }
+  });
+
+  it("returns invalid_url for an internal-IP link WITHOUT fetching", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await checkSubmittableLink("http://169.254.169.254/latest", {
+      fetchImpl,
+    });
+    expect(result).toEqual({ status: "invalid_url" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_url for a localhost link without fetching", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await checkSubmittableLink("http://localhost:8080/admin", {
+      fetchImpl,
+    });
+    expect(result).toEqual({ status: "invalid_url" });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
 

--- a/nexa/src/lib/submission/link-check.test.ts
+++ b/nexa/src/lib/submission/link-check.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  checkSubmittableLink,
+  parseHttpUrl,
+  MAX_BODY_BYTES,
+} from "./link-check";
+import { TimeoutError } from "@/lib/http";
+
+/** Build a stub `fetch` returning an HTML body with the given status. */
+function htmlFetch(html: string, init: ResponseInit = {}): typeof fetch {
+  return vi.fn(
+    async () =>
+      new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+        ...init,
+      }),
+  ) as unknown as typeof fetch;
+}
+
+/** A stub `fetch` that throws — simulates DNS/connection failure. */
+function throwingFetch(error: unknown): typeof fetch {
+  return vi.fn(async () => {
+    throw error;
+  }) as unknown as typeof fetch;
+}
+
+describe("parseHttpUrl", () => {
+  it("accepts http and https URLs with a host", () => {
+    expect(parseHttpUrl("https://city.gov/report")?.hostname).toBe("city.gov");
+    expect(parseHttpUrl("http://example.com")?.protocol).toBe("http:");
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(parseHttpUrl("  https://city.gov  ")?.hostname).toBe("city.gov");
+  });
+
+  it.each([
+    ["javascript:alert(1)"],
+    ["data:text/html,<form>"],
+    ["mailto:a@b.com"],
+    ["ftp://host/file"],
+    ["http://"],
+    ["https://"],
+    ["not a url"],
+    [""],
+  ])("rejects %s", (raw) => {
+    expect(parseHttpUrl(raw)).toBeNull();
+  });
+});
+
+describe("checkSubmittableLink", () => {
+  it("returns invalid_url for a non-http scheme without fetching", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await checkSubmittableLink("javascript:alert(1)", {
+      fetchImpl,
+    });
+    expect(result).toEqual({ status: "invalid_url" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_url for a malformed URL without fetching", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await checkSubmittableLink("http://", { fetchImpl });
+    expect(result).toEqual({ status: "invalid_url" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("detects a POST form as form_found with high confidence", async () => {
+    const html = `<html><body>
+      <form method="POST" action="/submit"><input name="desc" /></form>
+    </body></html>`;
+    const result = await checkSubmittableLink("https://city.gov/report", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result).toEqual({
+      status: "form_found",
+      confidence: "high",
+      signals: expect.arrayContaining(["post_form"]),
+    });
+  });
+
+  it("detects a self-closing/unterminated POST form tag", async () => {
+    // SPA-style page: a <form method=post> tag with no matching </form>.
+    const html = `<html><body><form method="post" data-spa>`;
+    const result = await checkSubmittableLink("https://city.gov/report", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result.status).toBe("form_found");
+    if (result.status === "form_found") {
+      expect(result.confidence).toBe("high");
+    }
+  });
+
+  it("detects a SeeClickFix reporting portal marker", async () => {
+    const html = `<html><head><title>SeeClickFix</title></head>
+      <body>Report an issue to your city</body></html>`;
+    const result = await checkSubmittableLink(
+      "https://seeclickfix.com/report",
+      { fetchImpl: htmlFetch(html) },
+    );
+    expect(result.status).toBe("form_found");
+    if (result.status === "form_found") {
+      expect(result.signals).toContain("seeclickfix");
+    }
+  });
+
+  it("treats a GET form co-located with portal text as medium confidence", async () => {
+    const html = `<html><body>
+      <h1>Submit a request</h1>
+      <form action="/search"><input name="q" /></form>
+    </body></html>`;
+    const result = await checkSubmittableLink("https://example.com/portal", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result).toMatchObject({
+      status: "form_found",
+      confidence: "medium",
+    });
+  });
+
+  it("treats portal text with no form as low confidence (JS-rendered form)", async () => {
+    const html = `<html><body><div id="app">Report a problem online</div></body></html>`;
+    const result = await checkSubmittableLink("https://example.com/portal", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result).toMatchObject({
+      status: "form_found",
+      confidence: "low",
+    });
+  });
+
+  it("treats a plain input form with no portal markers as medium confidence", async () => {
+    const html = `<html><body><form action="/x"><input name="a" /></form></body></html>`;
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result).toEqual({
+      status: "form_found",
+      confidence: "medium",
+      signals: ["input_form"],
+    });
+  });
+
+  it("returns no_form for reachable HTML with no form or markers", async () => {
+    const html = `<html><body><h1>Welcome to our city</h1><p>Hello.</p></body></html>`;
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: htmlFetch(html),
+    });
+    expect(result).toMatchObject({ status: "no_form" });
+  });
+
+  it("returns no_form for an empty body", async () => {
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: htmlFetch("   "),
+    });
+    expect(result).toMatchObject({ status: "no_form" });
+  });
+
+  it("returns unreachable for a 404", async () => {
+    const result = await checkSubmittableLink("https://example.com/missing", {
+      fetchImpl: htmlFetch("Not found", { status: 404 }),
+    });
+    expect(result).toMatchObject({ status: "unreachable" });
+    if (result.status === "unreachable") {
+      expect(result.reason).toContain("404");
+    }
+  });
+
+  it("returns unreachable for a 500", async () => {
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: htmlFetch("Server error", { status: 500 }),
+    });
+    expect(result).toMatchObject({ status: "unreachable" });
+  });
+
+  it("returns unreachable on a timeout", async () => {
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: throwingFetch(new TimeoutError(12_000)),
+    });
+    expect(result).toEqual({
+      status: "unreachable",
+      reason: "The link timed out.",
+    });
+  });
+
+  it("returns unreachable on a DNS/network throw", async () => {
+    const dnsError = Object.assign(new Error("getaddrinfo ENOTFOUND"), {
+      code: "ENOTFOUND",
+    });
+    const result = await checkSubmittableLink("https://nope.invalid/", {
+      fetchImpl: throwingFetch(dnsError),
+    });
+    expect(result).toMatchObject({ status: "unreachable" });
+  });
+
+  it("follows redirects to a form (the stub fetch resolves the final page)", async () => {
+    // fetch with redirect:"follow" lands on the final 200 HTML; emulate that.
+    const html = `<form method="post"><input name="x" /></form>`;
+    const fetchImpl = htmlFetch(html);
+    const result = await checkSubmittableLink("https://example.com/old", {
+      fetchImpl,
+    });
+    expect(result.status).toBe("form_found");
+    // The request was issued with redirect:"follow".
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.com/old",
+      expect.objectContaining({ redirect: "follow" }),
+    );
+  });
+
+  it("treats a 403 from a .gov host as a likely (low-confidence) form", async () => {
+    const result = await checkSubmittableLink("https://paloalto.gov/report", {
+      fetchImpl: htmlFetch("Forbidden", { status: 403 }),
+    });
+    expect(result).toEqual({
+      status: "form_found",
+      confidence: "low",
+      signals: ["gov_domain_bot_protected"],
+    });
+  });
+
+  it("treats a 401 from a seeclickfix host as a likely form", async () => {
+    const result = await checkSubmittableLink(
+      "https://city.seeclickfix.com/report",
+      { fetchImpl: htmlFetch("Unauthorized", { status: 401 }) },
+    );
+    expect(result.status).toBe("form_found");
+  });
+
+  it("does NOT treat a 403 from a non-gov host as a form", async () => {
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: htmlFetch("Forbidden", { status: 403 }),
+    });
+    expect(result).toMatchObject({ status: "unreachable" });
+  });
+
+  it("caps an oversized body and still classifies it", async () => {
+    // A huge body whose form sits in the first chunk. We assert the cap is
+    // honored by streaming a body larger than MAX_BODY_BYTES.
+    const head = `<form method="post"><input name="x" /></form>`;
+    const filler = "x".repeat(MAX_BODY_BYTES * 2);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder();
+        controller.enqueue(enc.encode(head));
+        controller.enqueue(enc.encode(filler));
+        controller.close();
+      },
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const result = await checkSubmittableLink("https://example.com/big", {
+      fetchImpl,
+    });
+    expect(result.status).toBe("form_found");
+  });
+
+  it("never throws — an unexpected fetch error maps to unreachable", async () => {
+    const result = await checkSubmittableLink("https://example.com/", {
+      fetchImpl: throwingFetch(new Error("boom")),
+    });
+    expect(result).toMatchObject({ status: "unreachable" });
+  });
+});

--- a/nexa/src/lib/submission/link-check.ts
+++ b/nexa/src/lib/submission/link-check.ts
@@ -67,6 +67,68 @@ export function parseHttpUrl(raw: string): URL | null {
   return url;
 }
 
+/**
+ * True when `ip` is a private, loopback, link-local, or otherwise non-public
+ * address — the targets an SSRF attacker would aim at (internal services, the
+ * cloud metadata endpoint 169.254.169.254, etc.). Covers IPv4 literals and the
+ * common IPv6 cases. Best-effort string matching (no DNS); the caller pairs it
+ * with a resolution check on the production path.
+ */
+export function isPrivateIp(ip: string): boolean {
+  const host = ip
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .trim();
+
+  // IPv6 loopback / link-local / unique-local, and IPv4-mapped IPv6.
+  if (host === "::1" || host === "::") return true;
+  if (
+    host.startsWith("fe80:") ||
+    host.startsWith("fc") ||
+    host.startsWith("fd")
+  )
+    return true;
+  const mapped = host.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  const v4 = mapped ? mapped[1] : host;
+
+  const parts = v4.split(".");
+  if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = parts.map(Number);
+    if ([a, b].some((n) => n > 255)) return true; // malformed -> reject
+    if (a === 0 || a === 127) return true; // 0.0.0.0/8, loopback
+    if (a === 10) return true; // 10/8
+    if (a === 169 && b === 254) return true; // link-local + metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
+    if (a === 192 && b === 168) return true; // 192.168/16
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
+    if (a >= 224) return true; // multicast / reserved
+  }
+  return false;
+}
+
+/**
+ * True when we must NOT fetch this hostname server-side: localhost-ish names,
+ * internal-only TLDs, single-label hosts (no public TLD), or a literal private
+ * IP. Blocks the obvious SSRF vectors without a DNS lookup.
+ */
+export function isBlockedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  if (!host) return true;
+  if (host === "localhost") return true;
+  if (
+    host.endsWith(".localhost") ||
+    host.endsWith(".local") ||
+    host.endsWith(".internal")
+  )
+    return true;
+  // Single-label hosts (no dot) aren't public domains — they resolve to
+  // internal names. Allow IPv6 literals (which contain ':') to fall through to
+  // the IP check below.
+  if (!host.includes(".") && !host.includes(":")) return true;
+  if (isPrivateIp(host)) return true;
+  return false;
+}
+
 /** Known gov-ish TLDs whose bot-protection 403/401 we treat as "likely a real form". */
 function isLikelyGovHost(hostname: string): boolean {
   const host = hostname.toLowerCase();
@@ -220,7 +282,32 @@ export async function checkSubmittableLink(
   const parsed = parseHttpUrl(url);
   if (!parsed) return { status: "invalid_url" };
 
+  // SSRF guard: never let a user-supplied link make the server fetch an
+  // internal/loopback/link-local target (e.g. 127.0.0.1, 10.x, 192.168.x, or
+  // the cloud metadata endpoint 169.254.169.254). Treat such links as invalid.
+  if (isBlockedHostname(parsed.hostname)) return { status: "invalid_url" };
+
   const { fetchImpl, timeoutMs = DEFAULT_HTTP_TIMEOUT_MS } = options;
+
+  // On the real path (no injected fetch), resolve the host and reject if it
+  // points at a private address — blocks a public domain aimed at an internal
+  // IP. Tests inject `fetchImpl`, so they skip this real DNS lookup.
+  if (!fetchImpl) {
+    try {
+      const { lookup } = await import("node:dns/promises");
+      const resolved = await lookup(parsed.hostname, { all: true });
+      if (resolved.some((entry) => isPrivateIp(entry.address))) {
+        return { status: "invalid_url" };
+      }
+    } catch {
+      // DNS failure -> the host doesn't resolve; report it as unreachable
+      // rather than fetching.
+      return {
+        status: "unreachable",
+        reason: "The link could not be reached.",
+      };
+    }
+  }
 
   let response: Response;
   try {

--- a/nexa/src/lib/submission/link-check.ts
+++ b/nexa/src/lib/submission/link-check.ts
@@ -1,0 +1,317 @@
+// ---------------------------------------------------------------------------
+// Custom-agency-link form detection.
+//
+// When a user overrides Nexa's auto-routing with their own agency link (the
+// "Filing somewhere else?" field on the review step), we want to tell them
+// whether that link actually points at something they can file a report at —
+// before they submit. This module does that check.
+//
+// It is deliberately advisory: `checkSubmittableLink` NEVER throws and always
+// resolves to one of four typed verdicts (see {@link LinkCheckResult}). The UI
+// surfaces the verdict as inline feedback but never blocks submission on it.
+//
+// Detection is pragmatic and dependency-free — there is no HTML parser in the
+// project (checked package.json), so we key off string/regex heuristics over
+// the fetched HTML rather than adding a DOM library. The page is fetched with a
+// bounded timeout (reusing `fetchWithTimeout`), a sane browser-ish User-Agent,
+// and a hard cap on how many bytes we read, so a hostile/huge page can't stall
+// or OOM the route.
+// ---------------------------------------------------------------------------
+
+import {
+  fetchWithTimeout,
+  DEFAULT_HTTP_TIMEOUT_MS,
+  TimeoutError,
+} from "@/lib/http";
+import type { LinkCheckResult } from "@/lib/api/types";
+
+/**
+ * Max bytes of the response body we read before giving up. A reporting form
+ * lives in the first chunk of HTML; reading megabytes of a hostile page buys us
+ * nothing and risks memory/time. 512 KiB comfortably covers real civic pages.
+ */
+export const MAX_BODY_BYTES = 512 * 1024;
+
+/**
+ * A browser-ish User-Agent. Many real .gov / civic portals serve different
+ * markup (or simply refuse) to an obvious bot UA, so we present as a normal
+ * browser to get representative HTML. We still identify Nexa in a comment-style
+ * suffix for operator transparency without tripping naive bot filters.
+ */
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; NexaCivicLinkCheck/1.0; +https://nexa.report/bot)";
+
+/** Injectable `fetch` for tests; defaults to the timeout-wrapped global fetch. */
+export type LinkCheckOptions = {
+  fetchImpl?: typeof fetch;
+  /** Overrides the per-request timeout (defaults to {@link DEFAULT_HTTP_TIMEOUT_MS}). */
+  timeoutMs?: number;
+};
+
+/**
+ * Validate that `raw` is a syntactically usable http(s) URL with a real host.
+ * Rejects non-http(s) schemes (`javascript:`, `data:`, `mailto:`, `ftp:`…),
+ * missing/empty hosts, and anything `URL` can't parse. Returns the normalized
+ * `URL` on success so callers fetch exactly what was validated.
+ */
+export function parseHttpUrl(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  // A bare scheme like `http:///path` parses but has no host to fetch.
+  if (!url.hostname) return null;
+  return url;
+}
+
+/** Known gov-ish TLDs whose bot-protection 403/401 we treat as "likely a real form". */
+function isLikelyGovHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === "gov" ||
+    host.endsWith(".gov") ||
+    host.endsWith(".gov.uk") ||
+    host.endsWith(".us") ||
+    host.endsWith(".mil") ||
+    host.endsWith(".city") ||
+    // Common municipal SaaS reporting portals also gate bots aggressively.
+    host.endsWith("seeclickfix.com") ||
+    host.endsWith("publicstuff.com") ||
+    host.endsWith("granicus.com")
+  );
+}
+
+/**
+ * Signal patterns that strongly indicate a submittable civic-reporting form or
+ * portal. Each entry is [human-readable signal name, test]. Kept as a flat list
+ * so both the detector and tests can reason about which markers fired.
+ */
+const PORTAL_MARKERS: Array<[signal: string, test: RegExp]> = [
+  ["seeclickfix", /seeclickfix/i],
+  ["open311", /open311|\/georeport\/v2|service_request/i],
+  [
+    "submit_a_request",
+    /submit\s+a\s+request|report\s+(an?\s+)?(issue|problem|concern)/i,
+  ],
+  ["311_portal", /\b311\b|service\s+request|report\s+it/i],
+  [
+    "service_portal_saas",
+    /publicstuff|govqa|accela|romulus|cityworks|salesforce\.com\/form/i,
+  ],
+];
+
+/**
+ * True when the HTML contains a `<form>` that looks submittable: it either
+ * declares `method="post"` or carries at least one input/textarea/select the
+ * user would fill in. A purely decorative search box on an otherwise static
+ * page is weak signal, so we additionally require the page to look like a
+ * reporting context (handled by the caller via portal markers) before treating
+ * a GET-only form as "found".
+ */
+function detectForms(html: string): {
+  hasPostForm: boolean;
+  hasInputForm: boolean;
+} {
+  let hasPostForm = false;
+  let hasInputForm = false;
+
+  // Walk each <form ...> ... </form> block. A defensive cap on iterations keeps
+  // a pathological page (thousands of tiny forms) from spinning the regex.
+  const formRe = /<form\b([^>]*)>([\s\S]*?)<\/form>/gi;
+  let match: RegExpExecArray | null;
+  let seen = 0;
+  while ((match = formRe.exec(html)) !== null && seen < 50) {
+    seen++;
+    const attrs = match[1];
+    const body = match[2];
+    if (/\bmethod\s*=\s*["']?\s*post/i.test(attrs)) hasPostForm = true;
+    if (/<(input|textarea|select)\b/i.test(body)) hasInputForm = true;
+    if (hasPostForm) break; // strongest signal found; no need to keep scanning
+  }
+
+  // Some SPA/JS-rendered portals ship a self-closing or unterminated <form> tag
+  // (no matching </form> in the initial HTML). Treat a lone POST form tag as a
+  // post form so we don't miss those.
+  if (!hasPostForm && /<form\b[^>]*\bmethod\s*=\s*["']?\s*post/i.test(html)) {
+    hasPostForm = true;
+  }
+
+  return { hasPostForm, hasInputForm };
+}
+
+/** Which portal markers fired in the HTML, by signal name. */
+function detectPortalMarkers(html: string): string[] {
+  return PORTAL_MARKERS.filter(([, test]) => test.test(html)).map(
+    ([signal]) => signal,
+  );
+}
+
+/**
+ * Read the response body up to {@link MAX_BODY_BYTES}, then abort the stream.
+ * Returns "" if the body can't be read. We stream-and-cap rather than calling
+ * `.text()` so an attacker-controlled multi-GB response can't be buffered whole.
+ */
+async function readCappedBody(response: Response): Promise<string> {
+  const body = response.body;
+  if (!body) {
+    // No stream (e.g. a stubbed Response); fall back to text() but still cap.
+    try {
+      const text = await response.text();
+      return text.slice(0, MAX_BODY_BYTES);
+    } catch {
+      return "";
+    }
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let received = 0;
+  let out = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      out += decoder.decode(value, { stream: true });
+      if (received >= MAX_BODY_BYTES) break;
+    }
+    out += decoder.decode();
+  } catch {
+    // Partial body is still useful for detection; return what we have.
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // ignore — we're done with the stream either way
+    }
+  }
+  return out.slice(0, MAX_BODY_BYTES);
+}
+
+/**
+ * Classify a custom agency link as one of four {@link LinkCheckResult} verdicts.
+ * Never throws — every failure mode (bad URL, DNS error, timeout, non-HTML,
+ * empty body, bot block) maps to a typed result so the caller can render
+ * advisory feedback without a try/catch.
+ *
+ * Heuristics & rationale:
+ *  - Syntactic validation first (no network) rejects non-http(s) and hostless
+ *    URLs as `invalid_url`.
+ *  - A `<form method=post>` (or a form with fillable inputs on a reporting page)
+ *    or a known civic-portal marker (SeeClickFix / Open311 / "submit a request"
+ *    / 311) is `form_found`. POST form or SaaS portal => high confidence; a
+ *    GET form that only co-occurs with portal text => medium; portal text alone
+ *    (JS-rendered form not in initial HTML) => low.
+ *  - A 401/403 from a gov-ish host is `form_found` at low confidence, NOT
+ *    `unreachable`: real .gov reporting pages routinely 403 plain bots, and
+ *    flagging those as broken would wrongly scare users off valid links.
+ *  - Any other non-2xx/3xx, a DNS/connection throw, or a timeout is
+ *    `unreachable`.
+ *  - Reachable HTML with no form and no markers is `no_form`.
+ */
+export async function checkSubmittableLink(
+  url: string,
+  options: LinkCheckOptions = {},
+): Promise<LinkCheckResult> {
+  const parsed = parseHttpUrl(url);
+  if (!parsed) return { status: "invalid_url" };
+
+  const { fetchImpl, timeoutMs = DEFAULT_HTTP_TIMEOUT_MS } = options;
+
+  let response: Response;
+  try {
+    const init: RequestInit & { timeoutMs?: number } = {
+      method: "GET",
+      redirect: "follow",
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+      cache: "no-store",
+      timeoutMs,
+    };
+    response = fetchImpl
+      ? await fetchImpl(parsed.toString(), init)
+      : await fetchWithTimeout(parsed.toString(), init);
+  } catch (error) {
+    if (error instanceof TimeoutError) {
+      return { status: "unreachable", reason: "The link timed out." };
+    }
+    return {
+      status: "unreachable",
+      reason: "We couldn't connect to that link.",
+    };
+  }
+
+  // Bot-protection on a gov-ish host: many real .gov reporting portals answer a
+  // plain bot with 401/403. Don't punish those — treat as a likely form, but at
+  // low confidence since we never saw the markup.
+  if (
+    (response.status === 401 || response.status === 403) &&
+    isLikelyGovHost(parsed.hostname)
+  ) {
+    return {
+      status: "form_found",
+      confidence: "low",
+      signals: ["gov_domain_bot_protected"],
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      status: "unreachable",
+      reason: `The link returned an error (HTTP ${response.status}).`,
+    };
+  }
+
+  const html = await readCappedBody(response);
+  if (!html.trim()) {
+    return {
+      status: "no_form",
+      reason: "The page was empty.",
+    };
+  }
+
+  const { hasPostForm, hasInputForm } = detectForms(html);
+  const markers = detectPortalMarkers(html);
+
+  // High confidence: an actual POST form, or a recognized civic-portal SaaS.
+  if (hasPostForm) {
+    return {
+      status: "form_found",
+      confidence: "high",
+      signals: ["post_form", ...markers],
+    };
+  }
+
+  // A known reporting portal/marker on the page.
+  if (markers.length > 0) {
+    // A fillable (GET) form co-located with portal text is a strong-but-not-
+    // POST signal; portal text without any form is likely a JS-rendered form.
+    return {
+      status: "form_found",
+      confidence: hasInputForm ? "medium" : "low",
+      signals: hasInputForm ? ["input_form", ...markers] : markers,
+    };
+  }
+
+  // A fillable form with no reporting markers: could be a login/search box, so
+  // medium confidence rather than high — but still a submittable form.
+  if (hasInputForm) {
+    return {
+      status: "form_found",
+      confidence: "medium",
+      signals: ["input_form"],
+    };
+  }
+
+  return {
+    status: "no_form",
+    reason: "We couldn't find a form on that page.",
+  };
+}


### PR DESCRIPTION
## What

When a user overrides Nexa's auto-routing with their own agency link (the **"Filing somewhere else?"** field on the report review step), this PR verifies whether that link points at a **valid, submittable reporting form** and surfaces clear inline feedback. It is **purely advisory** — submission is never blocked on it, and the override is still stored verbatim by the create route.

Builds on the just-shipped `customAgencyUrl` feature (#289) and mirrors the existing official-form lookup (`form-link` route + `useFormLookup`) for envelope/hook/route posture. No new dependencies (the project has no HTML parser, so detection is regex/string heuristics).

## Result type — `LinkCheckResult` (4 verdict states)

A never-throwing discriminated union (`src/lib/api/types.ts`):

| status | meaning |
|---|---|
| `invalid_url` | not a syntactically valid http(s) URL (non-http scheme, `javascript:`/`data:`, missing host). Never fetched. |
| `unreachable` | DNS/connection failure, timeout, or a non-2xx/3xx HTTP status that isn't bot-protection. |
| `no_form` | reachable HTML, but no submittable form / reporting marker found. |
| `form_found` | a `<form method=post>`, a fillable form, or a known civic portal marker — carries a `confidence` band + matched `signals`. |

## Detection heuristics & rationale (`src/lib/submission/link-check.ts`)

- **Syntactic validation first (no network):** rejects non-http(s) and hostless URLs as `invalid_url` before any fetch.
- **Bounded + defensive fetch:** reuses `fetchWithTimeout`, follows redirects, sends a browser-ish User-Agent (many civic portals serve different markup / refuse obvious bots), and **streams the body with a 512 KiB cap** so a hostile/huge page can't stall or OOM the route.
- **Form signals → confidence:** a `<form method=post>` (incl. an unterminated SPA `<form>` tag) ⇒ **high**; a fillable GET form co-located with reporting text ⇒ **medium**; portal text alone (JS-rendered form not in the initial HTML) ⇒ **low**; a plain input form with no markers ⇒ **medium**.
- **Civic-portal markers:** SeeClickFix / Open311 (`/georeport/v2`, `service_request`) / "submit a request" / 311 / known SaaS portals (PublicStuff, GovQA, Accela, Cityworks…).
- **gov-domain 403 handling:** a **401/403 from a gov-ish host** (`.gov`, `.us`, `.mil`, `.city`, `seeclickfix.com`, …) is treated as a **likely form at low confidence**, NOT `unreachable` — real .gov reporting pages routinely 403 plain bots, and flagging those as broken would wrongly scare users off valid links. A 403 from a non-gov host stays `unreachable`.

## Every failure case handled

bad scheme · `javascript:`/`data:` · malformed/empty URL · missing host · DNS/network throw · timeout (`TimeoutError`) · 404 · 500 · non-gov 403 · gov 401/403 (likely-form) · redirect to a form · empty body · oversized body · reachable-but-no-form · unexpected fetch error → all map to a typed verdict; `checkSubmittableLink` never throws.

## Exposure + UI

- `POST /api/reports/check-link` — zod-validated `url`, shared per-IP rate limit, standard success/error envelope (mirrors `form-link`). Unauthenticated, matching its sibling.
- `useLinkCheck` hook — debounced (500ms), supersede-safe (stale responses can't overwrite a newer verdict), maps a 400 → `invalid_url` and network errors → `unreachable`.
- Review step renders inline feedback under the override field: green "Looks like a submittable form", amber "couldn't find a form", red "doesn't work" / "not a valid web link". i18n in **en/es/zh/fr**. Submit is never gated.

## Tests

- `link-check.test.ts` — 30 cases across all verdicts/failure modes (injected `fetchImpl` stub; no live network).
- `check-link/route.test.ts` — valid → verdict, invalid/missing/non-JSON → 400, rate-limit 429, unexpected throw → 500.
- `use-link-check.test.tsx` — debounce, blank clears, 400→invalid, network→unreachable, reset cancels.
- `review-step.test.tsx` — feedback renders for each verdict; submit stays enabled.

## Gates (all green, no live network)

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- `npm run format:check` clean
- `npm run test:coverage` exit 0 (902 passing; statements 86.16% / branches 79.5% / functions 85.41% / lines 87.97% — above all floors)
- `DATABASE_URL=… npx next build` compiles (`/api/reports/check-link` present)