### PR TITLE
test(submission): comprehensive e2e coverage across all 11 municipalities

### DIFF
--- a/nexa/eval/dataset/end-to-end-cases.json
+++ b/nexa/eval/dataset/end-to-end-cases.json
@@ -502,5 +502,21 @@
     "issueType": "ILLEGAL_DUMPING",
     "expectedAgencyName": "San Leandro SeeClickFix (Open311)",
     "note": "city-san-leandro interior point reused from routing-cases.json"
+  },
+  {
+    "id": "boundary-paloalto-vs-eastpaloalto-64",
+    "latitude": 37.4515,
+    "longitude": -122.128,
+    "issueType": "ILLEGAL_DUMPING",
+    "expectedAgencyName": "Palo Alto 311",
+    "note": "ROBUSTNESS — boundary point on the Palo Alto / East Palo Alto seam (reused from routing-cases contested-paloalto-vs-eastpaloalto). It must resolve to the Palo Alto side, so the correct agency is Palo Alto 311, NOT an EPA agency. Asserts agency-level routing lands on the right side of a contested boundary."
+  },
+  {
+    "id": "boundary-menlo-vs-paloalto-65",
+    "latitude": 37.4305,
+    "longitude": -122.191,
+    "issueType": "STREETLIGHT_OUTAGE",
+    "expectedAgencyName": "Menlo Park ACT",
+    "note": "ROBUSTNESS — boundary point on the Menlo Park / Palo Alto seam (reused from routing-cases contested-menlo-vs-paloalto). It falls inside Menlo Park, so a Menlo Park agency is correct (routing is ambiguous: ACT + SeeClickFix both cover streetlights, and Menlo Park ACT is in the candidate set). Asserts agency-level routing lands on the Menlo Park side of a contested boundary."
   }
 ]

--- a/nexa/eval/dataset/readiness-cases.json
+++ b/nexa/eval/dataset/readiness-cases.json
@@ -398,5 +398,288 @@
       "vehicleColor": null,
       "observationDatetime": null
     }
+  },
+  {
+    "id": "graffiti-mp-act-21-webform",
+    "issueType": "GRAFFITI",
+    "note": "Menlo Park graffiti, PINNED to the Menlo Park ACT WEB_FORM desk (expectAgencyName). Routing here is ambiguous (ACT + SeeClickFix both cover graffiti); the default disambiguation prefers the Open311 API sibling, so this is the only case that proves the ACT web-form intake is itself reachable and every ACT required field (description, location_address) fills.",
+    "expectAgencyName": "Menlo Park ACT",
+    "report": {
+      "description": "Spray-paint tags across the underpass retaining wall.",
+      "aiDescription": "Graffiti on public underpass wall.",
+      "latitude": 37.44865,
+      "longitude": -122.17515,
+      "address": "Ravenswood Ave underpass, Menlo Park, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/graffiti-mp-act-21.jpg",
+      "contactEmail": "reporter21@example.com",
+      "contactName": "Casey Tan",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "light-mv-22-webform",
+    "issueType": "STREETLIGHT_OUTAGE",
+    "note": "Mountain View streetlight out -> Mountain View Public Works (WEB_FORM). Confident single match; exercises the contact_name/contact_email optional fields alongside the required description + location_address.",
+    "report": {
+      "description": "Whole block of streetlights dark for the past week.",
+      "aiDescription": "Streetlight outage on residential block.",
+      "latitude": 37.40875,
+      "longitude": -122.10304,
+      "address": "Rengstorff Ave & Latham St, Mountain View, CA",
+      "photoUrl": null,
+      "contactEmail": "reporter22@example.com",
+      "contactName": "Morgan Diaz",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "signal-scc-23-webform",
+    "issueType": "TRAFFIC_SIGNAL",
+    "note": "Unincorporated Santa Clara County traffic signal -> Santa Clara County Public Works (WEB_FORM). Confident single match on a county-only issue type.",
+    "report": {
+      "description": "Traffic signal stuck on flashing red at the rural intersection.",
+      "aiDescription": "Malfunctioning traffic signal on county road.",
+      "latitude": 37.28744,
+      "longitude": -122.13637,
+      "address": "Page Mill Rd & Moody Rd, unincorporated Santa Clara County, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/signal-scc-23.jpg",
+      "contactEmail": null,
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "sidewalk-epa-pw-24-webform",
+    "issueType": "SIDEWALK_DAMAGE",
+    "note": "East Palo Alto sidewalk -> East Palo Alto Public Works (WEB_FORM). Second EPA Public Works issue type beyond road damage; required description + location_address fill.",
+    "report": {
+      "description": "Buckled sidewalk slab lifting a tripping edge.",
+      "aiDescription": "Damaged sidewalk creating a trip hazard.",
+      "latitude": 37.46892,
+      "longitude": -122.15081,
+      "address": "Bay Rd & Clarke Ave, East Palo Alto, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/sidewalk-epa-24.jpg",
+      "contactEmail": "reporter24@example.com",
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "flood-mil-25-api",
+    "issueType": "FLOODING_DRAINAGE",
+    "note": "Milpitas flooding/drainage -> Milpitas SeeClickFix (Open311 API, service_code 26645). Confirms the GeoReport v2 body assembles for a new-taxonomy service_code. (Milpitas has no GRAFFITI service, so a covered type is used.)",
+    "report": {
+      "description": "Storm drain backing up and flooding the intersection.",
+      "aiDescription": "Blocked storm drain causing street flooding.",
+      "latitude": 37.41862,
+      "longitude": -121.9299,
+      "address": "Milpitas, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/flood-mil-25.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "vehicle-mil-26-api",
+    "issueType": "ABANDONED_VEHICLE",
+    "note": "Milpitas abandoned vehicle -> Milpitas SeeClickFix (Open311 API, service_code 26639). New-taxonomy API service code GeoReport assembly.",
+    "report": {
+      "description": "Car with flat tires parked unmoved for weeks.",
+      "aiDescription": "Abandoned vehicle on public street.",
+      "latitude": 37.41979,
+      "longitude": -121.9299,
+      "address": "Milpitas, CA",
+      "photoUrl": null,
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "road-mh-27-api",
+    "issueType": "ROAD_DAMAGE",
+    "note": "Morgan Hill pothole -> Morgan Hill SeeClickFix (Open311 API). Road-damage GeoReport assembly for Morgan Hill (only dumping was previously exercised).",
+    "report": {
+      "description": "Deep pothole in the southbound lane near the curve.",
+      "aiDescription": "Pothole in roadway lane.",
+      "latitude": 37.12387,
+      "longitude": -121.69618,
+      "address": "Morgan Hill, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/road-mh-27.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "park-gil-28-api",
+    "issueType": "PARKING",
+    "note": "Gilroy parking violation -> Gilroy SeeClickFix (Open311 API, service_code 64773). New-taxonomy API service code GeoReport assembly with description fallback to aiDescription (no citizen description).",
+    "report": {
+      "description": null,
+      "aiDescription": "Vehicle blocking a marked fire lane.",
+      "latitude": 36.99637,
+      "longitude": -121.64129,
+      "address": "Gilroy, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/park-gil-28.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "sidewalk-wat-29-api",
+    "issueType": "SIDEWALK_DAMAGE",
+    "note": "Watsonville sidewalk -> Watsonville SeeClickFix (Open311 API, service_code 50066). Second Watsonville issue type beyond road damage.",
+    "report": {
+      "description": "Cracked and heaving sidewalk outside the school.",
+      "aiDescription": "Damaged sidewalk near a school.",
+      "latitude": 36.91,
+      "longitude": -121.7681,
+      "address": "Watsonville, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/sidewalk-wat-29.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "code-val-30-api",
+    "issueType": "CODE_ENFORCEMENT",
+    "note": "Vallejo code enforcement -> Vallejo SeeClickFix (Open311 API, service_code 4718). New-taxonomy API service code GeoReport assembly.",
+    "report": {
+      "description": "Overgrown vacant lot with accumulating junk and blight.",
+      "aiDescription": "Property maintenance / code enforcement concern.",
+      "latitude": 38.12024,
+      "longitude": -122.38386,
+      "address": "Vallejo, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/code-val-30.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "tree-sl-31-api",
+    "issueType": "TREE_MAINTENANCE",
+    "note": "San Leandro tree maintenance -> San Leandro SeeClickFix (Open311 API, service_code 53558). Second San Leandro issue type beyond streetlight.",
+    "report": {
+      "description": "Large fallen tree limb blocking half the sidewalk.",
+      "aiDescription": "Fallen tree limb obstructing a sidewalk.",
+      "latitude": 37.70885,
+      "longitude": -122.20861,
+      "address": "San Leandro, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/tree-sl-31.jpg",
+      "contactEmail": "reporter@example.com",
+      "contactName": "Alex Kim",
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "road-boundary-pa-vs-epa-32",
+    "issueType": "ROAD_DAMAGE",
+    "note": "ROBUSTNESS — boundary coordinate on the Palo Alto / East Palo Alto seam. It falls inside Palo Alto's polygon (mirrors routing-cases contested-paloalto-vs-eastpaloalto), so it MUST route to Palo Alto 311 (not an EPA agency). expectAgencyName asserts the correct side.",
+    "expectAgencyName": "Palo Alto 311",
+    "report": {
+      "description": "Pothole right at the jurisdiction line on the shared street.",
+      "aiDescription": "Pothole in roadway near a city boundary.",
+      "latitude": 37.4515,
+      "longitude": -122.128,
+      "address": "Near the Palo Alto / East Palo Alto line, CA",
+      "photoUrl": "https://uploads.nexa.example/reports/road-boundary-32.jpg",
+      "contactEmail": "reporter32@example.com",
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "graffiti-pa-33-missing-required",
+    "issueType": "GRAFFITI",
+    "note": "NEGATIVE CONTROL — Palo Alto 311 (WEB_FORM) requires location_address, but this report has none. The field-validation gate must flag it NOT ready, proving required-field gating works for WEB_FORM intakes (the emit-pa-12 negative control only covers PHONE).",
+    "report": {
+      "description": "Graffiti on a utility box, but I am not sure of the exact address.",
+      "aiDescription": "Graffiti on public utility box.",
+      "latitude": 37.35109,
+      "longitude": -122.18512,
+      "address": null,
+      "photoUrl": "https://uploads.nexa.example/reports/graffiti-pa-33.jpg",
+      "contactEmail": null,
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
+  },
+  {
+    "id": "road-outside-all-34",
+    "issueType": "ROAD_DAMAGE",
+    "note": "ROBUSTNESS — a location OUTSIDE all 11 served jurisdictions (Pacific Ocean off the California coast). It MUST resolve to no agency and be handled gracefully (no crash, manual-assist). Excluded from the readiness rate since there is no intake to fill.",
+    "expectNoAgency": true,
+    "report": {
+      "description": "Reported coordinate is far offshore, outside any served city.",
+      "aiDescription": "Out-of-area report.",
+      "latitude": 36.0,
+      "longitude": -123.5,
+      "address": "Pacific Ocean off the California coast",
+      "photoUrl": null,
+      "contactEmail": null,
+      "contactName": null,
+      "licensePlate": null,
+      "vehicleMake": null,
+      "vehicleModel": null,
+      "vehicleColor": null,
+      "observationDatetime": null
+    }
   }
 ]

--- a/nexa/eval/readiness.ts
+++ b/nexa/eval/readiness.ts
@@ -66,12 +66,19 @@ const AGENCY_ROWS: AgencyRow[] = AGENCIES.map((a) => ({
 
 const agencyById = new Map(AGENCY_ROWS.map((a) => [a.id, a]));
 
+// `resolveAgencyId` queries by { jurisdiction, issueTypes: { has } }, selecting
+// only `id`. `resolveAgencyCandidates` (used by the disambiguation robustness
+// path) queries the SAME table by { id: { in: candidates } }, selecting
+// id/name/jurisdiction/intakeMethod and ordering by name. The stub answers both
+// shapes off `AGENCY_ROWS` so the harness can drive either production function
+// without a live DB.
 type FindManyArgs = {
   where?: {
     jurisdiction?: string;
     issueTypes?: { has?: string };
+    id?: { in?: string[] };
   };
-  orderBy?: { id?: "asc" | "desc" };
+  orderBy?: { id?: "asc" | "desc" } | { name?: "asc" | "desc" };
 };
 
 const prismaStub = {
@@ -79,21 +86,44 @@ const prismaStub = {
     async findMany(args: FindManyArgs) {
       const jurisdiction = args.where?.jurisdiction;
       const issueType = args.where?.issueTypes?.has;
+      const idIn = args.where?.id?.in;
       let rows = AGENCY_ROWS.filter(
         (a) =>
           (jurisdiction === undefined || a.jurisdiction === jurisdiction) &&
           (issueType === undefined ||
             a.issueTypes.includes(
               issueType as AgencySeed["issueTypes"][number],
-            )),
+            )) &&
+          (idIn === undefined || idIn.includes(a.id)),
       );
-      const dir = args.orderBy?.id ?? "asc";
-      rows = rows
-        .slice()
-        .sort((a, b) =>
-          dir === "desc" ? b.id.localeCompare(a.id) : a.id.localeCompare(b.id),
-        );
-      return rows.map((a) => ({ id: a.id }));
+      const order = args.orderBy ?? { id: "asc" };
+      if ("name" in order && order.name) {
+        const dir = order.name;
+        rows = rows
+          .slice()
+          .sort((a, b) =>
+            dir === "desc"
+              ? b.name.localeCompare(a.name)
+              : a.name.localeCompare(b.name),
+          );
+      } else {
+        const dir = ("id" in order && order.id) || "asc";
+        rows = rows
+          .slice()
+          .sort((a, b) =>
+            dir === "desc"
+              ? b.id.localeCompare(a.id)
+              : a.id.localeCompare(b.id),
+          );
+      }
+      // Return the full row; both callers `select` a subset, which is a no-op
+      // narrowing over a superset object.
+      return rows.map((a) => ({
+        id: a.id,
+        name: a.name,
+        jurisdiction: a.jurisdiction,
+        intakeMethod: a.intakeMethod,
+      }));
     },
   },
 };
@@ -106,7 +136,10 @@ const prismaStub = {
 // which the CJS eval transform rejects) deferred into async `main()`.
 type AgencyModule = typeof import("../src/lib/jurisdictions/agency");
 type Open311Module = typeof import("../src/lib/submission/open311");
-let resolveAgencyId: AgencyModule["resolveAgencyId"];
+// `resolveAgencyCandidates` internally calls the production `resolveAgencyId`
+// (which our Prisma stub backs), so one call yields BOTH the routing decision
+// and the ambiguity candidate set + disambiguating question.
+let resolveAgencyCandidates: AgencyModule["resolveAgencyCandidates"];
 let parseOpen311Config: Open311Module["parseOpen311Config"];
 let resolveServiceCode: Open311Module["resolveServiceCode"];
 let buildRequestParams: Open311Module["buildRequestParams"];
@@ -114,7 +147,7 @@ let buildRequestParams: Open311Module["buildRequestParams"];
 async function loadDeps(): Promise<void> {
   const agency = await import("../src/lib/jurisdictions/agency");
   const open311 = await import("../src/lib/submission/open311");
-  resolveAgencyId = agency.resolveAgencyId;
+  resolveAgencyCandidates = agency.resolveAgencyCandidates;
   parseOpen311Config = open311.parseOpen311Config;
   resolveServiceCode = open311.resolveServiceCode;
   buildRequestParams = open311.buildRequestParams;
@@ -149,6 +182,25 @@ interface ReadinessCase {
   issueType: IssueType;
   note?: string;
   report: ReadinessReport;
+  /**
+   * Optional routing assertion. When set, the harness asserts the report
+   * resolves to (confident match) OR has among its ambiguity candidates an
+   * agency with this exact `name`; the named agency is the one whose required
+   * fields are then assessed. This lets a case pin field-filling to a SPECIFIC
+   * agency that loses the default API-preferred disambiguation — e.g. asserting
+   * the Menlo Park ACT WEB_FORM desk (not just its Open311 sibling) can be
+   * reached and fully filled. A mismatch fails the run.
+   */
+  expectAgencyName?: string;
+  /**
+   * Robustness case: the report's location is OUTSIDE all served jurisdictions,
+   * so it MUST resolve to no agency. The harness asserts no agency resolves and
+   * treats that as the (correct) handled outcome — never a crash. Such a case is
+   * recorded as not-ready (there is no intake to fill) but is excluded from the
+   * readiness-rate denominator, since "no agency exists" is not a field-filling
+   * failure.
+   */
+  expectNoAgency?: boolean;
 }
 
 // Maps an agency `requiredFields` key onto the report value that fills it. This
@@ -216,10 +268,25 @@ interface CaseResult {
   agencyId: string | null;
   agencyName: string | null;
   intakeMethod: string | null;
+  /**
+   * The resolved intake channel target the manual/assist or filing step would
+   * use — a web-form URL, intake email, or hotline phone — so the dataset proves
+   * each agency exposes a usable channel, not just that fields are filled.
+   */
+  intakeTarget: string | null;
+  /** Every covering agency name (the candidate set) for ambiguous routing. */
+  candidateNames: string[];
+  /** The disambiguating question when routing is ambiguous (>1 candidate). */
+  disambiguation: string | null;
   serviceCode: string | null;
   missingFields: string[];
   fieldChecks: FieldCheck[];
   ready: boolean;
+  /**
+   * True when this case is excluded from the readiness-rate denominator (an
+   * outside-all-jurisdictions robustness case, where no agency exists to fill).
+   */
+  excludedFromRate: boolean;
   reason: string;
 }
 
@@ -230,10 +297,13 @@ interface CaseResult {
  * apply the disambiguation it defers to callers: prefer an API agency (the
  * machine-submittable channel), else the first candidate by id.
  */
-function chooseAgency(resolution: {
-  agencyId: string | null;
-  candidates: string[];
-}): { agency: AgencyRow | undefined; disambiguated: boolean } {
+function chooseAgency(
+  resolution: {
+    agencyId: string | null;
+    candidates: string[];
+  },
+  expectAgencyName?: string,
+): { agency: AgencyRow | undefined; disambiguated: boolean } {
   if (resolution.agencyId) {
     return {
       agency: agencyById.get(resolution.agencyId),
@@ -246,8 +316,21 @@ function chooseAgency(resolution: {
   const rows = resolution.candidates
     .map((id) => agencyById.get(id))
     .filter((a): a is AgencyRow => a !== undefined);
+  // A case may PIN assessment to a specific covering agency (e.g. the Menlo Park
+  // ACT WEB_FORM desk) that the default API-preferred disambiguation would skip.
+  if (expectAgencyName) {
+    const pinned = rows.find((a) => a.name === expectAgencyName);
+    if (pinned) return { agency: pinned, disambiguated: true };
+  }
   const api = rows.find((a) => a.intakeMethod === "API");
   return { agency: api ?? rows[0], disambiguated: true };
+}
+
+/** Resolves an agency's usable intake channel target (URL, email, or hotline). */
+function intakeTargetOf(agency: AgencyRow): string | null {
+  if (agency.intakeUrl) return agency.intakeUrl;
+  if (agency.intakeEmail) return agency.intakeEmail;
+  return intakePhone(agency.requiredFields);
 }
 
 /** Treats every `requiredFields` entry with `required: true` as a gate. */
@@ -392,13 +475,54 @@ function assessFormReadiness(
 }
 
 async function assessCase(c: ReadinessCase): Promise<CaseResult> {
-  const resolution = await resolveAgencyId({
+  // Reuse the production candidate resolver so the SAME call yields both the
+  // routing decision and (under ambiguity) the candidate set + disambiguating
+  // question the UI shows. Its `agencyId`/`candidates` mirror `resolveAgencyId`.
+  const disambig = await resolveAgencyCandidates({
     latitude: c.report.latitude,
     longitude: c.report.longitude,
     issueType: c.issueType,
   });
+  const resolution = {
+    agencyId: disambig.agencyId,
+    candidates: disambig.candidates.map((d) => d.id),
+  };
+  const candidateNames = disambig.candidates.map((d) => d.name);
 
-  const { agency, disambiguated } = chooseAgency(resolution);
+  // Robustness: an outside-all-jurisdictions location MUST resolve to no agency.
+  // This is the correct handled outcome (not a crash), and is excluded from the
+  // readiness denominator since there is no intake channel to fill.
+  if (c.expectNoAgency) {
+    if (disambig.candidates.length > 0) {
+      throw new Error(
+        `[${c.id}] expected NO agency (outside all jurisdictions) but resolved candidates [${candidateNames.join(", ")}].`,
+      );
+    }
+    return {
+      caseId: c.id,
+      issueType: c.issueType,
+      resolved: false,
+      disambiguated: false,
+      agencyId: null,
+      agencyName: null,
+      intakeMethod: null,
+      intakeTarget: null,
+      candidateNames: [],
+      disambiguation: null,
+      serviceCode: null,
+      missingFields: [],
+      fieldChecks: [],
+      ready: false,
+      excludedFromRate: true,
+      reason:
+        "Outside all served jurisdictions; resolved to no agency and handled gracefully (manual-assist).",
+    };
+  }
+
+  const { agency, disambiguated } = chooseAgency(
+    resolution,
+    c.expectAgencyName,
+  );
   if (!agency) {
     return {
       caseId: c.id,
@@ -408,12 +532,37 @@ async function assessCase(c: ReadinessCase): Promise<CaseResult> {
       agencyId: null,
       agencyName: null,
       intakeMethod: null,
+      intakeTarget: null,
+      candidateNames,
+      disambiguation: disambig.disambiguation,
       serviceCode: null,
       missingFields: [],
       fieldChecks: [],
       ready: false,
+      excludedFromRate: false,
       reason: "No agency covers this jurisdiction + issue type.",
     };
+  }
+
+  // Assert the pinned-agency expectation (when set): the named agency must be
+  // the one we resolved/assessed, otherwise the case is asserting nothing.
+  if (c.expectAgencyName && agency.name !== c.expectAgencyName) {
+    throw new Error(
+      `[${c.id}] expected agency "${c.expectAgencyName}" but assessed "${agency.name}" (candidates: [${candidateNames.join(", ")}]).`,
+    );
+  }
+
+  // Assert the disambiguation contract: ambiguous routing (more than one
+  // candidate) MUST carry a question; an unambiguous one MUST NOT.
+  if (disambig.candidates.length > 1 && !disambig.disambiguation) {
+    throw new Error(
+      `[${c.id}] ambiguous routing (${candidateNames.length} candidates) but no disambiguating question.`,
+    );
+  }
+  if (disambig.candidates.length === 1 && disambig.disambiguation) {
+    throw new Error(
+      `[${c.id}] single confident candidate but a disambiguating question was returned.`,
+    );
   }
 
   let checks: FieldCheck[];
@@ -448,10 +597,14 @@ async function assessCase(c: ReadinessCase): Promise<CaseResult> {
     agencyId: agency.id,
     agencyName: agency.name,
     intakeMethod: agency.intakeMethod,
+    intakeTarget: intakeTargetOf(agency),
+    candidateNames,
+    disambiguation: disambig.disambiguation,
     serviceCode,
     missingFields,
     fieldChecks: checks,
     ready,
+    excludedFromRate: false,
     reason,
   };
 }
@@ -462,10 +615,14 @@ async function assessCase(c: ReadinessCase): Promise<CaseResult> {
 
 interface ReadinessMetrics {
   total: number;
+  /** Cases counted toward the readiness rate (total minus excluded robustness cases). */
+  scored: number;
   ready: number;
   readiness: number;
   resolved: number;
   coverage: number;
+  /** Robustness cases excluded from the readiness denominator (outside-jurisdiction). */
+  excluded: number;
   perCategory: Record<
     string,
     { support: number; ready: number; readiness: number }
@@ -478,12 +635,16 @@ interface ReadinessMetrics {
 
 function aggregate(results: CaseResult[]): ReadinessMetrics {
   const total = results.length;
-  const ready = results.filter((r) => r.ready).length;
+  // Outside-all-jurisdictions robustness cases are excluded from the readiness
+  // RATE (there is no intake to fill), but still run to prove graceful handling.
+  const scoredResults = results.filter((r) => !r.excludedFromRate);
+  const scored = scoredResults.length;
+  const ready = scoredResults.filter((r) => r.ready).length;
   const resolved = results.filter((r) => r.resolved).length;
 
   const perCategory: ReadinessMetrics["perCategory"] = {};
   const perIntakeMethod: ReadinessMetrics["perIntakeMethod"] = {};
-  for (const r of results) {
+  for (const r of scoredResults) {
     const cat = perCategory[r.issueType] ?? {
       support: 0,
       ready: 0,
@@ -508,10 +669,12 @@ function aggregate(results: CaseResult[]): ReadinessMetrics {
 
   return {
     total,
+    scored,
     ready,
-    readiness: total === 0 ? 0 : ready / total,
+    readiness: scored === 0 ? 0 : ready / scored,
     resolved,
     coverage: total === 0 ? 0 : resolved / total,
+    excluded: total - scored,
     perCategory,
     perIntakeMethod,
   };
@@ -521,7 +684,10 @@ function renderReport(metrics: ReadinessMetrics): string {
   const lines: string[] = [];
   lines.push("\n=== Submission readiness (K3) ===");
   lines.push(
-    `Readiness: ${(metrics.readiness * 100).toFixed(1)}%  (${metrics.ready}/${metrics.total})  target >=${(TARGET_READINESS * 100).toFixed(0)}%`,
+    `Readiness: ${(metrics.readiness * 100).toFixed(1)}%  (${metrics.ready}/${metrics.scored})  target >=${(TARGET_READINESS * 100).toFixed(0)}%` +
+      (metrics.excluded > 0
+        ? `  [${metrics.excluded} outside-jurisdiction robustness case(s) excluded from rate]`
+        : ""),
   );
   lines.push(
     `Routed:    ${(metrics.coverage * 100).toFixed(1)}%  (${metrics.resolved}/${metrics.total} reached an agency)`,

--- a/nexa/eval/results/SUMMARY.md
+++ b/nexa/eval/results/SUMMARY.md
@@ -200,28 +200,44 @@ The harness exits non-zero when readiness falls below the **≥90% K3 target**
 regressions. CI now runs this step and a committed baseline lives at
 `eval/results/readiness.json` (un-ignored via `nexa/.gitignore`).
 
-### Baseline
+### Baseline (after the 11-municipality e2e-coverage expansion)
+
+The dataset was expanded so every one of the 11 served municipalities has each
+of its agencies exercised for required-field filling, plus robustness cases
+(boundary side-of-seam, missing-required negative controls, and an
+outside-all-jurisdictions case). The outside-jurisdiction case is **excluded
+from the readiness rate** (there is no intake to fill) but still runs to prove
+graceful no-agency handling.
 
 | Metric                  | Value         |
 | ----------------------- | ------------- |
-| Submission readiness    | **91.7%** (11/12) — PASS vs ≥90% |
-| Routed (reached agency) | 100.0% (12/12) |
+| Submission readiness    | **93.9%** (31/33) — PASS vs ≥90% |
+| Routed (reached agency) | 97.1% (33/34) |
+| Excluded (out-of-area)  | 1 (outside all jurisdictions) |
 
-| Issue type        | Support | Readiness |
-| ----------------- | ------- | --------- |
-| ROAD_DAMAGE       | 5       | 100.0%    |
-| ILLEGAL_DUMPING   | 4       | 100.0%    |
-| VEHICLE_EMISSIONS | 3       | 66.7%     |
+| Issue type         | Support | Readiness |
+| ------------------ | ------- | --------- |
+| ROAD_DAMAGE        | 10      | 100.0%    |
+| ILLEGAL_DUMPING    | 7       | 100.0%    |
+| STREETLIGHT_OUTAGE | 3       | 100.0%    |
+| SIDEWALK_DAMAGE    | 2       | 100.0%    |
+| GRAFFITI           | 2       | 50.0%     |
+| VEHICLE_EMISSIONS  | 3       | 66.7%     |
+| ABANDONED_VEHICLE / CODE_ENFORCEMENT / FLOODING_DRAINAGE / PARKING / TRAFFIC_SIGNAL / TREE_MAINTENANCE | 1 each | 100.0% |
 
 | Intake method | Support | Readiness |
 | ------------- | ------- | --------- |
-| API           | 2       | 100.0%    |
-| WEB_FORM      | 7       | 100.0%    |
+| API           | 15      | 100.0%    |
+| WEB_FORM      | 14      | 92.9%     |
+| EMAIL         | 1       | 100.0%    |
 | PHONE         | 3       | 66.7%     |
 
-The single not-ready case (`emit-pa-12-incomplete`) is an intentionally
-incomplete CARB smoking-vehicle report missing required vehicle fields — it
-keeps the dataset honest about the floor. Above the 90% gate.
+The not-ready cases are intentional negative controls that keep the dataset
+honest about the floor: `emit-pa-12-incomplete` (CARB smoking-vehicle report
+missing required vehicle fields, PHONE) and `graffiti-pa-33-missing-required`
+(Palo Alto 311 report with no `location_address`, WEB_FORM) — each proves the
+required-field gate actually fails when a required value is absent. Above the
+90% gate.
 
 ### How to reproduce
 
@@ -250,19 +266,28 @@ and there must be ≥1 auto-fileable case; the harness exits non-zero otherwise,
 the CI `eval` job fails on a regression. A committed baseline lives at
 `eval/results/submission.json` (un-ignored via `nexa/.gitignore`).
 
-### Baseline
+### Baseline (after the 11-municipality e2e-coverage expansion)
 
 | Metric                              | Value                          |
 | ----------------------------------- | ------------------------------ |
 | Filing success (auto-fileable)      | **100.0%** (1/1) — PASS         |
-| Outcomes                            | 1 filed · 19 manual-assist · 0 failed (n=20) |
+| Outcomes                            | 1 filed · 32 manual-assist · 1 no-agency(out-of-area) · 0 failed (n=34) |
 
-| Intake method | filed | manual_assist | failed |
-| ------------- | ----- | ------------- | ------ |
-| API           | 0     | 8             | 0      |
-| EMAIL         | 1     | 0             | 0      |
-| PHONE         | 0     | 3             | 0      |
-| WEB_FORM      | 0     | 8             | 0      |
+| Intake method | filed | manual_assist | no_agency | failed |
+| ------------- | ----- | ------------- | --------- | ------ |
+| API           | 0     | 15            | 0         | 0      |
+| EMAIL         | 1     | 0             | 0         | 0      |
+| PHONE         | 0     | 3             | 0         | 0      |
+| WEB_FORM      | 0     | 14            | 0         | 0      |
+| (unrouted)    | 0     | 0             | 1         | 0      |
+
+Every `manual_assist` handoff is now asserted to carry a non-null intake target
+(the agency's form URL, intake email, or hotline phone), so the dataset proves
+each un-fileable channel still surfaces a real destination to file at. The
+`no_agency` case is the outside-all-jurisdictions robustness report (Pacific
+Ocean off the California coast): it resolves to no agency and is handled
+gracefully — counted separately, NOT as a filing failure, so it does not trip
+the 100%-of-auto-fileable gate.
 
 Honest channel breakdown: **EMAIL is the only channel that auto-files today** —
 East Palo Alto Clean City files via Resend (`dump-epa-14`). Every seeded

--- a/nexa/eval/results/end-to-end.json
+++ b/nexa/eval/results/end-to-end.json
@@ -1,8 +1,8 @@
 {
   "mode": "end-to-end",
-  "datasetSize": 63,
+  "datasetSize": 65,
   "target": 0.8,
-  "ranAt": "2026-06-10T09:37:04.849Z",
+  "ranAt": "2026-06-11T01:59:39.943Z",
   "results": [
     {
       "caseId": "palo-alto-road_damage-01",
@@ -765,13 +765,37 @@
       ],
       "correct": true,
       "reason": "Confident match reached San Leandro SeeClickFix (Open311)."
+    },
+    {
+      "caseId": "boundary-paloalto-vs-eastpaloalto-64",
+      "issueType": "ILLEGAL_DUMPING",
+      "expectedAgencyName": "Palo Alto 311",
+      "outcome": "confident",
+      "resolvedAgencyName": "Palo Alto 311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Palo Alto 311."
+    },
+    {
+      "caseId": "boundary-menlo-vs-paloalto-65",
+      "issueType": "STREETLIGHT_OUTAGE",
+      "expectedAgencyName": "Menlo Park ACT",
+      "outcome": "confident",
+      "resolvedAgencyName": "Menlo Park ACT",
+      "candidateNames": [
+        "Menlo Park ACT"
+      ],
+      "correct": true,
+      "reason": "Confident match reached Menlo Park ACT."
     }
   ],
   "metrics": {
-    "total": 63,
-    "correct": 63,
+    "total": 65,
+    "correct": 65,
     "accuracy": 1,
-    "resolved": 63,
+    "resolved": 65,
     "coverage": 1,
     "ambiguous": 6,
     "perCategory": {
@@ -781,13 +805,18 @@
         "accuracy": 1
       },
       "ILLEGAL_DUMPING": {
-        "support": 27,
-        "correct": 27,
+        "support": 28,
+        "correct": 28,
         "accuracy": 1
       },
       "VEHICLE_EMISSIONS": {
         "support": 6,
         "correct": 6,
+        "accuracy": 1
+      },
+      "STREETLIGHT_OUTAGE": {
+        "support": 1,
+        "correct": 1,
         "accuracy": 1
       }
     }

--- a/nexa/eval/results/readiness.json
+++ b/nexa/eval/results/readiness.json
@@ -1,8 +1,8 @@
 {
   "mode": "readiness",
-  "datasetSize": 20,
+  "datasetSize": 34,
   "target": 0.9,
-  "ranAt": "2026-06-10T09:36:52.013Z",
+  "ranAt": "2026-06-11T01:59:39.593Z",
   "results": [
     {
       "caseId": "road-pa-01",
@@ -12,6 +12,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -27,6 +32,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -37,6 +43,11 @@
       "agencyId": "city-mountain-view::Mountain View Public Works",
       "agencyName": "Mountain View Public Works",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.mountainview.gov/our-city/departments/public-works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -52,6 +63,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -62,6 +74,11 @@
       "agencyId": "county-santa-clara-unincorporated::Santa Clara County Public Works",
       "agencyName": "Santa Clara County Public Works",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://roads.santaclaracounty.gov/services/service-requests",
+      "candidateNames": [
+        "Santa Clara County Public Works"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -77,6 +94,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -87,6 +105,12 @@
       "agencyId": "city-menlo-park::Menlo Park SeeClickFix (Open311)",
       "agencyName": "Menlo Park SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "disambiguation": "More than one office handles this here. Which should we file your report with?",
       "serviceCode": "94213",
       "missingFields": [],
       "fieldChecks": [
@@ -107,6 +131,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -117,6 +142,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -132,6 +162,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -142,6 +173,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -157,6 +193,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -167,6 +204,11 @@
       "agencyId": "city-mountain-view::Mountain View Public Works",
       "agencyName": "Mountain View Public Works",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.mountainview.gov/our-city/departments/public-works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -182,6 +224,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -192,6 +235,12 @@
       "agencyId": "city-menlo-park::Menlo Park SeeClickFix (Open311)",
       "agencyName": "Menlo Park SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "disambiguation": "More than one office handles this here. Which should we file your report with?",
       "serviceCode": "94210",
       "missingFields": [],
       "fieldChecks": [
@@ -212,6 +261,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -222,6 +272,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -237,6 +292,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -247,6 +303,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "intakeTarget": "(800) 242-4450",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -272,6 +333,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "phone hotline intake resolvable; all required fields filled."
     },
     {
@@ -282,6 +344,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "intakeTarget": "(800) 242-4450",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -307,6 +374,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "phone hotline intake resolvable; all required fields filled."
     },
     {
@@ -317,6 +385,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "intakeTarget": "(800) 242-4450",
+      "candidateNames": [
+        "CARB Smoking Vehicle Complaint"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [
         "license_plate"
@@ -344,6 +417,7 @@
         }
       ],
       "ready": false,
+      "excludedFromRate": false,
       "reason": "Required field(s) not populated from report."
     },
     {
@@ -354,6 +428,11 @@
       "agencyId": "city-east-palo-alto::East Palo Alto Public Works",
       "agencyName": "East Palo Alto Public Works",
       "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.cityofepa.org/contact",
+      "candidateNames": [
+        "East Palo Alto Public Works"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -369,6 +448,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "web form intake resolvable; all required fields filled."
     },
     {
@@ -379,6 +459,11 @@
       "agencyId": "city-east-palo-alto::East Palo Alto Clean City",
       "agencyName": "East Palo Alto Clean City",
       "intakeMethod": "EMAIL",
+      "intakeTarget": "cleancity@cityofepa.org",
+      "candidateNames": [
+        "East Palo Alto Clean City"
+      ],
+      "disambiguation": null,
       "serviceCode": null,
       "missingFields": [],
       "fieldChecks": [
@@ -394,6 +479,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "email intake resolvable; all required fields filled."
     },
     {
@@ -404,6 +490,11 @@
       "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
       "agencyName": "Milpitas SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "26652",
       "missingFields": [],
       "fieldChecks": [
@@ -424,6 +515,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -434,6 +526,11 @@
       "agencyId": "city-morgan-hill::Morgan Hill SeeClickFix (Open311)",
       "agencyName": "Morgan Hill SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "38127",
       "missingFields": [],
       "fieldChecks": [
@@ -454,6 +551,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -464,6 +562,11 @@
       "agencyId": "city-gilroy::Gilroy SeeClickFix (Open311)",
       "agencyName": "Gilroy SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "57748",
       "missingFields": [],
       "fieldChecks": [
@@ -484,6 +587,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -494,6 +598,11 @@
       "agencyId": "city-watsonville::Watsonville SeeClickFix (Open311)",
       "agencyName": "Watsonville SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "50064",
       "missingFields": [],
       "fieldChecks": [
@@ -514,6 +623,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -524,6 +634,11 @@
       "agencyId": "city-vallejo::Vallejo SeeClickFix (Open311)",
       "agencyName": "Vallejo SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "3613",
       "missingFields": [],
       "fieldChecks": [
@@ -544,6 +659,7 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
     },
     {
@@ -554,6 +670,11 @@
       "agencyId": "city-san-leandro::San Leandro SeeClickFix (Open311)",
       "agencyName": "San Leandro SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
       "serviceCode": "53607",
       "missingFields": [],
       "fieldChecks": [
@@ -574,19 +695,481 @@
         }
       ],
       "ready": true,
+      "excludedFromRate": false,
       "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "graffiti-mp-act-21-webform",
+      "issueType": "GRAFFITI",
+      "resolved": true,
+      "disambiguated": true,
+      "agencyId": "city-menlo-park::Menlo Park ACT",
+      "agencyName": "Menlo Park ACT",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.menlopark.gov/Services/ACT-Menlo-Park",
+      "candidateNames": [
+        "Menlo Park ACT",
+        "Menlo Park SeeClickFix (Open311)"
+      ],
+      "disambiguation": "More than one office handles this here. Which should we file your report with?",
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "[ambiguous routing -> chose Menlo Park ACT] web form intake resolvable; all required fields filled."
+    },
+    {
+      "caseId": "light-mv-22-webform",
+      "issueType": "STREETLIGHT_OUTAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-mountain-view::Mountain View Public Works",
+      "agencyName": "Mountain View Public Works",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.mountainview.gov/our-city/departments/public-works",
+      "candidateNames": [
+        "Mountain View Public Works"
+      ],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "web form intake resolvable; all required fields filled."
+    },
+    {
+      "caseId": "signal-scc-23-webform",
+      "issueType": "TRAFFIC_SIGNAL",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "county-santa-clara-unincorporated::Santa Clara County Public Works",
+      "agencyName": "Santa Clara County Public Works",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://roads.santaclaracounty.gov/services/service-requests",
+      "candidateNames": [
+        "Santa Clara County Public Works"
+      ],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "web form intake resolvable; all required fields filled."
+    },
+    {
+      "caseId": "sidewalk-epa-pw-24-webform",
+      "issueType": "SIDEWALK_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-east-palo-alto::East Palo Alto Public Works",
+      "agencyName": "East Palo Alto Public Works",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.cityofepa.org/contact",
+      "candidateNames": [
+        "East Palo Alto Public Works"
+      ],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "web form intake resolvable; all required fields filled."
+    },
+    {
+      "caseId": "flood-mil-25-api",
+      "issueType": "FLOODING_DRAINAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
+      "agencyName": "Milpitas SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "26645",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "vehicle-mil-26-api",
+      "issueType": "ABANDONED_VEHICLE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
+      "agencyName": "Milpitas SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Milpitas SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "26639",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "road-mh-27-api",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-morgan-hill::Morgan Hill SeeClickFix (Open311)",
+      "agencyName": "Morgan Hill SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Morgan Hill SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "38109",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "park-gil-28-api",
+      "issueType": "PARKING",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-gilroy::Gilroy SeeClickFix (Open311)",
+      "agencyName": "Gilroy SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Gilroy SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "64773",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "sidewalk-wat-29-api",
+      "issueType": "SIDEWALK_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-watsonville::Watsonville SeeClickFix (Open311)",
+      "agencyName": "Watsonville SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Watsonville SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "50066",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "code-val-30-api",
+      "issueType": "CODE_ENFORCEMENT",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-vallejo::Vallejo SeeClickFix (Open311)",
+      "agencyName": "Vallejo SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "Vallejo SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "4718",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "tree-sl-31-api",
+      "issueType": "TREE_MAINTENANCE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-san-leandro::San Leandro SeeClickFix (Open311)",
+      "agencyName": "San Leandro SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "intakeTarget": "https://seeclickfix.com/open311/v2",
+      "candidateNames": [
+        "San Leandro SeeClickFix (Open311)"
+      ],
+      "disambiguation": null,
+      "serviceCode": "53558",
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "service_code",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location(lat+long|address_string)",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "API intake reached; GeoReport v2 body fully populated."
+    },
+    {
+      "caseId": "road-boundary-pa-vs-epa-32",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-palo-alto::Palo Alto 311",
+      "agencyName": "Palo Alto 311",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": true
+        }
+      ],
+      "ready": true,
+      "excludedFromRate": false,
+      "reason": "web form intake resolvable; all required fields filled."
+    },
+    {
+      "caseId": "graffiti-pa-33-missing-required",
+      "issueType": "GRAFFITI",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-palo-alto::Palo Alto 311",
+      "agencyName": "Palo Alto 311",
+      "intakeMethod": "WEB_FORM",
+      "intakeTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "candidateNames": [
+        "Palo Alto 311"
+      ],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [
+        "location_address"
+      ],
+      "fieldChecks": [
+        {
+          "field": "description",
+          "required": true,
+          "satisfied": true
+        },
+        {
+          "field": "location_address",
+          "required": true,
+          "satisfied": false
+        }
+      ],
+      "ready": false,
+      "excludedFromRate": false,
+      "reason": "Required field(s) not populated from report."
+    },
+    {
+      "caseId": "road-outside-all-34",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": false,
+      "disambiguated": false,
+      "agencyId": null,
+      "agencyName": null,
+      "intakeMethod": null,
+      "intakeTarget": null,
+      "candidateNames": [],
+      "disambiguation": null,
+      "serviceCode": null,
+      "missingFields": [],
+      "fieldChecks": [],
+      "ready": false,
+      "excludedFromRate": true,
+      "reason": "Outside all served jurisdictions; resolved to no agency and handled gracefully (manual-assist)."
     }
   ],
   "metrics": {
-    "total": 20,
-    "ready": 19,
-    "readiness": 0.95,
-    "resolved": 20,
-    "coverage": 1,
+    "total": 34,
+    "scored": 33,
+    "ready": 31,
+    "readiness": 0.9393939393939394,
+    "resolved": 33,
+    "coverage": 0.9705882352941176,
+    "excluded": 1,
     "perCategory": {
       "ROAD_DAMAGE": {
-        "support": 8,
-        "ready": 8,
+        "support": 10,
+        "ready": 10,
         "readiness": 1
       },
       "ILLEGAL_DUMPING": {
@@ -600,20 +1183,60 @@
         "readiness": 0.6666666666666666
       },
       "STREETLIGHT_OUTAGE": {
+        "support": 3,
+        "ready": 3,
+        "readiness": 1
+      },
+      "GRAFFITI": {
+        "support": 2,
+        "ready": 1,
+        "readiness": 0.5
+      },
+      "TRAFFIC_SIGNAL": {
+        "support": 1,
+        "ready": 1,
+        "readiness": 1
+      },
+      "SIDEWALK_DAMAGE": {
         "support": 2,
         "ready": 2,
+        "readiness": 1
+      },
+      "FLOODING_DRAINAGE": {
+        "support": 1,
+        "ready": 1,
+        "readiness": 1
+      },
+      "ABANDONED_VEHICLE": {
+        "support": 1,
+        "ready": 1,
+        "readiness": 1
+      },
+      "PARKING": {
+        "support": 1,
+        "ready": 1,
+        "readiness": 1
+      },
+      "CODE_ENFORCEMENT": {
+        "support": 1,
+        "ready": 1,
+        "readiness": 1
+      },
+      "TREE_MAINTENANCE": {
+        "support": 1,
+        "ready": 1,
         "readiness": 1
       }
     },
     "perIntakeMethod": {
       "WEB_FORM": {
-        "support": 8,
-        "ready": 8,
-        "readiness": 1
+        "support": 14,
+        "ready": 13,
+        "readiness": 0.9285714285714286
       },
       "API": {
-        "support": 8,
-        "ready": 8,
+        "support": 15,
+        "ready": 15,
         "readiness": 1
       },
       "PHONE": {

--- a/nexa/eval/results/submission.json
+++ b/nexa/eval/results/submission.json
@@ -1,8 +1,8 @@
 {
   "mode": "submission",
-  "datasetSize": 20,
+  "datasetSize": 34,
   "target": 1,
-  "ranAt": "2026-06-10T21:59:10.122Z",
+  "ranAt": "2026-06-11T01:59:40.343Z",
   "results": [
     {
       "caseId": "road-pa-01",
@@ -12,10 +12,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
     },
     {
       "caseId": "road-mv-02",
@@ -25,10 +26,11 @@
       "agencyId": "city-mountain-view::Mountain View Public Works",
       "agencyName": "Mountain View Public Works",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.mountainview.gov/our-city/departments/public-works",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.mountainview.gov/our-city/departments/public-works."
     },
     {
       "caseId": "road-scc-03",
@@ -38,10 +40,11 @@
       "agencyId": "county-santa-clara-unincorporated::Santa Clara County Public Works",
       "agencyName": "Santa Clara County Public Works",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://roads.santaclaracounty.gov/services/service-requests",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://roads.santaclaracounty.gov/services/service-requests."
     },
     {
       "caseId": "road-mp-04-api",
@@ -51,10 +54,11 @@
       "agencyId": "city-menlo-park::Menlo Park SeeClickFix (Open311)",
       "agencyName": "Menlo Park SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "road-pa-05-aifallback",
@@ -64,10 +68,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
     },
     {
       "caseId": "dump-pa-06",
@@ -77,10 +82,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
     },
     {
       "caseId": "dump-mv-07",
@@ -90,10 +96,11 @@
       "agencyId": "city-mountain-view::Mountain View Public Works",
       "agencyName": "Mountain View Public Works",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.mountainview.gov/our-city/departments/public-works",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.mountainview.gov/our-city/departments/public-works."
     },
     {
       "caseId": "dump-mp-08-api",
@@ -103,10 +110,11 @@
       "agencyId": "city-menlo-park::Menlo Park SeeClickFix (Open311)",
       "agencyName": "Menlo Park SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "[ambiguous routing -> chose Menlo Park SeeClickFix (Open311)] Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "dump-pa-09-nophoto",
@@ -116,10 +124,11 @@
       "agencyId": "city-palo-alto::Palo Alto 311",
       "agencyName": "Palo Alto 311",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
     },
     {
       "caseId": "emit-pa-10",
@@ -129,10 +138,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "manualAssistTarget": "(800) 242-4450",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist."
+      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist at (800) 242-4450."
     },
     {
       "caseId": "emit-pa-11",
@@ -142,10 +152,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "manualAssistTarget": "(800) 242-4450",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist."
+      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist at (800) 242-4450."
     },
     {
       "caseId": "emit-pa-12-incomplete",
@@ -155,10 +166,11 @@
       "agencyId": "city-palo-alto::CARB Smoking Vehicle Complaint",
       "agencyName": "CARB Smoking Vehicle Complaint",
       "intakeMethod": "PHONE",
+      "manualAssistTarget": "(800) 242-4450",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist."
+      "reason": "PHONE intake has no automated filing agent; handed off to manual-assist at (800) 242-4450."
     },
     {
       "caseId": "road-epa-13",
@@ -168,10 +180,11 @@
       "agencyId": "city-east-palo-alto::East Palo Alto Public Works",
       "agencyName": "East Palo Alto Public Works",
       "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.cityofepa.org/contact",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist."
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.cityofepa.org/contact."
     },
     {
       "caseId": "dump-epa-14",
@@ -181,6 +194,7 @@
       "agencyId": "city-east-palo-alto::East Palo Alto Clean City",
       "agencyName": "East Palo Alto Clean City",
       "intakeMethod": "EMAIL",
+      "manualAssistTarget": "cleancity@cityofepa.org",
       "channel": "EMAIL",
       "outcome": "filed",
       "trackingId": "email-dump-epa-14",
@@ -194,10 +208,11 @@
       "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
       "agencyName": "Milpitas SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "dump-mh-16-api",
@@ -207,10 +222,11 @@
       "agencyId": "city-morgan-hill::Morgan Hill SeeClickFix (Open311)",
       "agencyName": "Morgan Hill SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "light-gil-17-api",
@@ -220,10 +236,11 @@
       "agencyId": "city-gilroy::Gilroy SeeClickFix (Open311)",
       "agencyName": "Gilroy SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "road-wat-18-api",
@@ -233,10 +250,11 @@
       "agencyId": "city-watsonville::Watsonville SeeClickFix (Open311)",
       "agencyName": "Watsonville SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "dump-val-19-api",
@@ -246,10 +264,11 @@
       "agencyId": "city-vallejo::Vallejo SeeClickFix (Open311)",
       "agencyName": "Vallejo SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
     },
     {
       "caseId": "light-sl-20-api",
@@ -259,38 +278,246 @@
       "agencyId": "city-san-leandro::San Leandro SeeClickFix (Open311)",
       "agencyName": "San Leandro SeeClickFix (Open311)",
       "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
       "channel": null,
       "outcome": "manual_assist",
       "trackingId": null,
-      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist."
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "graffiti-mp-act-21-webform",
+      "issueType": "GRAFFITI",
+      "resolved": true,
+      "disambiguated": true,
+      "agencyId": "city-menlo-park::Menlo Park ACT",
+      "agencyName": "Menlo Park ACT",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.menlopark.gov/Services/ACT-Menlo-Park",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "[ambiguous routing -> chose Menlo Park ACT] WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.menlopark.gov/Services/ACT-Menlo-Park."
+    },
+    {
+      "caseId": "light-mv-22-webform",
+      "issueType": "STREETLIGHT_OUTAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-mountain-view::Mountain View Public Works",
+      "agencyName": "Mountain View Public Works",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.mountainview.gov/our-city/departments/public-works",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.mountainview.gov/our-city/departments/public-works."
+    },
+    {
+      "caseId": "signal-scc-23-webform",
+      "issueType": "TRAFFIC_SIGNAL",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "county-santa-clara-unincorporated::Santa Clara County Public Works",
+      "agencyName": "Santa Clara County Public Works",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://roads.santaclaracounty.gov/services/service-requests",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://roads.santaclaracounty.gov/services/service-requests."
+    },
+    {
+      "caseId": "sidewalk-epa-pw-24-webform",
+      "issueType": "SIDEWALK_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-east-palo-alto::East Palo Alto Public Works",
+      "agencyName": "East Palo Alto Public Works",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.cityofepa.org/contact",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.cityofepa.org/contact."
+    },
+    {
+      "caseId": "flood-mil-25-api",
+      "issueType": "FLOODING_DRAINAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
+      "agencyName": "Milpitas SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "vehicle-mil-26-api",
+      "issueType": "ABANDONED_VEHICLE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-milpitas::Milpitas SeeClickFix (Open311)",
+      "agencyName": "Milpitas SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "road-mh-27-api",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-morgan-hill::Morgan Hill SeeClickFix (Open311)",
+      "agencyName": "Morgan Hill SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "park-gil-28-api",
+      "issueType": "PARKING",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-gilroy::Gilroy SeeClickFix (Open311)",
+      "agencyName": "Gilroy SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "sidewalk-wat-29-api",
+      "issueType": "SIDEWALK_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-watsonville::Watsonville SeeClickFix (Open311)",
+      "agencyName": "Watsonville SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "code-val-30-api",
+      "issueType": "CODE_ENFORCEMENT",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-vallejo::Vallejo SeeClickFix (Open311)",
+      "agencyName": "Vallejo SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "tree-sl-31-api",
+      "issueType": "TREE_MAINTENANCE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-san-leandro::San Leandro SeeClickFix (Open311)",
+      "agencyName": "San Leandro SeeClickFix (Open311)",
+      "intakeMethod": "API",
+      "manualAssistTarget": "https://seeclickfix.com/open311/v2",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at https://seeclickfix.com/open311/v2."
+    },
+    {
+      "caseId": "road-boundary-pa-vs-epa-32",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-palo-alto::Palo Alto 311",
+      "agencyName": "Palo Alto 311",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
+    },
+    {
+      "caseId": "graffiti-pa-33-missing-required",
+      "issueType": "GRAFFITI",
+      "resolved": true,
+      "disambiguated": false,
+      "agencyId": "city-palo-alto::Palo Alto 311",
+      "agencyName": "Palo Alto 311",
+      "intakeMethod": "WEB_FORM",
+      "manualAssistTarget": "https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311",
+      "channel": null,
+      "outcome": "manual_assist",
+      "trackingId": null,
+      "reason": "WEB_FORM intake has no automated filing agent; handed off to manual-assist at https://www.paloalto.gov/Residents/Services/Report-an-Issue/Palo-Alto-311."
+    },
+    {
+      "caseId": "road-outside-all-34",
+      "issueType": "ROAD_DAMAGE",
+      "resolved": false,
+      "disambiguated": false,
+      "agencyId": null,
+      "agencyName": null,
+      "intakeMethod": null,
+      "channel": null,
+      "manualAssistTarget": null,
+      "outcome": "no_agency",
+      "reason": "Outside all served jurisdictions; no agency resolved — handled gracefully (manual-assist), not a filing failure.",
+      "trackingId": null
     }
   ],
   "metrics": {
-    "total": 20,
+    "total": 34,
     "filed": 1,
-    "manualAssist": 19,
+    "manualAssist": 32,
+    "noAgency": 1,
     "failed": 0,
     "autoFileable": 1,
     "filingSuccessRate": 1,
     "perChannel": {
       "WEB_FORM": {
         "filed": 0,
-        "manualAssist": 8,
+        "manualAssist": 14,
+        "noAgency": 0,
         "failed": 0
       },
       "API": {
         "filed": 0,
-        "manualAssist": 8,
+        "manualAssist": 15,
+        "noAgency": 0,
         "failed": 0
       },
       "PHONE": {
         "filed": 0,
         "manualAssist": 3,
+        "noAgency": 0,
         "failed": 0
       },
       "EMAIL": {
         "filed": 1,
         "manualAssist": 0,
+        "noAgency": 0,
+        "failed": 0
+      },
+      "<unrouted>": {
+        "filed": 0,
+        "manualAssist": 0,
+        "noAgency": 1,
         "failed": 0
       }
     }

--- a/nexa/eval/submission.ts
+++ b/nexa/eval/submission.ts
@@ -82,12 +82,18 @@ const AGENCY_ROWS: AgencyRow[] = AGENCIES.map((a) => ({
 
 const agencyById = new Map(AGENCY_ROWS.map((a) => [a.id, a]));
 
+// `resolveAgencyId` queries by { jurisdiction, issueTypes: { has } }, selecting
+// only `id`. `resolveAgencyCandidates` (the disambiguation robustness path)
+// queries the SAME table by { id: { in: candidates } }, ordering by name. The
+// stub answers both shapes off `AGENCY_ROWS` so the harness can drive either
+// production function without a live DB.
 type FindManyArgs = {
   where?: {
     jurisdiction?: string;
     issueTypes?: { has?: string };
+    id?: { in?: string[] };
   };
-  orderBy?: { id?: "asc" | "desc" };
+  orderBy?: { id?: "asc" | "desc" } | { name?: "asc" | "desc" };
 };
 
 const prismaStub = {
@@ -95,21 +101,42 @@ const prismaStub = {
     async findMany(args: FindManyArgs) {
       const jurisdiction = args.where?.jurisdiction;
       const issueType = args.where?.issueTypes?.has;
+      const idIn = args.where?.id?.in;
       let rows = AGENCY_ROWS.filter(
         (a) =>
           (jurisdiction === undefined || a.jurisdiction === jurisdiction) &&
           (issueType === undefined ||
             a.issueTypes.includes(
               issueType as AgencySeed["issueTypes"][number],
-            )),
+            )) &&
+          (idIn === undefined || idIn.includes(a.id)),
       );
-      const dir = args.orderBy?.id ?? "asc";
-      rows = rows
-        .slice()
-        .sort((a, b) =>
-          dir === "desc" ? b.id.localeCompare(a.id) : a.id.localeCompare(b.id),
-        );
-      return rows.map((a) => ({ id: a.id }));
+      const order = args.orderBy ?? { id: "asc" };
+      if ("name" in order && order.name) {
+        const dir = order.name;
+        rows = rows
+          .slice()
+          .sort((a, b) =>
+            dir === "desc"
+              ? b.name.localeCompare(a.name)
+              : a.name.localeCompare(b.name),
+          );
+      } else {
+        const dir = ("id" in order && order.id) || "asc";
+        rows = rows
+          .slice()
+          .sort((a, b) =>
+            dir === "desc"
+              ? b.id.localeCompare(a.id)
+              : a.id.localeCompare(b.id),
+          );
+      }
+      return rows.map((a) => ({
+        id: a.id,
+        name: a.name,
+        jurisdiction: a.jurisdiction,
+        intakeMethod: a.intakeMethod,
+      }));
     },
   },
 };
@@ -123,7 +150,10 @@ const prismaStub = {
 type AgencyModule = typeof import("../src/lib/jurisdictions/agency");
 type Open311Module = typeof import("../src/lib/submission/open311");
 type EmailModule = typeof import("../src/lib/submission/email");
-let resolveAgencyId: AgencyModule["resolveAgencyId"];
+// `resolveAgencyCandidates` internally calls the production `resolveAgencyId`
+// (which our Prisma stub backs), so we drive the candidate resolver directly and
+// get both the routing decision and the ambiguity candidate set from one call.
+let resolveAgencyCandidates: AgencyModule["resolveAgencyCandidates"];
 let parseOpen311Config: Open311Module["parseOpen311Config"];
 let canAutoFileOpen311: Open311Module["canAutoFileOpen311"];
 let submitToOpen311: Open311Module["submitToOpen311"];
@@ -133,7 +163,7 @@ async function loadDeps(): Promise<void> {
   const agency = await import("../src/lib/jurisdictions/agency");
   const open311 = await import("../src/lib/submission/open311");
   const email = await import("../src/lib/submission/email");
-  resolveAgencyId = agency.resolveAgencyId;
+  resolveAgencyCandidates = agency.resolveAgencyCandidates;
   parseOpen311Config = open311.parseOpen311Config;
   canAutoFileOpen311 = open311.canAutoFileOpen311;
   submitToOpen311 = open311.submitToOpen311;
@@ -170,6 +200,22 @@ interface SubmissionCase {
   issueType: IssueType;
   note?: string;
   report: SubmissionReport;
+  /**
+   * Optional routing assertion (mirrors eval/readiness.ts). When set, the case
+   * resolves to (or has among its ambiguity candidates) an agency with this
+   * exact `name`, and that agency is the one filed/handed-off with. Pins the
+   * filing path to a SPECIFIC agency that the default API-preferred
+   * disambiguation would otherwise skip (e.g. the Menlo Park ACT WEB_FORM desk).
+   */
+  expectAgencyName?: string;
+  /**
+   * Robustness case: the location is OUTSIDE all served jurisdictions, so it
+   * MUST resolve to no agency. The harness asserts no agency resolves and
+   * records a "no_agency" handled outcome — NOT a filing failure (so it does not
+   * trip the 100%-of-auto-fileable gate). Proves out-of-area reports degrade
+   * gracefully instead of crashing.
+   */
+  expectNoAgency?: boolean;
 }
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -223,7 +269,7 @@ function makeResendStub(caseId: string) {
 // Per-case filing
 // ---------------------------------------------------------------------------
 
-type Outcome = "filed" | "manual_assist" | "failed";
+type Outcome = "filed" | "manual_assist" | "no_agency" | "failed";
 
 interface CaseResult {
   caseId: string;
@@ -236,6 +282,12 @@ interface CaseResult {
   intakeMethod: string | null;
   /** The channel the filing agent actually used, when it filed. */
   channel: "API" | "EMAIL" | null;
+  /**
+   * For a manual_assist handoff: the intake target the user is pointed at — the
+   * agency's form URL, intake email, or hotline phone. Asserted non-null, so the
+   * dataset proves every un-fileable channel still surfaces a real destination.
+   */
+  manualAssistTarget: string | null;
   outcome: Outcome;
   trackingId: string | null;
   reason: string;
@@ -247,10 +299,13 @@ interface CaseResult {
  * otherwise (ambiguous routing: `agencyId` null with multiple `candidates`) we
  * prefer an API agency (the machine-submittable channel), else the first by id.
  */
-function chooseAgency(resolution: {
-  agencyId: string | null;
-  candidates: string[];
-}): { agency: AgencyRow | undefined; disambiguated: boolean } {
+function chooseAgency(
+  resolution: {
+    agencyId: string | null;
+    candidates: string[];
+  },
+  expectAgencyName?: string,
+): { agency: AgencyRow | undefined; disambiguated: boolean } {
   if (resolution.agencyId) {
     return {
       agency: agencyById.get(resolution.agencyId),
@@ -263,18 +318,76 @@ function chooseAgency(resolution: {
   const rows = resolution.candidates
     .map((id) => agencyById.get(id))
     .filter((a): a is AgencyRow => a !== undefined);
+  // A case may PIN filing to a specific covering agency the default
+  // API-preferred disambiguation would otherwise skip (e.g. Menlo Park ACT).
+  if (expectAgencyName) {
+    const pinned = rows.find((a) => a.name === expectAgencyName);
+    if (pinned) return { agency: pinned, disambiguated: true };
+  }
   const api = rows.find((a) => a.intakeMethod === "API");
   return { agency: api ?? rows[0], disambiguated: true };
 }
 
+/** Resolves an agency's usable manual-assist target (URL, email, or hotline). */
+function manualAssistTargetOf(agency: AgencyRow): string | null {
+  if (agency.intakeUrl) return agency.intakeUrl;
+  if (agency.intakeEmail) return agency.intakeEmail;
+  const rf = agency.requiredFields;
+  if (rf && typeof rf === "object") {
+    const phone = (rf as { contact_phone?: unknown }).contact_phone;
+    if (phone && typeof phone === "object") {
+      const value = (phone as { value?: unknown }).value;
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+  }
+  return null;
+}
+
 async function fileCase(c: SubmissionCase): Promise<CaseResult> {
-  const resolution = await resolveAgencyId({
+  // Reuse the production candidate resolver (same call drives both the routing
+  // decision and the ambiguity candidate set), mirroring eval/readiness.ts.
+  const disambig = await resolveAgencyCandidates({
     latitude: c.report.latitude,
     longitude: c.report.longitude,
     issueType: c.issueType,
   });
+  const resolution = {
+    agencyId: disambig.agencyId,
+    candidates: disambig.candidates.map((d) => d.id),
+  };
 
-  const { agency, disambiguated } = chooseAgency(resolution);
+  // Robustness: an outside-all-jurisdictions location MUST resolve to no agency.
+  // Record a handled "no_agency" outcome — never "failed" — so out-of-area
+  // reports degrade gracefully and do not trip the auto-fileable filing gate.
+  if (c.expectNoAgency) {
+    if (disambig.candidates.length > 0) {
+      throw new Error(
+        `[${c.id}] expected NO agency (outside all jurisdictions) but resolved candidates [${disambig.candidates
+          .map((d) => d.name)
+          .join(", ")}].`,
+      );
+    }
+    return {
+      caseId: c.id,
+      issueType: c.issueType,
+      resolved: false,
+      disambiguated: false,
+      agencyId: null,
+      agencyName: null,
+      intakeMethod: null,
+      channel: null,
+      manualAssistTarget: null,
+      outcome: "no_agency",
+      reason:
+        "Outside all served jurisdictions; no agency resolved — handled gracefully (manual-assist), not a filing failure.",
+      trackingId: null,
+    };
+  }
+
+  const { agency, disambiguated } = chooseAgency(
+    resolution,
+    c.expectAgencyName,
+  );
   if (!agency) {
     return {
       caseId: c.id,
@@ -285,12 +398,21 @@ async function fileCase(c: SubmissionCase): Promise<CaseResult> {
       agencyName: null,
       intakeMethod: null,
       channel: null,
+      manualAssistTarget: null,
       outcome: "failed",
       reason: "No agency covers this jurisdiction + issue type.",
       trackingId: null,
     };
   }
 
+  // Assert the pinned-agency expectation when set.
+  if (c.expectAgencyName && agency.name !== c.expectAgencyName) {
+    throw new Error(
+      `[${c.id}] expected agency "${c.expectAgencyName}" but filed/handed-off with "${agency.name}".`,
+    );
+  }
+
+  const manualAssistTarget = manualAssistTargetOf(agency);
   const base = {
     caseId: c.id,
     issueType: c.issueType,
@@ -299,6 +421,9 @@ async function fileCase(c: SubmissionCase): Promise<CaseResult> {
     agencyId: agency.id,
     agencyName: agency.name,
     intakeMethod: agency.intakeMethod,
+    // The intake destination a manual handoff would point at. Always resolvable
+    // for a submittable agency; asserted non-null on every manual_assist below.
+    manualAssistTarget,
   };
 
   const tag = (reason: string): string =>
@@ -313,13 +438,14 @@ async function fileCase(c: SubmissionCase): Promise<CaseResult> {
     // jurisdiction_id on a multi-tenant SeeClickFix endpoint — #239/#250) degrade
     // to manual-assist BEFORE any POST. That is the correct, honest outcome.
     if (!canAutoFileOpen311(config, agency.intakeUrl)) {
+      assertManualAssistTarget(c.id, agency.name, manualAssistTarget);
       return {
         ...base,
         channel: null,
         outcome: "manual_assist",
         trackingId: null,
         reason: tag(
-          "Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist.",
+          `Open311 config cannot auto-file (no usable jurisdiction_id for multi-tenant endpoint); handed off to manual-assist at ${manualAssistTarget}.`,
         ),
       };
     }
@@ -426,15 +552,33 @@ async function fileCase(c: SubmissionCase): Promise<CaseResult> {
   }
 
   // --- WEB_FORM / PHONE: no automated agent — correct manual-assist handoff. --
+  assertManualAssistTarget(c.id, agency.name, manualAssistTarget);
   return {
     ...base,
     channel: null,
     outcome: "manual_assist",
     trackingId: null,
     reason: tag(
-      `${agency.intakeMethod} intake has no automated filing agent; handed off to manual-assist.`,
+      `${agency.intakeMethod} intake has no automated filing agent; handed off to manual-assist at ${manualAssistTarget}.`,
     ),
   };
+}
+
+/**
+ * A manual-assist handoff is only useful if it names WHERE to file. Every
+ * submittable agency exposes a web-form URL, an intake email, or a published
+ * hotline (PHONE intake), so a null target means the seed is broken — fail loud.
+ */
+function assertManualAssistTarget(
+  caseId: string,
+  agencyName: string,
+  target: string | null,
+): void {
+  if (!target) {
+    throw new Error(
+      `[${caseId}] manual-assist handoff to "${agencyName}" has no intake target (URL/email/phone).`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -444,6 +588,7 @@ async function fileCase(c: SubmissionCase): Promise<CaseResult> {
 interface ChannelBreakdown {
   filed: number;
   manualAssist: number;
+  noAgency: number;
   failed: number;
 }
 
@@ -451,9 +596,11 @@ interface SubmissionMetrics {
   total: number;
   filed: number;
   manualAssist: number;
+  /** Outside-all-jurisdictions cases handled gracefully (no agency, not a failure). */
+  noAgency: number;
   failed: number;
   autoFileable: number;
-  /** filed / (filed + failed) — manual_assist excluded from the denominator. */
+  /** filed / (filed + failed) — manual_assist and no_agency excluded from the denominator. */
   filingSuccessRate: number;
   /** Per intake method: how each channel resolved. */
   perChannel: Record<string, ChannelBreakdown>;
@@ -464,15 +611,22 @@ function aggregate(results: CaseResult[]): SubmissionMetrics {
   const manualAssist = results.filter(
     (r) => r.outcome === "manual_assist",
   ).length;
+  const noAgency = results.filter((r) => r.outcome === "no_agency").length;
   const failed = results.filter((r) => r.outcome === "failed").length;
   const autoFileable = filed + failed;
 
   const perChannel: Record<string, ChannelBreakdown> = {};
   for (const r of results) {
     const key = r.intakeMethod ?? "<unrouted>";
-    const c = perChannel[key] ?? { filed: 0, manualAssist: 0, failed: 0 };
+    const c = perChannel[key] ?? {
+      filed: 0,
+      manualAssist: 0,
+      noAgency: 0,
+      failed: 0,
+    };
     if (r.outcome === "filed") c.filed++;
     else if (r.outcome === "manual_assist") c.manualAssist++;
+    else if (r.outcome === "no_agency") c.noAgency++;
     else c.failed++;
     perChannel[key] = c;
   }
@@ -481,6 +635,7 @@ function aggregate(results: CaseResult[]): SubmissionMetrics {
     total: results.length,
     filed,
     manualAssist,
+    noAgency,
     failed,
     autoFileable,
     filingSuccessRate: autoFileable === 0 ? 0 : filed / autoFileable,
@@ -495,14 +650,14 @@ function renderReport(metrics: SubmissionMetrics): string {
     `Filing success (auto-fileable): ${(metrics.filingSuccessRate * 100).toFixed(1)}%  (${metrics.filed}/${metrics.autoFileable})  target 100%`,
   );
   lines.push(
-    `Outcomes: ${metrics.filed} filed · ${metrics.manualAssist} manual-assist · ${metrics.failed} failed  (n=${metrics.total})`,
+    `Outcomes: ${metrics.filed} filed · ${metrics.manualAssist} manual-assist · ${metrics.noAgency} no-agency(out-of-area) · ${metrics.failed} failed  (n=${metrics.total})`,
   );
 
   lines.push("\nPer-intake-method breakdown:");
   for (const m of Object.keys(metrics.perChannel).sort()) {
     const v = metrics.perChannel[m];
     lines.push(
-      `  ${m.padEnd(12)} filed=${v.filed}  manual_assist=${v.manualAssist}  failed=${v.failed}`,
+      `  ${m.padEnd(12)} filed=${v.filed}  manual_assist=${v.manualAssist}  no_agency=${v.noAgency}  failed=${v.failed}`,
     );
   }
 
@@ -533,7 +688,11 @@ async function main() {
     const r = await fileCase(cases[i]);
     results.push(r);
     const mark =
-      r.outcome === "filed" ? "✓" : r.outcome === "manual_assist" ? "↪" : "✗";
+      r.outcome === "filed"
+        ? "✓"
+        : r.outcome === "manual_assist" || r.outcome === "no_agency"
+          ? "↪"
+          : "✗";
     const where = r.agencyName ?? "<unrouted>";
     const idPart = r.trackingId ? ` id=${r.trackingId}` : "";
     console.log(


### PR DESCRIPTION
## Goal

Make the submission pipeline's end-to-end coverage **comprehensive and robust across all 11 served municipalities** — proving the submission agents (a) route each report to the correct agency and (b) fill out every required field correctly, for every municipality, issue type, and intake method. All changes **extend the existing offline harnesses/datasets** (`eval/routing.ts`, `eval/readiness.ts`, `eval/end-to-end.ts`, `eval/submission.ts`, `eval/coverage.ts`) and reuse the in-memory Prisma stub + the real production functions — no parallel harness, no invented data. `prisma/agencies.ts` is untouched, so the 153-triple coverage count and its test lock are unchanged.

## Coverage matrix (11 municipalities × agency × intake × what's exercised)

Routing/agency accuracy is asserted by `eval:routing` + `eval:end-to-end`; required-field filling by `eval:readiness`; actual filing / manual-assist handoff by `eval:submission`. ✅ = exercised after this PR.

| Jurisdiction | Agency | Intake | Routing (e2e) | Field-filling (readiness) | Filing / handoff (submission) |
| --- | --- | --- | --- | --- | --- |
| Palo Alto | Palo Alto 311 | WEB_FORM | ✅ | ✅ | ✅ manual-assist (URL) |
| Palo Alto | CARB Smoking Vehicle | PHONE | ✅ | ✅ | ✅ manual-assist (hotline) |
| Menlo Park | Menlo Park ACT | WEB_FORM | ✅ | ✅ (pinned via `expectAgencyName`) | ✅ manual-assist (URL) |
| Menlo Park | Menlo Park SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239 no jurisdiction_id) |
| East Palo Alto | EPA Public Works | WEB_FORM | ✅ | ✅ | ✅ manual-assist (URL) |
| East Palo Alto | EPA Clean City | EMAIL | ✅ | ✅ | ✅ **filed** (Resend, real auto-file) |
| Mountain View | Mountain View Public Works | WEB_FORM | ✅ | ✅ | ✅ manual-assist (URL) |
| Santa Clara County (uninc.) | SCC Public Works | WEB_FORM | ✅ | ✅ | ✅ manual-assist (URL) |
| Milpitas | Milpitas SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |
| Morgan Hill | Morgan Hill SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |
| Gilroy | Gilroy SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |
| Watsonville | Watsonville SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |
| Vallejo | Vallejo SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |
| San Leandro | San Leandro SeeClickFix | API | ✅ | ✅ (GeoReport body) | ✅ manual-assist (#239) |

All 16 agency rows across the 11 jurisdictions and all 4 intake methods (API / WEB_FORM / EMAIL / PHONE) are now exercised by the field-filling and filing harnesses.

## Gaps the audit found (and this PR closed)

- **Menlo Park ACT (WEB_FORM) was never field-tested.** Routing there is ambiguous (ACT + the SeeClickFix API both cover the spot) and the harness's default disambiguation prefers the API sibling, so the ACT web-form intake/required-fields were never assessed. Closed via a new optional `expectAgencyName` that pins assessment to a named candidate.
- **Several API cities had only one issue type assessed** for GeoReport assembly; **Mountain View / SCC / EPA Public Works** each had a single type. Added a second covered type per agency (all using live-verified service codes already in the seed).
- **No ambiguity candidate-set / disambiguating-question assertion.** The harnesses now drive the real `resolveAgencyCandidates`, asserting the full candidate set + the disambiguating question on ambiguous routing (and asserting an unambiguous match carries none).
- **No outside-all-jurisdictions case** anywhere — added (see below).
- **manual-assist never asserted it surfaces a destination** — now every handoff is asserted to carry a non-null intake URL/email/phone.

## Robustness cases added

- **Ambiguous routing** → real `resolveAgencyCandidates` returns the candidate set + a disambiguating question; asserted in both readiness and submission.
- **Boundary coordinates** on the Palo Alto/East Palo Alto and Menlo Park/Palo Alto seams (reusing the verified `contested-*` coordinates) assert the report resolves to the **correct side** at the agency level (`end-to-end` cases 64–65 + readiness boundary case 32).
- **Missing OPTIONAL field still ready** (existing `dump-pa-09-nophoto`); **missing REQUIRED field flagged not-ready** — added a WEB_FORM negative control (`graffiti-pa-33-missing-required`, no `location_address`) alongside the existing PHONE one, so the required-field gate is proven to fail loudly on every channel.
- **Un-fileable Open311 agencies** (#239/#250, no usable `jurisdiction_id`) short-circuit to manual-assist before any POST — exercised by all 15 API cases.
- **Outside all 11 jurisdictions** (Pacific Ocean, `road-outside-all-34`) resolves to **no agency** and is handled gracefully: excluded from the readiness rate (no intake to fill) and recorded as a distinct `no_agency` outcome in submission — **never a crash, never a filing failure**.

Every GPS coordinate is a verified interior/boundary point reused from the existing datasets and re-confirmed via the real `resolveJurisdiction`/`resolveAgencyId`.

## New counts

| Dataset / harness | Before | After |
| --- | --- | --- |
| `end-to-end-cases.json` | 63 | **65** (+2 boundary) |
| `readiness-cases.json` (drives readiness **and** submission) | 20 | **34** (+14) |
| `routing-cases.json` | 83 | 83 (unchanged — already 1+ case per jurisdiction × agency) |
| Coverage triples (`eval:coverage`) | 153 | 153 (seed untouched) |

## Verification — all green

| Check | Result |
| --- | --- |
| `eval:routing` | PASS — 100% (target ≥85%) |
| `eval:readiness` | PASS — 93.9% (31/33; 1 out-of-area excluded) vs ≥90% |
| `eval:end-to-end` | PASS — 100% (65/65) vs ≥80% |
| `eval:submission` | PASS — 100% of auto-fileable (1 filed · 32 manual-assist · 1 no-agency · 0 failed, n=34) |
| `eval:coverage` | PASS — 153/30 triples, 11 jurisdictions |
| `eval:validate-boundaries` | PASS — 12 golden point-in-polygon assertions |
| `tsc --noEmit` | clean |
| `lint` | 0 errors (4 pre-existing warnings, none in changed files) |
| `format:check` | clean |
| `test:coverage` | exit 0 — 860 passed / 3 skipped |

Committed `eval/results/*.json` baselines and the `SUMMARY.md` readiness/submission tables were updated to match. Do **not** merge — review only.
