### PR TITLE
feat(report): pre-compose the report at the user's custom agency link

### DIFF
--- a/nexa/src/app/api/reports/[id]/submission-fields/route.test.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.test.ts
@@ -82,9 +82,13 @@ describe("GET /api/reports/[id]/submission-fields", () => {
     const res = await GET(request(), params("r1"));
     const body = await res.json();
 
-    // Assert: no 403/404; route returns the null-agency envelope.
+    // Assert: no 403/404; route returns the null-agency envelope (no agency and
+    // no override link, so nothing to file and no destination).
     expect(res.status).toBe(200);
-    expect(body).toEqual({ success: true, data: { agency: null, fields: [] } });
+    expect(body).toEqual({
+      success: true,
+      data: { agency: null, formUrl: null, customAgencyUrl: null, fields: [] },
+    });
   });
 
   it("returns agency, formUrl and prefilled fields for an owned report with an agency", async () => {
@@ -139,6 +143,68 @@ describe("GET /api/reports/[id]/submission-fields", () => {
     expect(byKey.description.value).toBe("Large pothole on the corner.");
     // The agency resolver is not consulted when the report already has an agency.
     expect(resolveAgencyId).not.toHaveBeenCalled();
+  });
+
+  it("prefers the user's custom link as the destination over the agency form", async () => {
+    // Arrange: an agency matched, but the user pasted their own correct link.
+    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
+    const agency = makeAgency({
+      id: "agency_1",
+      name: "Palo Alto 311",
+      intakeUrl: "https://www.paloalto.gov/311",
+      intakeMethod: IntakeMethod.WEB_FORM,
+      requiredFields: { description: { type: "string", required: true } },
+    });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({
+        id: "r1",
+        userId: "owner",
+        agencyId: "agency_1",
+        description: "Broken streetlight.",
+        customAgencyUrl: "https://correctcity.gov/report",
+      }),
+      agency,
+    } as never);
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert: the override link wins as the destination, and is surfaced.
+    expect(body.data.formUrl).toBe("https://correctcity.gov/report");
+    expect(body.data.customAgencyUrl).toBe("https://correctcity.gov/report");
+    expect(body.data.fields.length).toBeGreaterThan(0);
+  });
+
+  it("pre-composes the report against the custom link when no agency matched", async () => {
+    // Arrange: out of coverage (no agency), but the user supplied a link.
+    mockedGetSession.mockResolvedValue({ userId: "owner", email: "o@x.com" });
+    prismaMock.report.findUnique.mockResolvedValue({
+      ...makeReport({
+        id: "r1",
+        userId: "owner",
+        agencyId: null,
+        address: "1 Main St",
+        description: "Fallen tree blocking the road.",
+        customAgencyUrl: "https://mytown.gov/contact",
+      }),
+      agency: null,
+    } as never);
+    resolveAgencyId.mockResolvedValue({ agencyId: null, candidates: [] });
+
+    // Act
+    const res = await GET(request(), params("r1"));
+    const body = await res.json();
+
+    // Assert: no agency, but the report is still pre-composed against the link.
+    expect(body.data.agency).toBeNull();
+    expect(body.data.formUrl).toBe("https://mytown.gov/contact");
+    expect(body.data.customAgencyUrl).toBe("https://mytown.gov/contact");
+    const byKey = Object.fromEntries(
+      body.data.fields.map((f: { key: string }) => [f.key, f]),
+    );
+    expect(byKey.description.value).toBe("Fallen tree blocking the road.");
+    expect(byKey.location_address.value).toBe("1 Main St");
   });
 
   it("resolves the agency by location when the report has none attached", async () => {

--- a/nexa/src/app/api/reports/[id]/submission-fields/route.ts
+++ b/nexa/src/app/api/reports/[id]/submission-fields/route.ts
@@ -5,6 +5,17 @@ import { resolveAgencyId } from "@/lib/jurisdictions/agency";
 import { buildPrefillFields } from "@/lib/submission/prefill";
 import { successResponse, errorResponse } from "@/lib/api/response";
 
+// A generic field set used to pre-compose the report when there is no matched
+// agency (so no required-fields schema) but the user supplied their own link.
+// Covers the values every civic form asks for.
+const DEFAULT_PREFILL_SCHEMA = {
+  description: { type: "string", required: true },
+  location_address: { type: "string", required: true },
+  latitude: { type: "number", required: false },
+  longitude: { type: "number", required: false },
+  photo: { type: "file", required: false },
+} as const;
+
 // GET /api/reports/[id]/submission-fields
 //
 // Returns the per-field "copy-over" guide for filing this report with its
@@ -44,23 +55,38 @@ export async function GET(
       }
     }
 
+    // The user's own override link (the "Filing somewhere else?" field). When
+    // present it is the destination we route them to, regardless of what we
+    // auto-routed — so a copy-over guide is worth building even with no agency.
+    const customAgencyUrl = report.customAgencyUrl ?? null;
+
+    const prefillReport = {
+      description: report.description,
+      aiDescription: report.aiDescription,
+      address: report.address,
+      latitude: report.latitude,
+      longitude: report.longitude,
+      imageUrl: report.imageUrl,
+      createdAt: report.createdAt,
+      contactEmail: session?.email ?? null,
+    };
+
     if (!agency) {
-      return successResponse({ agency: null, fields: [] });
+      // No matched agency, but if the user supplied their own link we still
+      // pre-compose the report against a generic field set so they can paste it
+      // into that page. With no link and no agency there is nothing to fill.
+      const fields = customAgencyUrl
+        ? buildPrefillFields(prefillReport, DEFAULT_PREFILL_SCHEMA)
+        : [];
+      return successResponse({
+        agency: null,
+        formUrl: customAgencyUrl,
+        customAgencyUrl,
+        fields,
+      });
     }
 
-    const fields = buildPrefillFields(
-      {
-        description: report.description,
-        aiDescription: report.aiDescription,
-        address: report.address,
-        latitude: report.latitude,
-        longitude: report.longitude,
-        imageUrl: report.imageUrl,
-        createdAt: report.createdAt,
-        contactEmail: session?.email ?? null,
-      },
-      agency.requiredFields,
-    );
+    const fields = buildPrefillFields(prefillReport, agency.requiredFields);
 
     return successResponse({
       agency: {
@@ -68,7 +94,9 @@ export async function GET(
         intakeUrl: agency.intakeUrl,
         intakeMethod: agency.intakeMethod,
       },
-      formUrl: agency.intakeUrl,
+      // Prefer the user's override link as the destination when they gave one.
+      formUrl: customAgencyUrl ?? agency.intakeUrl,
+      customAgencyUrl,
       fields,
     });
   } catch (error) {

--- a/nexa/src/components/report/submission-assistant.tsx
+++ b/nexa/src/components/report/submission-assistant.tsx
@@ -28,6 +28,8 @@ interface SubmissionFieldsResponse {
     intakeMethod: string;
   } | null;
   formUrl?: string | null;
+  /** The user's own override link, when they provided one (#289). */
+  customAgencyUrl?: string | null;
   fields: PrefillField[];
 }
 
@@ -267,33 +269,47 @@ export function SubmissionAssistant({
     );
   }
 
-  if (!fields.agency || fields.fields.length === 0) {
+  // Render the guide when we have fields and somewhere to send the user: either
+  // a matched agency or the user's own override link.
+  if (
+    fields.fields.length === 0 ||
+    (!fields.agency && !fields.customAgencyUrl)
+  ) {
     return null;
   }
 
   // PHONE-intake agencies (e.g. the CARB smoking-vehicle hotline) have no online
   // form — the user calls the number surfaced below — so the copy adapts. (#193)
-  const isPhone = fields.agency.intakeMethod === "PHONE";
+  const isPhone = fields.agency?.intakeMethod === "PHONE";
+  const usingCustomLink = !!fields.customAgencyUrl;
+  // Where to send the user: their own link wins (the route already prefers it
+  // for `formUrl`, but be explicit so the label stays correct).
+  const destinationUrl = fields.customAgencyUrl ?? fields.formUrl ?? null;
+  const destinationName = fields.agency?.name ?? "the agency you linked";
 
   return (
     <div className="ep-card w-full max-w-md p-6 text-left">
       <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-        File with {fields.agency.name}
+        File with {destinationName}
       </span>
       <p className="mt-2 text-sm text-muted-foreground">
-        {isPhone
-          ? "Nexa doesn't submit for you. Call the number below and read off each value to file your report."
-          : "Nexa doesn't submit for you. Open the official form and copy each value below into the matching field."}
+        {usingCustomLink
+          ? "Nexa doesn't submit for you. Open the link you provided and copy each value below into the matching field."
+          : isPhone
+            ? "Nexa doesn't submit for you. Call the number below and read off each value to file your report."
+            : "Nexa doesn't submit for you. Open the official form and copy each value below into the matching field."}
       </p>
 
-      {fields.formUrl && (
+      {destinationUrl && (
         <a
-          href={fields.formUrl}
+          href={destinationUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="mt-3 inline-flex items-center gap-1.5 text-sm text-ep-purple underline-offset-4 hover:underline"
         >
-          Open {fields.agency.name} form
+          {usingCustomLink
+            ? "Open the link you provided"
+            : `Open ${destinationName} form`}
           <ExternalLink className="size-3.5" />
         </a>
       )}


### PR DESCRIPTION
Follows the custom-agency-link override (#289). Previously the link was stored but the submission copy-over guide still pointed at the auto-routed agency. Now the 'link version' actually delivers the report pre-composed at the page the user chose.

- `submission-fields` route returns `customAgencyUrl` and prefers it as the destination `formUrl`. When no agency matched but the user gave a link, it still pre-composes the report against a default field set (description, location, coordinates, photo) so there's a ready-to-paste report.
- `SubmissionAssistant` renders the copy-over guide for the custom-link case (it previously returned null with no agency), routes the 'Open the link you provided' button to the user's URL, and pre-fills every field with copy-to-clipboard.

tsc clean · lint 0 errors · prettier clean · coverage gate exit 0 · route/assistant tests pass (added custom-link cases, incl. no-agency).